### PR TITLE
Improve subtitle panel reading flow

### DIFF
--- a/app/src/main/java/com/kienhoang/dualsubreplay/ui/DualSubApp.kt
+++ b/app/src/main/java/com/kienhoang/dualsubreplay/ui/DualSubApp.kt
@@ -48,6 +48,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -63,6 +64,7 @@ import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.kienhoang.dualsubreplay.data.SubtitleSegment
 import com.kienhoang.dualsubreplay.ui.theme.DualSubTheme
+import kotlinx.coroutines.flow.first
 
 @Composable
 fun DualSubApp(viewModel: AppViewModel) {
@@ -118,7 +120,7 @@ private fun DualSubExperience(
                     modifier = Modifier
                         .align(Alignment.BottomCenter)
                         .fillMaxWidth()
-                        .fillMaxHeight(0.48f)
+                        .fillMaxHeight(0.60f)
                         .testTag("subtitle_timeline"),
                     onHide = onHideSubtitles,
                     onSettings = { showSettings = true },
@@ -238,7 +240,14 @@ private fun SubtitlePanel(
 private fun SubtitleTimeline(state: DualSubUiState, onReplay: (SubtitleSegment) -> Unit) {
     val listState = rememberLazyListState()
     LaunchedEffect(state.currentIndex) {
-        if (state.currentIndex >= 0 && !listState.isScrollInProgress) {
+        val visibleItemIndices = snapshotFlow {
+            listState.layoutInfo.visibleItemsInfo.map { it.index }
+        }.first { it.isNotEmpty() }
+
+        if (
+            !listState.isScrollInProgress &&
+            shouldPromoteActiveSubtitle(state.currentIndex, visibleItemIndices)
+        ) {
             listState.animateScrollToItem(state.currentIndex)
         }
     }
@@ -258,6 +267,19 @@ private fun SubtitleTimeline(state: DualSubUiState, onReplay: (SubtitleSegment) 
             )
         }
     }
+}
+
+/**
+ * Keeps earlier paragraphs on screen until the active paragraph reaches the
+ * bottom-most visible slot. Seeking past the viewport also promotes the active
+ * paragraph so playback can recover without leaving it off-screen.
+ */
+internal fun shouldPromoteActiveSubtitle(
+    currentIndex: Int,
+    visibleItemIndices: List<Int>,
+): Boolean {
+    if (currentIndex < 0 || visibleItemIndices.isEmpty()) return false
+    return currentIndex >= visibleItemIndices.last()
 }
 
 @Composable

--- a/app/src/test/java/com/kienhoang/dualsubreplay/ui/PlaybackArchitectureTest.kt
+++ b/app/src/test/java/com/kienhoang/dualsubreplay/ui/PlaybackArchitectureTest.kt
@@ -91,4 +91,20 @@ class PlaybackArchitectureTest {
         assertEquals(1, activeSubtitleIndex(segments, 2_500))
         assertEquals(-1, activeSubtitleIndex(segments, 3_000))
     }
+
+    @Test
+    fun activeSubtitleStaysInPlaceUntilItReachesTheBottomOfThePanel() {
+        val visibleItems = listOf(4, 5, 6, 7)
+
+        assertFalse(shouldPromoteActiveSubtitle(5, visibleItems))
+        assertFalse(shouldPromoteActiveSubtitle(6, visibleItems))
+        assertTrue(shouldPromoteActiveSubtitle(7, visibleItems))
+    }
+
+    @Test
+    fun activeSubtitlePromotesAfterASeekBeyondTheVisiblePanel() {
+        assertTrue(shouldPromoteActiveSubtitle(12, listOf(4, 5, 6, 7)))
+        assertFalse(shouldPromoteActiveSubtitle(-1, listOf(4, 5, 6, 7)))
+        assertFalse(shouldPromoteActiveSubtitle(7, emptyList()))
+    }
 }


### PR DESCRIPTION
## What changed

- Increase the dual-subtitle panel from 48% to 60% of the available app height.
- Keep the active subtitle in its current visible position while earlier paragraphs remain readable.
- Move the active subtitle to the top only when it reaches the bottom-most visible slot.
- Recover correctly after seeking beyond the visible subtitle viewport.
- Add unit coverage for the new bottom-threshold behavior.

## Why

The previous timeline called `animateScrollToItem(currentIndex)` on every paragraph change, immediately pinning each new paragraph to the top and removing reading context for slower readers.

## Validation

- `git diff --check` passed.
- Added unit tests for normal progression, bottom threshold, invalid state, and seeking past the viewport.
- The local Android build could not download Gradle because this workspace blocks `services.gradle.org`; GitHub Actions will run the repository's full test, lint, APK build, and managed-device suite.