### PR TITLE
Publish v0.2.8 official release

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,8 +1,9 @@
-name: Android build and preview APK
+name: Android build and releases
 
 on:
   push:
     branches: [main]
+    tags: ["v*"]
   pull_request:
   workflow_dispatch:
 
@@ -137,8 +138,103 @@ jobs:
           prerelease: true
           make_latest: false
           body: |
-            Automated preview build from the latest verified `main` commit.
+            Testing build from the latest verified `main` commit.
+
+            Most people should install the [latest official release](https://github.com/${{ github.repository }}/releases/latest) instead.
 
             This APK uses a CI debug signature. Uninstall an older preview first if Android reports a signature mismatch.
           files: release/DualSub-Replay-v0.2.8-preview.apk
           overwrite_files: true
+
+  publish-release:
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: [verify-build, managed-device-tests]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Check out tagged source
+        uses: actions/checkout@v4
+
+      - name: Set up Java 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Install Android build SDK
+        run: sdkmanager "platforms;android-36" "build-tools;36.0.0"
+
+      - name: Set up Gradle cache
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Require tag to match the app version
+        run: |
+          tag_version="${GITHUB_REF_NAME#v}"
+          app_version="$(sed -n 's/.*versionName = "\([^"]*\)".*/\1/p' app/build.gradle.kts | head -n 1)"
+          if [ -z "$app_version" ] || [ "$tag_version" != "$app_version" ]; then
+            echo "Tag $GITHUB_REF_NAME does not match app version $app_version" >&2
+            exit 1
+          fi
+
+      - name: Restore production signing key
+        env:
+          ANDROID_RELEASE_KEYSTORE_BASE64: ${{ secrets.ANDROID_RELEASE_KEYSTORE_BASE64 }}
+        run: |
+          if [ -z "$ANDROID_RELEASE_KEYSTORE_BASE64" ]; then
+            echo "ANDROID_RELEASE_KEYSTORE_BASE64 is not configured" >&2
+            exit 1
+          fi
+          printf '%s' "$ANDROID_RELEASE_KEYSTORE_BASE64" | base64 --decode > "$RUNNER_TEMP/dual-sub-replay-release.jks"
+          chmod 600 "$RUNNER_TEMP/dual-sub-replay-release.jks"
+
+      - name: Build production release APK
+        env:
+          ANDROID_RELEASE_STORE_FILE: ${{ runner.temp }}/dual-sub-replay-release.jks
+          ANDROID_RELEASE_STORE_PASSWORD: ${{ secrets.ANDROID_RELEASE_STORE_PASSWORD }}
+          ANDROID_RELEASE_KEY_ALIAS: ${{ secrets.ANDROID_RELEASE_KEY_ALIAS }}
+          ANDROID_RELEASE_KEY_PASSWORD: ${{ secrets.ANDROID_RELEASE_KEY_PASSWORD }}
+        run: bash ./gradlew assembleRelease -PrequireReleaseSigning=true --stacktrace
+
+      - name: Verify and package official APK
+        run: |
+          source_apk="app/build/outputs/apk/release/app-release.apk"
+          release_apk="release/DualSub-Replay.apk"
+          mkdir -p release
+          cp "$source_apk" "$release_apk"
+          "$ANDROID_HOME/build-tools/36.0.0/apksigner" verify --verbose --print-certs "$release_apk" | tee release/signing-report.txt
+          if grep -q 'CN=Android Debug' release/signing-report.txt; then
+            echo "Official APK was signed with the Android debug certificate" >&2
+            exit 1
+          fi
+          "$ANDROID_HOME/build-tools/36.0.0/aapt" dump badging "$release_apk" | head -n 1
+          sha256sum "$release_apk" | sed 's#  release/#  #' > release/DualSub-Replay.apk.sha256
+
+      - name: Publish official GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: DualSub Replay ${{ github.ref_name }}
+          prerelease: false
+          make_latest: true
+          fail_on_unmatched_files: true
+          body: |
+            ## Download and install
+
+            Download **DualSub-Replay.apk** below. On Android 8.0 or newer, open the downloaded file and allow your browser or file manager to install unknown apps if Android asks.
+
+            **Preview users:** uninstall the preview build once before installing this official release because the official app uses a new production signing key.
+
+            ## Highlights
+
+            - Browse YouTube and open videos in a dedicated learning player.
+            - Read original and Vietnamese subtitles together.
+            - Tap a subtitle paragraph to replay that moment.
+            - Use YouTube controls, fullscreen, comments, and recommendations.
+
+            The `.sha256` file can be used to verify the APK download.
+          files: |
+            release/DualSub-Replay.apk
+            release/DualSub-Replay.apk.sha256

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.iml
 .gradle/
+.kotlin/
 .idea/
 local.properties
 build/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,24 @@
 # DualSub Replay
 
-DualSub Replay is an experimental Android language-learning app inspired by the useful parts of 1Letters: find a YouTube video, read the original and Vietnamese subtitles together, and tap any paragraph to hear it again.
+An Android language-learning app for watching YouTube with original and Vietnamese subtitles together. Tap any subtitle paragraph to replay that moment.
+
+## Download
+
+### [Download the latest official APK](https://github.com/hoangkien1703/dual-sub-replay/releases/latest/download/DualSub-Replay.apk)
+
+Requires **Android 8.0 or newer**. No account or API key is required.
+
+### Installation
+
+1. Tap the download link above and open `DualSub-Replay.apk` when it finishes.
+2. If Android asks, allow your browser or file manager to **install unknown apps**.
+3. Tap **Install**, then open DualSub Replay.
+
+Android may show a standard warning because the app is downloaded directly from GitHub instead of Google Play.
+
+> **Updating from a preview?** Uninstall the preview build once before installing the official app. Official releases use a new production signing key; future official versions will install as normal updates.
+
+Want to test the newest development build? See the [preview release](https://github.com/hoangkien1703/dual-sub-replay/releases/tag/preview). Preview builds may be less stable and use a different signature.
 
 ## Features
 
@@ -17,7 +35,7 @@ DualSub Replay is an experimental Android language-learning app inspired by the 
 - Hide the subtitle timeline to reveal the scrollable YouTube watch page, including video
   actions, comments, and recommendations; selecting another video keeps the learning flow.
 - Reopen the subtitle timeline and remember the subtitle text size.
-- Build and test an installable preview APK automatically with GitHub Actions.
+- Build, test, and publish installable APKs automatically with GitHub Actions.
 
 ## User flow
 
@@ -37,7 +55,7 @@ YouTube's official Data API does not allow ordinary viewers to download captions
 
 Video playback uses YouTube's IFrame Player API through `android-youtube-player`. The app does not download video or audio, remove ads, obscure the player controls, or enable background playback. Some videos cannot be embedded because of owner, region, age, or account restrictions; the Learning screen offers to open those videos in YouTube.
 
-The preview APK uses a CI debug signature persisted in the private GitHub Actions cache so later preview updates keep the same signature. A stable release-signing keystore must be configured through GitHub Secrets before production distribution; never commit a keystore or password.
+Official APKs use a dedicated production signing key kept outside the repository and restored through encrypted GitHub Actions secrets. Preview APKs use a separate CI debug signature, so Android treats the preview and official release as different update lines.
 
 ## Development
 
@@ -66,7 +84,7 @@ bash ./gradlew pixel2Api36DebugAndroidTest
 
 The managed-device suite uses a Pixel 2 profile with an API 36 AOSP image. Its WebView fixtures are designed to run without calls to the live YouTube site. On headless CI hosts, also pass `-Pandroid.testoptions.manageddevices.emulator.gpu=swiftshader_indirect`.
 
-The APK is produced at `app/build/outputs/apk/debug/app-debug.apk`.
+Debug APKs are produced at `app/build/outputs/apk/debug/app-debug.apk`. An official release build requires the four `ANDROID_RELEASE_*` signing environment variables and `-PrequireReleaseSigning=true`; signing credentials must never be committed.
 
 ## Architecture
 
@@ -81,7 +99,7 @@ The APK is produced at `app/build/outputs/apk/debug/app-debug.apk`.
 
 ## Continuous integration
 
-Every push and pull request uses the committed wrapper to run unit tests, lint, debug APK assembly, and Android-test APK assembly. A second job executes the offline fixture suite on the API 36 managed device. A push to `main` publishes `DualSub-Replay-v0.2.8-preview.apk` to the rolling `preview` release only after both jobs pass.
+Every push and pull request uses the committed wrapper to run unit tests, lint, debug APK assembly, and Android-test APK assembly. A second job executes the offline fixture suite on the API 36 managed device. A push to `main` updates the rolling `preview` release only after both jobs pass. A version tag such as `v0.2.8` must match the app version and publishes a verified, production-signed APK as the latest official release.
 
 ## Privacy
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -3,6 +3,27 @@ plugins {
     id("org.jetbrains.kotlin.plugin.compose")
 }
 
+val releaseStoreFile = providers.environmentVariable("ANDROID_RELEASE_STORE_FILE").orNull
+val releaseStorePassword = providers.environmentVariable("ANDROID_RELEASE_STORE_PASSWORD").orNull
+val releaseKeyAlias = providers.environmentVariable("ANDROID_RELEASE_KEY_ALIAS").orNull
+val releaseKeyPassword = providers.environmentVariable("ANDROID_RELEASE_KEY_PASSWORD").orNull
+val releaseSigningValues = listOf(
+    releaseStoreFile,
+    releaseStorePassword,
+    releaseKeyAlias,
+    releaseKeyPassword,
+)
+val hasReleaseSigning = releaseSigningValues.all { !it.isNullOrBlank() }
+val requireReleaseSigning = providers.gradleProperty("requireReleaseSigning").orNull == "true"
+
+if (requireReleaseSigning && !hasReleaseSigning) {
+    throw GradleException(
+        "Release signing requires ANDROID_RELEASE_STORE_FILE, " +
+            "ANDROID_RELEASE_STORE_PASSWORD, ANDROID_RELEASE_KEY_ALIAS, and " +
+            "ANDROID_RELEASE_KEY_PASSWORD.",
+    )
+}
+
 android {
     namespace = "com.kienhoang.dualsubreplay"
     compileSdk = 36
@@ -27,9 +48,23 @@ android {
         targetCompatibility = JavaVersion.VERSION_17
     }
 
+    signingConfigs {
+        if (hasReleaseSigning) {
+            create("production") {
+                storeFile = file(requireNotNull(releaseStoreFile))
+                storePassword = requireNotNull(releaseStorePassword)
+                keyAlias = requireNotNull(releaseKeyAlias)
+                keyPassword = requireNotNull(releaseKeyPassword)
+            }
+        }
+    }
+
     buildTypes {
         release {
             isMinifyEnabled = false
+            if (hasReleaseSigning) {
+                signingConfig = signingConfigs.getByName("production")
+            }
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro",


### PR DESCRIPTION
## What changed

- add production release signing through protected GitHub Actions secrets
- publish version tags as verified official releases with a stable APK filename and SHA-256 checksum
- keep the rolling preview channel while directing normal users to the official release
- place a one-click download and simple Android installation instructions at the top of the README

## Why

The existing v0.2.8 preview is ready to become the official release, but it was debug-signed and the repository did not give non-technical users a clear download path.

## Validation

- `testDebugUnitTest lintDebug assembleDebug assembleDebugAndroidTest assembleRelease`
- 7/7 API 36 managed-device tests
- production APK signature verified with `apksigner`
- package metadata verified as version `0.2.8`, code `10`
- production APK installed and cold-launched on API 36; MainActivity resumed and crash buffer remained empty
- GitHub Actions workflow YAML parsed successfully