### PR TITLE
Hide duplicate YouTube watch player

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -46,13 +46,13 @@ jobs:
         run: bash ./gradlew testDebugUnitTest lintDebug assembleDebug assembleDebugAndroidTest --stacktrace
 
       - name: Name preview APK
-        run: cp app/build/outputs/apk/debug/app-debug.apk DualSub-Replay-v0.2.7-preview.apk
+        run: cp app/build/outputs/apk/debug/app-debug.apk DualSub-Replay-v0.2.8-preview.apk
 
       - name: Upload APK artifact
         uses: actions/upload-artifact@v4
         with:
-          name: DualSub-Replay-v0.2.7-preview
-          path: DualSub-Replay-v0.2.7-preview.apk
+          name: DualSub-Replay-v0.2.8-preview
+          path: DualSub-Replay-v0.2.8-preview.apk
           if-no-files-found: error
 
   managed-device-tests:
@@ -112,7 +112,7 @@ jobs:
       - name: Download verified preview APK
         uses: actions/download-artifact@v4
         with:
-          name: DualSub-Replay-v0.2.7-preview
+          name: DualSub-Replay-v0.2.8-preview
           path: release
 
       - name: Remove obsolete preview APKs
@@ -127,6 +127,7 @@ jobs:
           gh release delete-asset preview DualSub-Replay-v0.2.4-preview.apk --yes || true
           gh release delete-asset preview DualSub-Replay-v0.2.5-preview.apk --yes || true
           gh release delete-asset preview DualSub-Replay-v0.2.6-preview.apk --yes || true
+          gh release delete-asset preview DualSub-Replay-v0.2.7-preview.apk --yes || true
 
       - name: Publish rolling preview release
         uses: softprops/action-gh-release@v2
@@ -139,5 +140,5 @@ jobs:
             Automated preview build from the latest verified `main` commit.
 
             This APK uses a CI debug signature. Uninstall an older preview first if Android reports a signature mismatch.
-          files: release/DualSub-Replay-v0.2.7-preview.apk
+          files: release/DualSub-Replay-v0.2.8-preview.apk
           overwrite_files: true

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ The APK is produced at `app/build/outputs/apk/debug/app-debug.apk`.
 
 ## Continuous integration
 
-Every push and pull request uses the committed wrapper to run unit tests, lint, debug APK assembly, and Android-test APK assembly. A second job executes the offline fixture suite on the API 36 managed device. A push to `main` publishes `DualSub-Replay-v0.2.7-preview.apk` to the rolling `preview` release only after both jobs pass.
+Every push and pull request uses the committed wrapper to run unit tests, lint, debug APK assembly, and Android-test APK assembly. A second job executes the offline fixture suite on the API 36 managed device. A push to `main` publishes `DualSub-Replay-v0.2.8-preview.apk` to the rolling `preview` release only after both jobs pass.
 
 ## Privacy
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -11,8 +11,8 @@ android {
         applicationId = "com.kienhoang.dualsubreplay"
         minSdk = 26
         targetSdk = 36
-        versionCode = 9
-        versionName = "0.2.7"
+        versionCode = 10
+        versionName = "0.2.8"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/androidTest/java/com/kienhoang/dualsubreplay/ui/BrowseWebViewLifecycleTest.kt
+++ b/app/src/androidTest/java/com/kienhoang/dualsubreplay/ui/BrowseWebViewLifecycleTest.kt
@@ -1,9 +1,18 @@
 package com.kienhoang.dualsubreplay.ui
 
 import android.webkit.WebView
+import android.webkit.WebViewClient
 import android.widget.FrameLayout
 import androidx.test.platform.app.InstrumentationRegistry
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+import org.json.JSONObject
+import org.json.JSONTokener
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class BrowseWebViewLifecycleTest {
@@ -21,5 +30,72 @@ class BrowseWebViewLifecycleTest {
             webView.destroySafely()
             assertNull(webView.parent)
         }
+    }
+
+    @Test
+    fun watchDetailsScriptHidesSiblingPlayerButKeepsDetailsAndRecommendations() {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val result = AtomicReference<String?>()
+        val finished = CountDownLatch(1)
+        lateinit var webView: WebView
+
+        instrumentation.runOnMainSync {
+            webView = WebView(instrumentation.targetContext).apply {
+                settings.javaScriptEnabled = true
+                webViewClient = object : WebViewClient() {
+                    override fun onPageFinished(view: WebView, url: String?) {
+                        view.evaluateJavascript(WATCH_DETAILS_SCRIPT) {
+                            view.evaluateJavascript(
+                                """
+                                (function() {
+                                  return JSON.stringify({
+                                    playerDisplay: getComputedStyle(document.getElementById('native-player')).display,
+                                    detailsDisplay: getComputedStyle(document.getElementById('details')).display,
+                                    recommendationDisplay: getComputedStyle(document.getElementById('recommendation')).display,
+                                    nativeAutoplay: document.getElementById('native-video').hasAttribute('autoplay'),
+                                    previewAutoplay: document.getElementById('preview-video').hasAttribute('autoplay')
+                                  });
+                                })();
+                                """.trimIndent(),
+                            ) { value ->
+                                result.set(value)
+                                finished.countDown()
+                            }
+                        }
+                    }
+                }
+                loadDataWithBaseURL(
+                    "https://m.youtube.com/watch?v=test",
+                    """
+                    <!doctype html>
+                    <html><head></head><body>
+                      <ytm-app>
+                        <ytm-player id="native-player">
+                          <div id="player-container-id"><video id="native-video" autoplay></video></div>
+                        </ytm-player>
+                        <ytm-watch><section id="details">Comments</section></ytm-watch>
+                        <ytm-compact-video-renderer id="recommendation">
+                          <video id="preview-video" autoplay></video>
+                        </ytm-compact-video-renderer>
+                      </ytm-app>
+                    </body></html>
+                    """.trimIndent(),
+                    "text/html",
+                    "UTF-8",
+                    null,
+                )
+            }
+        }
+
+        assertTrue("WebView fixture did not finish", finished.await(10, TimeUnit.SECONDS))
+        val jsonText = JSONTokener(result.get()).nextValue() as String
+        val state = JSONObject(jsonText)
+        assertEquals("none", state.getString("playerDisplay"))
+        assertFalse(state.getString("detailsDisplay") == "none")
+        assertFalse(state.getString("recommendationDisplay") == "none")
+        assertFalse(state.getBoolean("nativeAutoplay"))
+        assertTrue(state.getBoolean("previewAutoplay"))
+
+        instrumentation.runOnMainSync { webView.destroySafely() }
     }
 }

