### PR TITLE
Restore YouTube watch-page scrolling

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -46,13 +46,13 @@ jobs:
         run: bash ./gradlew testDebugUnitTest lintDebug assembleDebug assembleDebugAndroidTest --stacktrace
 
       - name: Name preview APK
-        run: cp app/build/outputs/apk/debug/app-debug.apk DualSub-Replay-v0.2.6-preview.apk
+        run: cp app/build/outputs/apk/debug/app-debug.apk DualSub-Replay-v0.2.7-preview.apk
 
       - name: Upload APK artifact
         uses: actions/upload-artifact@v4
         with:
-          name: DualSub-Replay-v0.2.6-preview
-          path: DualSub-Replay-v0.2.6-preview.apk
+          name: DualSub-Replay-v0.2.7-preview
+          path: DualSub-Replay-v0.2.7-preview.apk
           if-no-files-found: error
 
   managed-device-tests:
@@ -112,7 +112,7 @@ jobs:
       - name: Download verified preview APK
         uses: actions/download-artifact@v4
         with:
-          name: DualSub-Replay-v0.2.6-preview
+          name: DualSub-Replay-v0.2.7-preview
           path: release
 
       - name: Remove obsolete preview APKs
@@ -126,6 +126,7 @@ jobs:
           gh release delete-asset preview DualSub-Replay-v0.2.3-preview.apk --yes || true
           gh release delete-asset preview DualSub-Replay-v0.2.4-preview.apk --yes || true
           gh release delete-asset preview DualSub-Replay-v0.2.5-preview.apk --yes || true
+          gh release delete-asset preview DualSub-Replay-v0.2.6-preview.apk --yes || true
 
       - name: Publish rolling preview release
         uses: softprops/action-gh-release@v2
@@ -138,5 +139,5 @@ jobs:
             Automated preview build from the latest verified `main` commit.
 
             This APK uses a CI debug signature. Uninstall an older preview first if Android reports a signature mismatch.
-          files: release/DualSub-Replay-v0.2.6-preview.apk
+          files: release/DualSub-Replay-v0.2.7-preview.apk
           overwrite_files: true

--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ DualSub Replay is an experimental Android language-learning app inspired by the 
 - Merge short caption cues into readable paragraphs.
 - Place the dual-subtitle timeline below the player so it never obscures YouTube controls.
 - Highlight the current paragraph and tap any paragraph to replay it.
-- Hide and reopen the subtitle timeline and remember the subtitle text size.
+- Hide the subtitle timeline to reveal the scrollable YouTube watch page, including video
+  actions, comments, and recommendations; selecting another video keeps the learning flow.
+- Reopen the subtitle timeline and remember the subtitle text size.
 - Build and test an installable preview APK automatically with GitHub Actions.
 
 ## User flow
@@ -24,7 +26,8 @@ DualSub Replay is an experimental Android language-learning app inspired by the 
 3. The app intercepts the video URL and opens the dedicated Learning screen.
 4. The full-width player cues the video while captions and translations load underneath it.
 5. Tap any subtitle paragraph to seek to its start and resume playback.
-6. Press Back to leave fullscreen first, then return from Learning to Browse.
+6. Hide the subtitle timeline to like the video, read comments, or choose another video.
+7. Press Back to leave fullscreen first, then return from Learning to Browse.
 
 Sharing a YouTube watch, Short, live, embed, or `youtu.be` URL to DualSub Replay opens it directly in Learning.
 
@@ -78,7 +81,7 @@ The APK is produced at `app/build/outputs/apk/debug/app-debug.apk`.
 
 ## Continuous integration
 