--- a/app/src/main/java/com/kienhoang/dualsubreplay/ui/YouTubeBrowserScreen.kt
+++ b/app/src/main/java/com/kienhoang/dualsubreplay/ui/YouTubeBrowserScreen.kt
@@ -46,8 +46,6 @@ import com.kienhoang.dualsubreplay.BuildConfig
 import com.kienhoang.dualsubreplay.data.YouTubeUrlParser
 import java.util.Collections
 import java.util.WeakHashMap
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.isActive
 
 private const val BROWSER_LOG_TAG = "DualSubBrowser"
 private val destroyedWebViews = Collections.newSetFromMap(WeakHashMap<WebView, Boolean>())
@@ -219,14 +217,6 @@ internal fun YouTubeWatchPage(
         }
     }
 
-    LaunchedEffect(webView, lifecycleStarted) {
-        if (!lifecycleStarted) return@LaunchedEffect
-        while (isActive) {
-            webView.evaluateJavascript(WATCH_DETAILS_SCRIPT, null)
-            delay(750)
-        }
-    }
-
     DisposableEffect(webView) {
         onDispose { webView.destroySafely() }
     }
@@ -257,9 +247,28 @@ internal fun YouTubeWatchPage(
     }
 }
 
+/**
+ * The mobile watch page can render its player beside `ytm-watch` instead of inside it. Keep
+ * these selectors global so both layouts collapse; scoping them under `ytm-watch` leaves a
+ * second, full-size player visible below the app-owned player.
+ */
+internal val WATCH_NATIVE_PLAYER_SELECTORS: List<String> = listOf(
+    "ytm-player",
+    "ytd-player",
+    "#player",
+    "#player-container-id",
+    "#player-container",
+    ".player-container",
+    ".player-container.sticky-player",
+    ".player-size",
+    "#movie_player",
+    ".html5-video-player",
+)
+
 internal val WATCH_DETAILS_SCRIPT: String =
     """
     (function() {
+      const nativePlayerSelector = '${WATCH_NATIVE_PLAYER_SELECTORS.joinToString(",")}';
       const styleId = 'dual-sub-watch-details-style';
       let style = document.getElementById(styleId);
       if (!style) {
@@ -268,10 +277,7 @@ internal val WATCH_DETAILS_SCRIPT: String =
         (document.head || document.documentElement).appendChild(style);
       }
       style.textContent = `
-        ytm-watch ytm-player,
-        ytm-watch #player-container-id,
-        ytm-watch #player-container,
-        ytm-watch .player-container,
+        ${WATCH_NATIVE_PLAYER_SELECTORS.joinToString(",\n        ")},
         ytm-mobile-topbar-renderer {
           display: none !important;
           width: 0 !important;
@@ -288,11 +294,38 @@ internal val WATCH_DETAILS_SCRIPT: String =
         }
         html, body { overflow-y: auto !important; }
       `;
-      document.querySelectorAll('video').forEach(function(video) {
-        video.autoplay = false;
-        video.muted = true;
-        if (!video.paused) video.pause();
-      });
+
+      const pauseNativePlayerMedia = function(root) {
+        if (!root || !root.querySelectorAll) return;
+        const players = [];
+        if (root.matches && root.matches(nativePlayerSelector)) players.push(root);
+        const containingPlayer = root.closest && root.closest(nativePlayerSelector);
+        if (containingPlayer) players.push(containingPlayer);
+        root.querySelectorAll(nativePlayerSelector).forEach(function(player) {
+          players.push(player);
+        });
+        players.forEach(function(player) {
+          player.querySelectorAll('video').forEach(function(video) {
+            video.autoplay = false;
+            video.removeAttribute('autoplay');
+            video.muted = true;
+            if (!video.paused) video.pause();
+          });
+        });
+      };
+
+      pauseNativePlayerMedia(document);
+      if (!window.__dualSubWatchObserver && document.documentElement) {
+        window.__dualSubWatchObserver = new MutationObserver(function(mutations) {
+          mutations.forEach(function(mutation) {
+            mutation.addedNodes.forEach(pauseNativePlayerMedia);
+          });
+        });
+        window.__dualSubWatchObserver.observe(document.documentElement, {
+          childList: true,
+          subtree: true
+        });
+      }
       return true;
     })();
     """.trimIndent()

--- a/app/src/test/java/com/kienhoang/dualsubreplay/ui/PlaybackArchitectureTest.kt
+++ b/app/src/test/java/com/kienhoang/dualsubreplay/ui/PlaybackArchitectureTest.kt
@@ -49,8 +49,18 @@ class PlaybackArchitectureTest {
 
     @Test
     fun watchPageScriptCollapsesNativePlayerAndPreservesScrolling() {
-        assertTrue(WATCH_DETAILS_SCRIPT.contains("ytm-watch ytm-player"))
+        assertTrue(WATCH_NATIVE_PLAYER_SELECTORS.contains("ytm-player"))
+        assertTrue(WATCH_NATIVE_PLAYER_SELECTORS.contains("#player"))
+        assertTrue(WATCH_NATIVE_PLAYER_SELECTORS.contains("#player-container-id"))
+        assertTrue(WATCH_NATIVE_PLAYER_SELECTORS.contains("#movie_player"))
+        assertTrue(WATCH_NATIVE_PLAYER_SELECTORS.none { it.startsWith("ytm-watch ") })
+        WATCH_NATIVE_PLAYER_SELECTORS.forEach { selector ->
+            assertTrue(WATCH_DETAILS_SCRIPT.contains(selector))
+        }
+        assertTrue(WATCH_DETAILS_SCRIPT.contains("player.querySelectorAll('video')"))
         assertTrue(WATCH_DETAILS_SCRIPT.contains("video.pause()"))
+        assertTrue(WATCH_DETAILS_SCRIPT.contains("MutationObserver"))
+        assertFalse(WATCH_DETAILS_SCRIPT.contains("document.querySelectorAll('video')"))
         assertTrue(WATCH_DETAILS_SCRIPT.contains("overflow-y: auto"))
     }
 


### PR DESCRIPTION
## What changed

- Collapse YouTube mobile watch-page player roots globally instead of only when nested inside `ytm-watch`.
- Keep comments, metadata, and recommendation previews visible.
- Replace the 750 ms whole-page media scan with an idempotent `MutationObserver` that pauses media only inside the redundant watch-page player.
- Add unit assertions and an offline Android WebView fixture reproducing the sibling-player layout.
- Bump the preview build to v0.2.8.

## Root cause

v0.2.7 renders one app-owned IFrame player and a separate mobile YouTube watch page for actions/comments. YouTube can place the watch page's native `ytm-player` / `#player` as a sibling of `ytm-watch`, but the injected CSS required `ytm-watch` as an ancestor. The lower player therefore stayed visible and consumed another 16:9 area.

## Validation

- `git diff --check` passes.
- The generated JavaScript parses successfully.
- Local Gradle execution was attempted, but this workspace could not resolve Android Gradle Plugin 9.3.1 from Google Maven because outbound dependency resolution is restricted.
- GitHub Actions is the authoritative unit, lint, APK, and API 36 managed-WebView test gate.