-Every push and pull request uses the committed wrapper to run unit tests, lint, debug APK assembly, and Android-test APK assembly. A second job executes the offline fixture suite on the API 36 managed device. A push to `main` publishes `DualSub-Replay-v0.2.6-preview.apk` to the rolling `preview` release only after both jobs pass.
+Every push and pull request uses the committed wrapper to run unit tests, lint, debug APK assembly, and Android-test APK assembly. A second job executes the offline fixture suite on the API 36 managed device. A push to `main` publishes `DualSub-Replay-v0.2.7-preview.apk` to the rolling `preview` release only after both jobs pass.
 
 ## Privacy
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -11,8 +11,8 @@ android {
         applicationId = "com.kienhoang.dualsubreplay"
         minSdk = 26
         targetSdk = 36
-        versionCode = 8
-        versionName = "0.2.6"
+        versionCode = 9
+        versionName = "0.2.7"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/com/kienhoang/dualsubreplay/ui/DualSubApp.kt
+++ b/app/src/main/java/com/kienhoang/dualsubreplay/ui/DualSubApp.kt
@@ -128,6 +128,7 @@ private fun DualSubExperience(
                     state = state,
                     session = destination.session,
                     onExitLearning = onExitLearning,
+                    onVideoSelected = onVideoSelected,
                     onPlayerCurrentSecond = onPlayerCurrentSecond,
                     onPlayerVideoId = onPlayerVideoId,
                     resumeSecond = playbackResumeSecond(destination.session.videoId),
@@ -156,6 +157,7 @@ private fun LearningScreen(
     state: DualSubUiState,
     session: WatchSession,
     onExitLearning: () -> Unit,
+    onVideoSelected: (String, String) -> Unit,
     onPlayerCurrentSecond: (String, Float) -> Unit,
     onPlayerVideoId: (String, String) -> Unit,
     resumeSecond: Float,
@@ -203,26 +205,37 @@ private fun LearningScreen(
             )
         }
 
-        if (state.subtitlePanelVisible) {
-            SubtitlePanel(
-                state = state,
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1f)
+                .testTag("watch_details_container"),
+        ) {
+            YouTubeWatchPage(
+                videoId = session.videoId,
+                onVideoSelected = onVideoSelected,
                 modifier = Modifier
-                    .fillMaxWidth()
-                    .weight(1f)
-                    .testTag("subtitle_timeline"),
-                onHide = onHideSubtitles,
-                onSettings = onSettings,
-                onRetry = onRetryCaptions,
-                onReplay = { segment -> playerController.replayFrom(segment.startMs / 1_000f) },
+                    .fillMaxSize()
+                    .testTag("youtube_watch_details"),
             )
-        } else {
-            Box(
-                modifier = Modifier.fillMaxWidth().weight(1f),
-                contentAlignment = Alignment.TopEnd,
-            ) {
+
+            if (state.subtitlePanelVisible) {
+                SubtitlePanel(
+                    state = state,
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .testTag("subtitle_timeline"),
+                    onHide = onHideSubtitles,
+                    onSettings = onSettings,
+                    onRetry = onRetryCaptions,
+                    onReplay = { segment -> playerController.replayFrom(segment.startMs / 1_000f) },
+                )
+            } else {
                 SmallFloatingActionButton(
                     onClick = onShowSubtitles,
-                    modifier = Modifier.padding(12.dp),
+                    modifier = Modifier
+                        .align(Alignment.TopEnd)
+                        .padding(12.dp),
                     shape = CircleShape,
                     containerColor = MaterialTheme.colorScheme.primary,
                     contentColor = MaterialTheme.colorScheme.onPrimary,

--- a/app/src/main/java/com/kienhoang/dualsubreplay/ui/YouTubeBrowserScreen.kt
+++ b/app/src/main/java/com/kienhoang/dualsubreplay/ui/YouTubeBrowserScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -45,6 +46,8 @@ import com.kienhoang.dualsubreplay.BuildConfig
 import com.kienhoang.dualsubreplay.data.YouTubeUrlParser
 import java.util.Collections
 import java.util.WeakHashMap
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
 
 private const val BROWSER_LOG_TAG = "DualSubBrowser"
 private val destroyedWebViews = Collections.newSetFromMap(WeakHashMap<WebView, Boolean>())
@@ -55,6 +58,244 @@ internal fun browseVideoSelection(url: String): BrowseVideoSelection? {
     val videoId = YouTubeUrlParser.extractVideoId(url) ?: return null
     return BrowseVideoSelection(videoId, "https://www.youtube.com/watch?v=$videoId")
 }
+
+internal fun watchVideoSelection(currentVideoId: String, url: String): BrowseVideoSelection? =
+    browseVideoSelection(url)?.takeIf { it.videoId != currentVideoId }
+
+private fun mobileWatchUrl(videoId: String): String =
+    "https://m.youtube.com/watch?v=$videoId"
+
+/**
+ * Keeps YouTube's watch-page details, actions, comments, and recommendations below the
+ * app-owned 16:9 player. The native page player is collapsed and paused so there is only one
+ * visible and audible player. Selecting a different video hands navigation back to Learning.
+ */
+@SuppressLint("SetJavaScriptEnabled")
+@Composable
+internal fun YouTubeWatchPage(
+    videoId: String,
+    onVideoSelected: (videoId: String, canonicalUrl: String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val context = LocalContext.current
+    val lifecycleOwner = LocalLifecycleOwner.current
+    val currentOnVideoSelected by rememberUpdatedState(onVideoSelected)
+    var lifecycleStarted by remember {
+        mutableStateOf(lifecycleOwner.lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED))
+    }
+    var webViewGeneration by remember(videoId) { mutableIntStateOf(0) }
+    var rendererRecoveryUsed by remember(videoId) { mutableStateOf(false) }
+    var webViewUnavailable by remember(videoId) { mutableStateOf(false) }
+    var pageError by remember(videoId) { mutableStateOf<String?>(null) }
+
+    val webView = remember(videoId, webViewGeneration) {
+        WebView(context).apply {
+            layoutParams = ViewGroup.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.MATCH_PARENT,
+            )
+            settings.javaScriptEnabled = true
+            settings.domStorageEnabled = true
+            settings.mediaPlaybackRequiresUserGesture = true
+            settings.setSupportMultipleWindows(false)
+            settings.setSupportZoom(false)
+            settings.builtInZoomControls = false
+            settings.displayZoomControls = false
+            settings.useWideViewPort = false
+            settings.loadWithOverviewMode = false
+            settings.textZoom = 100
+            webChromeClient = WebChromeClient()
+            CookieManager.getInstance().setAcceptCookie(true)
+            CookieManager.getInstance().setAcceptThirdPartyCookies(this, true)
+
+            webViewClient = object : WebViewClient() {
+                private fun handleNewVideo(view: WebView, url: String?): Boolean {
+                    val targetUrl = url?.takeIf(String::isNotBlank) ?: return false
+                    val selection = watchVideoSelection(videoId, targetUrl) ?: return false
+                    view.stopLoading()
+                    currentOnVideoSelected(selection.videoId, selection.canonicalUrl)
+                    return true
+                }
+
+                private fun prepareWatchDetails(view: WebView) {
+                    view.evaluateJavascript(WATCH_DETAILS_SCRIPT, null)
+                }
+
+                override fun shouldOverrideUrlLoading(
+                    view: WebView,
+                    request: WebResourceRequest,
+                ): Boolean {
+                    if (!request.isForMainFrame) return false
+                    if (request.url.scheme !in setOf("http", "https")) return true
+                    return handleNewVideo(view, request.url.toString())
+                }
+
+                @Suppress("DEPRECATION")
+                override fun shouldOverrideUrlLoading(view: WebView, url: String): Boolean {
+                    val scheme = runCatching { android.net.Uri.parse(url).scheme }.getOrNull()
+                    if (scheme !in setOf("http", "https")) return true
+                    return handleNewVideo(view, url)
+                }
+
+                override fun doUpdateVisitedHistory(view: WebView, url: String?, isReload: Boolean) {
+                    super.doUpdateVisitedHistory(view, url, isReload)
+                    if (!handleNewVideo(view, url)) prepareWatchDetails(view)
+                }
+
+                override fun onPageStarted(view: WebView, url: String?, favicon: Bitmap?) {
+                    super.onPageStarted(view, url, favicon)
+                    pageError = null
+                    handleNewVideo(view, url)
+                }
+
+                override fun onPageFinished(view: WebView, url: String?) {
+                    super.onPageFinished(view, url)
+                    if (handleNewVideo(view, url)) return
+                    rendererRecoveryUsed = false
+                    webViewUnavailable = false
+                    prepareWatchDetails(view)
+                }
+
+                override fun onReceivedError(
+                    view: WebView,
+                    request: WebResourceRequest,
+                    error: WebResourceError,
+                ) {
+                    super.onReceivedError(view, request, error)
+                    if (request.isForMainFrame) {
+                        pageError = "YouTube could not load: ${error.description}"
+                    }
+                }
+
+                override fun onReceivedHttpError(
+                    view: WebView,
+                    request: WebResourceRequest,
+                    errorResponse: WebResourceResponse,
+                ) {
+                    super.onReceivedHttpError(view, request, errorResponse)
+                    if (request.isForMainFrame && errorResponse.statusCode >= 400) {
+                        pageError = "YouTube returned HTTP ${errorResponse.statusCode}."
+                    }
+                }
+
+                override fun onRenderProcessGone(
+                    view: WebView,
+                    detail: RenderProcessGoneDetail,
+                ): Boolean {
+                    val message = if (detail.didCrash()) {
+                        "The Android WebView renderer crashed."
+                    } else {
+                        "Android stopped the WebView renderer to reclaim memory."
+                    }
+                    Log.e(BROWSER_LOG_TAG, message)
+                    webViewUnavailable = true
+                    view.post {
+                        view.destroySafely()
+                        if (!rendererRecoveryUsed) {
+                            rendererRecoveryUsed = true
+                            webViewUnavailable = false
+                            webViewGeneration += 1
+                        } else {
+                            pageError = "$message Tap Reload to recreate it."
+                        }
+                    }
+                    return true
+                }
+            }
+            loadUrl(mobileWatchUrl(videoId))
+        }
+    }
+
+    DisposableEffect(lifecycleOwner, webView) {
+        val observer = LifecycleEventObserver { _, _ ->
+            lifecycleStarted = lifecycleOwner.lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)
+            if (lifecycleStarted) webView.onResume() else webView.onPause()
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        if (lifecycleStarted) webView.onResume() else webView.onPause()
+        onDispose {
+            lifecycleOwner.lifecycle.removeObserver(observer)
+            runCatching { webView.onPause() }
+        }
+    }
+
+    LaunchedEffect(webView, lifecycleStarted) {
+        if (!lifecycleStarted) return@LaunchedEffect
+        while (isActive) {
+            webView.evaluateJavascript(WATCH_DETAILS_SCRIPT, null)
+            delay(750)
+        }
+    }
+
+    DisposableEffect(webView) {
+        onDispose { webView.destroySafely() }
+    }
+
+    Box(modifier) {
+        key(webView) {
+            AndroidView(
+                factory = { webView },
+                modifier = Modifier.fillMaxSize(),
+            )
+        }
+        pageError?.let { message ->
+            WebPageErrorCard(
+                message = message,
+                onReload = {
+                    pageError = null
+                    rendererRecoveryUsed = false
+                    if (webViewUnavailable) {
+                        webViewUnavailable = false
+                        webViewGeneration += 1
+                    } else {
+                        webView.reload()
+                    }
+                },
+                modifier = Modifier.align(Alignment.Center),
+            )
+        }
+    }
+}
+
+internal val WATCH_DETAILS_SCRIPT: String =
+    """
+    (function() {
+      const styleId = 'dual-sub-watch-details-style';
+      let style = document.getElementById(styleId);
+      if (!style) {
+        style = document.createElement('style');
+        style.id = styleId;
+        (document.head || document.documentElement).appendChild(style);
+      }
+      style.textContent = `
+        ytm-watch ytm-player,
+        ytm-watch #player-container-id,
+        ytm-watch #player-container,
+        ytm-watch .player-container,
+        ytm-mobile-topbar-renderer {
+          display: none !important;
+          width: 0 !important;
+          height: 0 !important;
+          min-height: 0 !important;
+          max-height: 0 !important;
+          margin: 0 !important;
+          padding: 0 !important;
+          overflow: hidden !important;
+        }
+        ytm-watch, ytm-watch metadata-row-container, ytm-watch #below {
+          margin-top: 0 !important;
+          padding-top: 0 !important;
+        }
+        html, body { overflow-y: auto !important; }
+      `;
+      document.querySelectorAll('video').forEach(function(video) {
+        video.autoplay = false;
+        video.muted = true;
+        if (!video.paused) video.pause();
+      });
+      return true;
+    })();
+    """.trimIndent()
 
 /**
  * YouTube's mobile site is used only for discovery. Watch-page navigation is handed to the

--- a/app/src/test/java/com/kienhoang/dualsubreplay/ui/PlaybackArchitectureTest.kt
+++ b/app/src/test/java/com/kienhoang/dualsubreplay/ui/PlaybackArchitectureTest.kt
@@ -22,6 +22,39 @@ class PlaybackArchitectureTest {
     }
 
     @Test
+    fun watchPageKeepsCurrentVideoButHandsDifferentVideosToLearning() {
+        assertNull(
+            watchVideoSelection(
+                currentVideoId = "dQw4w9WgXcQ",
+                url = "https://m.youtube.com/watch?v=dQw4w9WgXcQ",
+            ),
+        )
+        assertEquals(
+            BrowseVideoSelection(
+                videoId = "aqz-KE-bpKQ",
+                canonicalUrl = "https://www.youtube.com/watch?v=aqz-KE-bpKQ",
+            ),
+            watchVideoSelection(
+                currentVideoId = "dQw4w9WgXcQ",
+                url = "https://m.youtube.com/watch?v=aqz-KE-bpKQ",
+            ),
+        )
+        assertNull(
+            watchVideoSelection(
+                currentVideoId = "dQw4w9WgXcQ",
+                url = "https://m.youtube.com/results?search_query=english",
+            ),
+        )
+    }
+
+    @Test
+    fun watchPageScriptCollapsesNativePlayerAndPreservesScrolling() {
+        assertTrue(WATCH_DETAILS_SCRIPT.contains("ytm-watch ytm-player"))
+        assertTrue(WATCH_DETAILS_SCRIPT.contains("video.pause()"))
+        assertTrue(WATCH_DETAILS_SCRIPT.contains("overflow-y: auto"))
+    }
+
+    @Test
     fun learningDestinationRetainsCompleteWatchSession() {
         val session = WatchSession(
             videoId = "dQw4w9WgXcQ",


### PR DESCRIPTION
## What changed

- keep the verified v0.2.6 full-width 16:9 embedded player
- render the mobile YouTube watch page underneath it
- collapse and pause the watch page's duplicate native player
- reveal likes, comments, recommendations, and normal scrolling when Duo Sub is hidden
- hand a newly selected video back to the Learning flow
- bump the preview build to v0.2.7

## Root cause

The v0.2.6 Learning screen allocated the entire area below the player to the subtitle panel. Hiding the panel replaced it with an empty Compose box, so there was no YouTube page available to scroll.

## Validation

- `git diff --check`
- added unit coverage for same-video and different-video watch navigation
- added assertions that the injected watch-page policy collapses/pauses the duplicate player while preserving vertical scrolling
- full unit tests, lint, APK assembly, and managed-device tests run in GitHub Actions