### PR TITLE
Add language selection and swipe-to-hide subtitles

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -47,13 +47,13 @@ jobs:
         run: bash ./gradlew testDebugUnitTest lintDebug assembleDebug assembleDebugAndroidTest --stacktrace
 
       - name: Name preview APK
-        run: cp app/build/outputs/apk/debug/app-debug.apk DualSub-Replay-v0.3.0-preview.apk
+        run: cp app/build/outputs/apk/debug/app-debug.apk DualSub-Replay-v0.3.1-preview.apk
 
       - name: Upload APK artifact
         uses: actions/upload-artifact@v4
         with:
-          name: DualSub-Replay-v0.3.0-preview
-          path: DualSub-Replay-v0.3.0-preview.apk
+          name: DualSub-Replay-v0.3.1-preview
+          path: DualSub-Replay-v0.3.1-preview.apk
           if-no-files-found: error
 
   managed-device-tests:
@@ -113,7 +113,7 @@ jobs:
       - name: Download verified preview APK
         uses: actions/download-artifact@v4
         with:
-          name: DualSub-Replay-v0.3.0-preview
+          name: DualSub-Replay-v0.3.1-preview
           path: release
 
       - name: Remove obsolete preview APKs
@@ -130,6 +130,7 @@ jobs:
           gh release delete-asset preview DualSub-Replay-v0.2.6-preview.apk --yes || true
           gh release delete-asset preview DualSub-Replay-v0.2.7-preview.apk --yes || true
           gh release delete-asset preview DualSub-Replay-v0.2.8-preview.apk --yes || true
+          gh release delete-asset preview DualSub-Replay-v0.3.0-preview.apk --yes || true
 
       - name: Publish rolling preview release
         uses: softprops/action-gh-release@v2
@@ -144,7 +145,7 @@ jobs:
             Most people should install the [latest official release](https://github.com/${{ github.repository }}/releases/latest) instead.
 
             This APK uses a CI debug signature. Uninstall an older preview first if Android reports a signature mismatch.
-          files: release/DualSub-Replay-v0.3.0-preview.apk
+          files: release/DualSub-Replay-v0.3.1-preview.apk
           overwrite_files: true
 
   publish-release:
@@ -231,9 +232,9 @@ jobs:
             ## Highlights
 
             - Browse YouTube and open videos in a dedicated learning player.
-            - Read original and Vietnamese subtitles together.
+            - Choose available caption languages and translate into any language supported by Google ML Kit.
             - Tap a subtitle paragraph to replay that moment.
-            - Use YouTube controls, fullscreen, comments, and recommendations.
+            - Swipe down to hide subtitles and use YouTube controls, fullscreen, comments, and recommendations.
 
             The `.sha256` file can be used to verify the APK download.
           files: |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DualSub Replay
 
-An Android language-learning app for watching YouTube with original and Vietnamese subtitles together. Tap any subtitle paragraph to replay that moment.
+An Android language-learning app for watching YouTube with original and translated subtitles together. Tap any subtitle paragraph to replay that moment.
 
 ## Download
 
@@ -27,11 +27,12 @@ Want to test the newest development build? See the [preview release](https://git
 - Play videos with YouTube's native mobile webpage player and controls.
 - Retrieve manual or auto-generated public captions automatically.
 - Parse YouTube's default timed-text XML, nested SRV3 XML, and JSON3 caption formats.
-- Prefer English or Japanese captions and translate them to Vietnamese on-device.
+- Choose from the caption languages offered by each video and translate into any language supported by Google ML Kit.
+- Download translation models on demand and remember the preferred target language.
 - Merge short caption cues into readable paragraphs.
 - Place the dual-subtitle timeline in a temporary bottom layer over the single YouTube page.
 - Highlight the current paragraph and tap any paragraph to replay it.
-- Hide the subtitle timeline to reveal the complete YouTube page, including the same video,
+- Swipe the panel header down or use its close button to reveal the complete YouTube page, including the same video,
   actions, comments, and recommendations; no second player or webpage is created.
 - Reopen the subtitle timeline and remember the subtitle text size.
 - Build, test, and publish installable APKs automatically with GitHub Actions.
@@ -39,11 +40,11 @@ Want to test the newest development build? See the [preview release](https://git
 ## User flow
 
 1. Open DualSub Replay; the YouTube Browse screen appears immediately.
-2. Search normally and choose a captioned English or Japanese video.
+2. Search normally and choose a captioned video.
 3. The selected watch page stays in the same WebView while captions and translations load.
 4. The bottom dual-subtitle layer tracks the native webpage video's playback time.
 5. Tap any subtitle paragraph to seek to its start and resume playback.
-6. Hide the subtitle timeline to like the video, read comments, or choose another video.
+6. Swipe the subtitle timeline down to like the video, read comments, or choose another video.
 7. Press Back to navigate through normal YouTube browsing history.
 
 Sharing a YouTube watch, Short, live, embed, or `youtu.be` URL to DualSub Replay navigates the same WebView directly to it.
@@ -90,7 +91,7 @@ Debug APKs are produced at `app/build/outputs/apk/debug/app-debug.apk`. An offic
 - `YouTubeUrlParser` normalizes shared links and extracts video IDs.
 - `YouTubeCaptionProvider` discovers and downloads timed caption cues.
 - `SubtitleMerger` converts small cues into replayable paragraphs.
-- `OnDeviceTranslator` uses Google ML Kit to translate to Vietnamese.
+- `OnDeviceTranslator` uses Google ML Kit to translate between the selected supported languages.
 - `AppViewModel` tracks the active watch URL, caption loading, translation, and active cue.
 - `SingleYouTubePage` owns the app's only WebView and keeps normal YouTube navigation and playback intact.
 - A small JavaScript polling bridge reads the native page video's time and seeks that same video for replay.
@@ -98,11 +99,11 @@ Debug APKs are produced at `app/build/outputs/apk/debug/app-debug.apk`. An offic
 
 ## Continuous integration
 
-Every push and pull request uses the committed wrapper to run unit tests, lint, debug APK assembly, and Android-test APK assembly. A second job executes the offline fixture suite on the API 36 managed device. A push to `main` updates the rolling `preview` release only after both jobs pass. A version tag such as `v0.3.0` must match the app version and publishes a verified, production-signed APK as the latest official release.
+Every push and pull request uses the committed wrapper to run unit tests, lint, debug APK assembly, and Android-test APK assembly. A second job executes the offline fixture suite on the API 36 managed device. A push to `main` updates the rolling `preview` release only after both jobs pass. A version tag such as `v0.3.1` must match the app version and publishes a verified, production-signed APK as the latest official release.
 
 ## Privacy
 
-No account or API key is required. YouTube receives normal player and transcript requests. ML Kit downloads translation models from Google, then performs translation on the device. The app stores the last Browse URL and text-size setting in local app preferences.
+No account or API key is required. YouTube receives normal player and transcript requests. ML Kit downloads only the language models needed for selected translations, then performs translation on the device. The app stores the last Browse URL, target language, and text-size setting in local app preferences.
 
 ## License
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -32,8 +32,8 @@ android {
         applicationId = "com.kienhoang.dualsubreplay"
         minSdk = 26
         targetSdk = 36
-        versionCode = 11
-        versionName = "0.3.0"
+        versionCode = 12
+        versionName = "0.3.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/androidTest/java/com/kienhoang/dualsubreplay/ui/SubtitleUiTest.kt
+++ b/app/src/androidTest/java/com/kienhoang/dualsubreplay/ui/SubtitleUiTest.kt
@@ -6,7 +6,10 @@ import androidx.compose.ui.test.assert
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
+import com.kienhoang.dualsubreplay.data.CaptionLanguage
 import com.kienhoang.dualsubreplay.data.SubtitleSegment
 import com.kienhoang.dualsubreplay.ui.theme.DualSubTheme
 import org.junit.Assert.assertEquals
@@ -21,24 +24,37 @@ class SubtitleUiTest {
     @Test
     fun settingsKeepsLanguageAndTextOptionsWithoutFocus() {
         var selectedLanguage: String? = null
+        var selectedTarget: String? = null
         var dismissed = false
         composeRule.setContent {
             DualSubTheme {
                 SubtitleSettingsDialog(
                     sourcePreference = "auto",
+                    targetLanguage = "vi",
+                    availableSourceLanguages = listOf(
+                        CaptionLanguage("en", "English"),
+                        CaptionLanguage("ja", "Japanese"),
+                    ),
                     fontScale = 1f,
                     onSourceChange = { selectedLanguage = it },
+                    onTargetChange = { selectedTarget = it },
                     onFontScaleChange = {},
                     onDismiss = { dismissed = true },
                 )
             }
         }
 
-        composeRule.onNodeWithText("Original language").assertIsDisplayed()
-        composeRule.onNodeWithText("Translation: Vietnamese").assertIsDisplayed()
+        composeRule.onNodeWithText("Original captions").assertIsDisplayed()
+        composeRule.onNodeWithText("Translate to").assertIsDisplayed()
+        composeRule.onNodeWithText("Vietnamese").assertIsDisplayed()
         composeRule.onNodeWithText("Focus").assertDoesNotExist()
-        composeRule.onNodeWithText("Japanese").performClick()
+        composeRule.onNodeWithTag("source_language_picker").performClick()
+        composeRule.onNodeWithTag("language_option_source_ja").performClick()
         composeRule.runOnIdle { assertEquals("ja", selectedLanguage) }
+        composeRule.onNodeWithTag("target_language_picker").performClick()
+        composeRule.onNodeWithTag("language_search").performTextInput("English")
+        composeRule.onNodeWithTag("language_option_target_en").performClick()
+        composeRule.runOnIdle { assertEquals("en", selectedTarget) }
         composeRule.onNodeWithText("Done").performClick()
         composeRule.runOnIdle { assertTrue(dismissed) }
     }

--- a/app/src/main/java/com/kienhoang/dualsubreplay/data/SubtitleModels.kt
+++ b/app/src/main/java/com/kienhoang/dualsubreplay/data/SubtitleModels.kt
@@ -18,4 +18,10 @@ data class CaptionTrackResult(
     val languageCode: String,
     val isGenerated: Boolean,
     val cues: List<RawCaptionCue>,
+    val availableLanguages: List<CaptionLanguage> = emptyList(),
+)
+
+data class CaptionLanguage(
+    val code: String,
+    val name: String,
 )

--- a/app/src/main/java/com/kienhoang/dualsubreplay/data/YouTubeCaptionProvider.kt
+++ b/app/src/main/java/com/kienhoang/dualsubreplay/data/YouTubeCaptionProvider.kt
@@ -87,7 +87,29 @@ class YouTubeCaptionProvider(
             isGenerated = selected.optString("kind") == "asr" ||
                 selected.optString("vssId").startsWith("a."),
             cues = cues,
+            availableLanguages = availableLanguages(tracks),
         )
+    }
+
+    private fun availableLanguages(tracks: JSONArray): List<CaptionLanguage> =
+        (0 until tracks.length())
+            .mapNotNull(tracks::optJSONObject)
+            .mapNotNull { track ->
+                val code = track.optString("languageCode").takeIf(String::isNotBlank) ?: return@mapNotNull null
+                CaptionLanguage(
+                    code = code,
+                    name = track.optJSONObject("name")?.let(::captionName).orEmpty()
+                        .ifBlank { code.uppercase() },
+                )
+            }
+            .distinctBy { it.code.substringBefore('-').lowercase() }
+
+    private fun captionName(name: JSONObject): String {
+        name.optString("simpleText").takeIf(String::isNotBlank)?.let { return it }
+        val runs = name.optJSONArray("runs") ?: return ""
+        return (0 until runs.length())
+            .mapNotNull(runs::optJSONObject)
+            .joinToString(separator = "") { it.optString("text") }
     }
 
     private fun fetchCaptionCues(baseUrl: String): List<RawCaptionCue> {

--- a/app/src/main/java/com/kienhoang/dualsubreplay/translation/OnDeviceTranslator.kt
+++ b/app/src/main/java/com/kienhoang/dualsubreplay/translation/OnDeviceTranslator.kt
@@ -12,12 +12,17 @@ import kotlin.coroutines.resumeWithException
 class OnDeviceTranslator {
     suspend fun translateAll(
         sourceLanguageCode: String,
+        targetLanguageCode: String,
         texts: List<String>,
         onTranslation: suspend (index: Int, translatedText: String) -> Unit,
     ) {
-        val source = TranslateLanguage.fromLanguageTag(sourceLanguageCode.substringBefore('-'))
-            ?: TranslateLanguage.ENGLISH
-        if (source == TranslateLanguage.VIETNAMESE) {
+        val normalizedSource = TranslationLanguages.normalize(sourceLanguageCode)
+        val normalizedTarget = TranslationLanguages.normalize(targetLanguageCode)
+        val source = TranslateLanguage.fromLanguageTag(normalizedSource)
+            ?: throw IllegalArgumentException("${TranslationLanguages.displayName(sourceLanguageCode)} translation is not supported.")
+        val target = TranslateLanguage.fromLanguageTag(normalizedTarget)
+            ?: throw IllegalArgumentException("${TranslationLanguages.displayName(targetLanguageCode)} translation is not supported.")
+        if (source == target) {
             texts.forEachIndexed { index, text -> onTranslation(index, text) }
             return
         }
@@ -25,7 +30,7 @@ class OnDeviceTranslator {
         val translator = Translation.getClient(
             TranslatorOptions.Builder()
                 .setSourceLanguage(source)
-                .setTargetLanguage(TranslateLanguage.VIETNAMESE)
+                .setTargetLanguage(target)
                 .build(),
         )
         try {

--- a/app/src/main/java/com/kienhoang/dualsubreplay/translation/TranslationLanguages.kt
+++ b/app/src/main/java/com/kienhoang/dualsubreplay/translation/TranslationLanguages.kt
@@ -1,0 +1,85 @@
+package com.kienhoang.dualsubreplay.translation
+
+data class TranslationLanguageOption(
+    val code: String,
+    val name: String,
+)
+
+object TranslationLanguages {
+    val all: List<TranslationLanguageOption> = listOf(
+        TranslationLanguageOption("af", "Afrikaans"),
+        TranslationLanguageOption("sq", "Albanian"),
+        TranslationLanguageOption("ar", "Arabic"),
+        TranslationLanguageOption("be", "Belarusian"),
+        TranslationLanguageOption("bn", "Bengali"),
+        TranslationLanguageOption("bg", "Bulgarian"),
+        TranslationLanguageOption("ca", "Catalan"),
+        TranslationLanguageOption("zh", "Chinese"),
+        TranslationLanguageOption("hr", "Croatian"),
+        TranslationLanguageOption("cs", "Czech"),
+        TranslationLanguageOption("da", "Danish"),
+        TranslationLanguageOption("nl", "Dutch"),
+        TranslationLanguageOption("en", "English"),
+        TranslationLanguageOption("eo", "Esperanto"),
+        TranslationLanguageOption("et", "Estonian"),
+        TranslationLanguageOption("fi", "Finnish"),
+        TranslationLanguageOption("fr", "French"),
+        TranslationLanguageOption("gl", "Galician"),
+        TranslationLanguageOption("ka", "Georgian"),
+        TranslationLanguageOption("de", "German"),
+        TranslationLanguageOption("el", "Greek"),
+        TranslationLanguageOption("gu", "Gujarati"),
+        TranslationLanguageOption("ht", "Haitian"),
+        TranslationLanguageOption("he", "Hebrew"),
+        TranslationLanguageOption("hi", "Hindi"),
+        TranslationLanguageOption("hu", "Hungarian"),
+        TranslationLanguageOption("is", "Icelandic"),
+        TranslationLanguageOption("id", "Indonesian"),
+        TranslationLanguageOption("ga", "Irish"),
+        TranslationLanguageOption("it", "Italian"),
+        TranslationLanguageOption("ja", "Japanese"),
+        TranslationLanguageOption("kn", "Kannada"),
+        TranslationLanguageOption("ko", "Korean"),
+        TranslationLanguageOption("lv", "Latvian"),
+        TranslationLanguageOption("lt", "Lithuanian"),
+        TranslationLanguageOption("mk", "Macedonian"),
+        TranslationLanguageOption("ms", "Malay"),
+        TranslationLanguageOption("mt", "Maltese"),
+        TranslationLanguageOption("mr", "Marathi"),
+        TranslationLanguageOption("no", "Norwegian"),
+        TranslationLanguageOption("fa", "Persian"),
+        TranslationLanguageOption("pl", "Polish"),
+        TranslationLanguageOption("pt", "Portuguese"),
+        TranslationLanguageOption("ro", "Romanian"),
+        TranslationLanguageOption("ru", "Russian"),
+        TranslationLanguageOption("sk", "Slovak"),
+        TranslationLanguageOption("sl", "Slovenian"),
+        TranslationLanguageOption("es", "Spanish"),
+        TranslationLanguageOption("sw", "Swahili"),
+        TranslationLanguageOption("sv", "Swedish"),
+        TranslationLanguageOption("tl", "Tagalog"),
+        TranslationLanguageOption("ta", "Tamil"),
+        TranslationLanguageOption("te", "Telugu"),
+        TranslationLanguageOption("th", "Thai"),
+        TranslationLanguageOption("tr", "Turkish"),
+        TranslationLanguageOption("uk", "Ukrainian"),
+        TranslationLanguageOption("ur", "Urdu"),
+        TranslationLanguageOption("vi", "Vietnamese"),
+        TranslationLanguageOption("cy", "Welsh"),
+    )
+
+    private val byCode = all.associateBy(TranslationLanguageOption::code)
+
+    fun normalize(code: String): String = when (code.substringBefore('-').lowercase()) {
+        "iw" -> "he"
+        else -> code.substringBefore('-').lowercase()
+    }
+
+    fun find(code: String?): TranslationLanguageOption? =
+        code?.let(::normalize)?.let(byCode::get)
+
+    fun displayName(code: String?): String =
+        find(code)?.name ?: code.orEmpty().uppercase().ifBlank { "Unknown" }
+
+    fun isSupported(code: String): Boolean = find(code) != null
+}

--- a/app/src/main/java/com/kienhoang/dualsubreplay/ui/AppViewModel.kt
+++ b/app/src/main/java/com/kienhoang/dualsubreplay/ui/AppViewModel.kt
@@ -3,6 +3,7 @@ package com.kienhoang.dualsubreplay.ui
 import android.app.Application
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
+import com.kienhoang.dualsubreplay.data.CaptionLanguage
 import com.kienhoang.dualsubreplay.data.CaptionProvider
 import com.kienhoang.dualsubreplay.data.CaptionUnavailableException
 import com.kienhoang.dualsubreplay.data.SubtitleMerger
@@ -10,6 +11,7 @@ import com.kienhoang.dualsubreplay.data.SubtitleSegment
 import com.kienhoang.dualsubreplay.data.YouTubeCaptionProvider
 import com.kienhoang.dualsubreplay.data.YouTubeUrlParser
 import com.kienhoang.dualsubreplay.translation.OnDeviceTranslator
+import com.kienhoang.dualsubreplay.translation.TranslationLanguages
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -26,6 +28,8 @@ data class DualSubUiState(
     val activeVideoId: String? = null,
     val subtitlePanelVisible: Boolean = true,
     val sourcePreference: String = "auto",
+    val targetLanguage: String = "vi",
+    val availableSourceLanguages: List<CaptionLanguage> = emptyList(),
     val resolvedSourceLanguage: String? = null,
     val generatedCaptions: Boolean = false,
     val segments: List<SubtitleSegment> = emptyList(),
@@ -54,6 +58,14 @@ internal fun activeSubtitleIndex(segments: List<SubtitleSegment>, timeMs: Long):
 
 internal const val YOUTUBE_HOME_URL = "https://m.youtube.com/"
 
+internal fun preferredCaptionLanguages(sourcePreference: String): List<String> =
+    sourcePreference.takeUnless { it == "auto" }?.let(::listOf).orEmpty()
+
+internal fun resolvedSourcePreference(requested: String, resolved: String): String =
+    requested.takeIf {
+        it == "auto" || TranslationLanguages.normalize(it) == TranslationLanguages.normalize(resolved)
+    } ?: "auto"
+
 class AppViewModel(application: Application) : AndroidViewModel(application) {
     private val preferences = application.getSharedPreferences("dual_sub_preferences", 0)
     private val captionProvider: CaptionProvider = YouTubeCaptionProvider()
@@ -67,6 +79,9 @@ class AppViewModel(application: Application) : AndroidViewModel(application) {
                 ?.takeIf { it.startsWith("https://") }
                 ?: YOUTUBE_HOME_URL,
             fontScale = preferences.getFloat("font_scale", 1f),
+            targetLanguage = preferences.getString("target_language", "vi")
+                ?.takeIf(TranslationLanguages::isSupported)
+                ?: "vi",
         ),
     )
     val state: StateFlow<DualSubUiState> = _state.asStateFlow()
@@ -108,10 +123,28 @@ class AppViewModel(application: Application) : AndroidViewModel(application) {
     }
 
     fun setSourcePreference(language: String) {
-        if (_state.value.sourcePreference == language) return
-        _state.update { it.copy(sourcePreference = language) }
+        val normalized = language.takeIf { it == "auto" } ?: TranslationLanguages.normalize(language)
+        val current = _state.value
+        if (
+            normalized != "auto" &&
+            current.availableSourceLanguages.none {
+                TranslationLanguages.normalize(it.code) == normalized
+            }
+        ) return
+        if (current.sourcePreference == normalized) return
+        _state.update { it.copy(sourcePreference = normalized) }
         val videoId = _state.value.activeVideoId ?: return
         loadVideo(videoId, showPanel = true)
+    }
+
+    fun setTargetLanguage(language: String) {
+        val normalized = TranslationLanguages.normalize(language)
+        if (!TranslationLanguages.isSupported(normalized) || _state.value.targetLanguage == normalized) return
+        preferences.edit().putString("target_language", normalized).apply()
+        _state.update { it.copy(targetLanguage = normalized) }
+        if (_state.value.activeVideoId != null && _state.value.segments.isNotEmpty()) {
+            retranslateCurrentSegments()
+        }
     }
 
     fun setFontScale(scale: Float) {
@@ -142,6 +175,7 @@ class AppViewModel(application: Application) : AndroidViewModel(application) {
             it.copy(
                 activeVideoId = null,
                 subtitlePanelVisible = true,
+                availableSourceLanguages = emptyList(),
                 resolvedSourceLanguage = null,
                 generatedCaptions = false,
                 segments = emptyList(),
@@ -160,6 +194,7 @@ class AppViewModel(application: Application) : AndroidViewModel(application) {
             it.copy(
                 activeVideoId = videoId,
                 subtitlePanelVisible = showPanel,
+                availableSourceLanguages = emptyList(),
                 resolvedSourceLanguage = null,
                 generatedCaptions = false,
                 segments = emptyList(),
@@ -171,11 +206,7 @@ class AppViewModel(application: Application) : AndroidViewModel(application) {
         }
         loadingJob = viewModelScope.launch {
             try {
-                val preferredLanguages = when (_state.value.sourcePreference) {
-                    "en" -> listOf("en", "ja")
-                    "ja" -> listOf("ja", "en")
-                    else -> listOf("en", "ja")
-                }
+                val preferredLanguages = preferredCaptionLanguages(_state.value.sourcePreference)
                 val track = captionProvider.fetch(videoId, preferredLanguages)
                 val merged = SubtitleMerger.merge(track.cues)
                 if (merged.isEmpty()) {
@@ -187,38 +218,25 @@ class AppViewModel(application: Application) : AndroidViewModel(application) {
                     if (!isCurrentLoad(current, videoId, generation)) return@update current
                     current.copy(
                         resolvedSourceLanguage = track.languageCode,
+                        sourcePreference = resolvedSourcePreference(
+                            current.sourcePreference,
+                            track.languageCode,
+                        ),
+                        availableSourceLanguages = track.availableLanguages,
                         generatedCaptions = track.isGenerated,
                         segments = merged,
                         stage = LoadStage.TRANSLATING,
-                        statusMessage = "Downloading the translation model and translating…",
+                        statusMessage = translationStartingMessage(current.targetLanguage),
                     )
                 }
 
-                translator.translateAll(
-                    sourceLanguageCode = track.languageCode,
-                    texts = merged.map(SubtitleSegment::originalText),
-                ) { index, translatedText ->
-                    _state.update { current ->
-                        if (!isCurrentLoad(current, videoId, generation)) return@update current
-                        current.copy(
-                            segments = current.segments.mapIndexed { itemIndex, segment ->
-                                if (itemIndex == index) segment.copy(translatedText = translatedText) else segment
-                            },
-                            statusMessage = "Translating ${index + 1} of ${merged.size}…",
-                        )
-                    }
-                }
-                _state.update { current ->
-                    if (!isCurrentLoad(current, videoId, generation)) return@update current
-                    current.copy(
-                        stage = LoadStage.READY,
-                        statusMessage = if (track.isGenerated) {
-                            "Using auto-generated captions"
-                        } else {
-                            "Captions ready"
-                        },
-                    )
-                }
+                translateSegments(
+                    videoId = videoId,
+                    generation = generation,
+                    sourceLanguage = track.languageCode,
+                    targetLanguage = _state.value.targetLanguage,
+                    segments = merged,
+                )
             } catch (error: Exception) {
                 if (error is CancellationException) throw error
                 _state.update { current ->
@@ -232,6 +250,84 @@ class AppViewModel(application: Application) : AndroidViewModel(application) {
             }
         }
     }
+
+    private fun retranslateCurrentSegments() {
+        val current = _state.value
+        val videoId = current.activeVideoId ?: return
+        val sourceLanguage = current.resolvedSourceLanguage ?: return
+        val segments = current.segments
+        if (segments.isEmpty()) return
+
+        val generation = ++loadGeneration
+        loadingJob?.cancel()
+        _state.update {
+            it.copy(
+                segments = it.segments.map { segment -> segment.copy(translatedText = null) },
+                stage = LoadStage.TRANSLATING,
+                statusMessage = translationStartingMessage(it.targetLanguage),
+                errorMessage = null,
+            )
+        }
+        loadingJob = viewModelScope.launch {
+            try {
+                translateSegments(
+                    videoId = videoId,
+                    generation = generation,
+                    sourceLanguage = sourceLanguage,
+                    targetLanguage = _state.value.targetLanguage,
+                    segments = segments,
+                )
+            } catch (error: Exception) {
+                if (error is CancellationException) throw error
+                _state.update { state ->
+                    if (!isCurrentLoad(state, videoId, generation)) return@update state
+                    state.copy(
+                        stage = LoadStage.ERROR,
+                        statusMessage = null,
+                        errorMessage = error.message ?: "The subtitles could not be translated.",
+                    )
+                }
+            }
+        }
+    }
+
+    private suspend fun translateSegments(
+        videoId: String,
+        generation: Long,
+        sourceLanguage: String,
+        targetLanguage: String,
+        segments: List<SubtitleSegment>,
+    ) {
+        translator.translateAll(
+            sourceLanguageCode = sourceLanguage,
+            targetLanguageCode = targetLanguage,
+            texts = segments.map(SubtitleSegment::originalText),
+        ) { index, translatedText ->
+            _state.update { current ->
+                if (!isCurrentLoad(current, videoId, generation)) return@update current
+                current.copy(
+                    segments = current.segments.mapIndexed { itemIndex, segment ->
+                        if (itemIndex == index) segment.copy(translatedText = translatedText) else segment
+                    },
+                    statusMessage = "Translating ${index + 1} of ${segments.size}…",
+                )
+            }
+        }
+        _state.update { current ->
+            if (!isCurrentLoad(current, videoId, generation)) return@update current
+            current.copy(
+                stage = LoadStage.READY,
+                statusMessage = if (current.generatedCaptions) {
+                    "Using auto-generated captions"
+                } else {
+                    "Captions ready"
+                },
+            )
+        }
+    }
+
+    private fun translationStartingMessage(targetLanguage: String): String =
+        "Preparing ${TranslationLanguages.displayName(targetLanguage)} translation…"
 
     private fun mobileWatchUrl(videoId: String): String =
         "https://m.youtube.com/watch?v=$videoId"

--- a/app/src/main/java/com/kienhoang/dualsubreplay/ui/DualSubApp.kt
+++ b/app/src/main/java/com/kienhoang/dualsubreplay/ui/DualSubApp.kt
@@ -1,7 +1,12 @@
 package com.kienhoang.dualsubreplay.ui
 
+import androidx.compose.animation.core.animate
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.foundation.gestures.draggable
+import androidx.compose.foundation.gestures.rememberDraggableState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -13,6 +18,8 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
@@ -31,12 +38,13 @@ import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.FilterChip
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedCard
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Slider
 import androidx.compose.material3.SmallFloatingActionButton
@@ -46,25 +54,35 @@ import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.kienhoang.dualsubreplay.data.CaptionLanguage
 import com.kienhoang.dualsubreplay.data.SubtitleSegment
+import com.kienhoang.dualsubreplay.translation.TranslationLanguages
 import com.kienhoang.dualsubreplay.ui.theme.DualSubTheme
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.flow.first
+import kotlin.math.max
+import kotlin.math.roundToInt
 
 @Composable
 fun DualSubApp(viewModel: AppViewModel) {
@@ -79,6 +97,7 @@ fun DualSubApp(viewModel: AppViewModel) {
             onHideSubtitles = viewModel::hideSubtitlePanel,
             onRetry = viewModel::retryCaptions,
             onSourceChange = viewModel::setSourcePreference,
+            onTargetChange = viewModel::setTargetLanguage,
             onFontScaleChange = viewModel::setFontScale,
         )
     }
@@ -93,6 +112,7 @@ private fun DualSubExperience(
     onHideSubtitles: () -> Unit,
     onRetry: () -> Unit,
     onSourceChange: (String) -> Unit,
+    onTargetChange: (String) -> Unit,
     onFontScaleChange: (Float) -> Unit,
 ) {
     var showSettings by remember { mutableStateOf(false) }
@@ -149,8 +169,11 @@ private fun DualSubExperience(
     if (showSettings) {
         SubtitleSettingsDialog(
             sourcePreference = state.sourcePreference,
+            targetLanguage = state.targetLanguage,
+            availableSourceLanguages = state.availableSourceLanguages,
             fontScale = state.fontScale,
             onSourceChange = onSourceChange,
+            onTargetChange = onTargetChange,
             onFontScaleChange = onFontScaleChange,
             onDismiss = { showSettings = false },
         )
@@ -167,62 +190,99 @@ private fun SubtitlePanel(
     onRetry: () -> Unit,
     onReplay: (SubtitleSegment) -> Unit,
 ) {
+    var panelOffsetY by remember { mutableFloatStateOf(0f) }
+    var panelHeightPx by remember { mutableFloatStateOf(0f) }
+    val minimumDismissDistancePx = with(LocalDensity.current) { 72.dp.toPx() }
+    val scope = rememberCoroutineScope()
+    val dragState = rememberDraggableState { delta ->
+        val maximum = panelHeightPx.takeIf { it > 0f } ?: Float.MAX_VALUE
+        panelOffsetY = (panelOffsetY + delta).coerceIn(0f, maximum)
+    }
+    val headerDragModifier = Modifier
+        .testTag("subtitle_panel_drag_handle")
+        .draggable(
+            state = dragState,
+            orientation = Orientation.Vertical,
+            onDragStopped = { velocity ->
+                val hide = shouldHideSubtitlePanel(
+                    dragOffsetPx = panelOffsetY,
+                    panelHeightPx = panelHeightPx,
+                    velocityPxPerSecond = velocity,
+                    minimumDistancePx = minimumDismissDistancePx,
+                )
+                scope.launch {
+                    val target = if (hide) panelHeightPx.coerceAtLeast(panelOffsetY) else 0f
+                    animate(
+                        initialValue = panelOffsetY,
+                        targetValue = target,
+                        animationSpec = tween(durationMillis = if (hide) 160 else 220),
+                    ) { value, _ -> panelOffsetY = value }
+                    if (hide) onHide()
+                }
+            },
+        )
+
     Surface(
-        modifier = modifier.shadow(18.dp, RoundedCornerShape(topStart = 18.dp, topEnd = 18.dp)),
+        modifier = modifier
+            .onSizeChanged { panelHeightPx = it.height.toFloat() }
+            .offset { IntOffset(0, panelOffsetY.roundToInt()) }
+            .shadow(18.dp, RoundedCornerShape(topStart = 18.dp, topEnd = 18.dp)),
         shape = RoundedCornerShape(topStart = 18.dp, topEnd = 18.dp),
         color = Color(0xFF061719),
         contentColor = Color(0xFFF3FAFA),
         tonalElevation = 8.dp,
     ) {
         Column(Modifier.fillMaxSize()) {
-            Box(
-                Modifier
-                    .padding(top = 6.dp)
-                    .size(width = 42.dp, height = 4.dp)
-                    .align(Alignment.CenterHorizontally),
-            ) {
-                Surface(Modifier.fillMaxSize(), shape = CircleShape, color = Color(0xFF607477)) {}
-            }
+            Column(headerDragModifier) {
+                Box(
+                    Modifier
+                        .padding(top = 6.dp)
+                        .size(width = 42.dp, height = 4.dp)
+                        .align(Alignment.CenterHorizontally),
+                ) {
+                    Surface(Modifier.fillMaxSize(), shape = CircleShape, color = Color(0xFF607477)) {}
+                }
 
-            Row(
-                modifier = Modifier.fillMaxWidth().height(52.dp).padding(start = 12.dp, end = 4.dp),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                Icon(
-                    Icons.Default.ClosedCaption,
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.primary,
-                )
-                Spacer(Modifier.size(10.dp))
-                Column(Modifier.weight(1f)) {
-                    Text(
-                        text = sourceDescription(state),
-                        style = MaterialTheme.typography.labelLarge,
-                        color = Color(0xFFF3FAFA),
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                    )
-                    Text(
-                        text = state.statusMessage ?: "Tap a paragraph to replay it",
-                        style = MaterialTheme.typography.labelSmall,
-                        color = Color(0xFFB7CED1),
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                    )
-                }
-                IconButton(onClick = onSettings) {
+                Row(
+                    modifier = Modifier.fillMaxWidth().height(52.dp).padding(start = 12.dp, end = 4.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
                     Icon(
-                        Icons.Default.Settings,
-                        contentDescription = "Subtitle settings",
-                        tint = Color(0xFFE5F2F3),
+                        Icons.Default.ClosedCaption,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.primary,
                     )
-                }
-                IconButton(onClick = onHide) {
-                    Icon(
-                        Icons.Default.Close,
-                        contentDescription = "Hide dual subtitles",
-                        tint = Color(0xFFE5F2F3),
-                    )
+                    Spacer(Modifier.size(10.dp))
+                    Column(Modifier.weight(1f)) {
+                        Text(
+                            text = sourceDescription(state),
+                            style = MaterialTheme.typography.labelLarge,
+                            color = Color(0xFFF3FAFA),
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                        Text(
+                            text = state.statusMessage ?: "Tap a paragraph to replay it",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = Color(0xFFB7CED1),
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                    }
+                    IconButton(onClick = onSettings) {
+                        Icon(
+                            Icons.Default.Settings,
+                            contentDescription = "Subtitle settings",
+                            tint = Color(0xFFE5F2F3),
+                        )
+                    }
+                    IconButton(onClick = onHide) {
+                        Icon(
+                            Icons.Default.Close,
+                            contentDescription = "Hide dual subtitles",
+                            tint = Color(0xFFE5F2F3),
+                        )
+                    }
                 }
             }
             HorizontalDivider(color = Color(0xFF244044))
@@ -234,6 +294,16 @@ private fun SubtitlePanel(
             }
         }
     }
+}
+
+internal fun shouldHideSubtitlePanel(
+    dragOffsetPx: Float,
+    panelHeightPx: Float,
+    velocityPxPerSecond: Float,
+    minimumDistancePx: Float,
+): Boolean {
+    val distanceThreshold = max(minimumDistancePx, panelHeightPx * 0.18f)
+    return dragOffsetPx >= distanceThreshold || velocityPxPerSecond >= 1_500f
 }
 
 @Composable
@@ -374,50 +444,170 @@ private fun CompactErrorPanel(message: String, onRetry: () -> Unit) {
 @Composable
 internal fun SubtitleSettingsDialog(
     sourcePreference: String,
+    targetLanguage: String,
+    availableSourceLanguages: List<CaptionLanguage>,
     fontScale: Float,
     onSourceChange: (String) -> Unit,
+    onTargetChange: (String) -> Unit,
     onFontScaleChange: (Float) -> Unit,
     onDismiss: () -> Unit,
 ) {
+    var pickerMode by remember { mutableStateOf<LanguagePickerMode?>(null) }
+    var searchQuery by remember { mutableStateOf("") }
+    val sourceChoices = listOf(LanguageChoice("auto", "Auto (recommended)")) +
+        availableSourceLanguages.map { LanguageChoice(it.code, it.name) }
+    val targetChoices = TranslationLanguages.all.map { LanguageChoice(it.code, it.name) }
+
+    val activePicker = pickerMode
+    if (activePicker != null) {
+        val choices = if (activePicker == LanguagePickerMode.SOURCE) sourceChoices else targetChoices
+        LanguagePickerDialog(
+            title = if (activePicker == LanguagePickerMode.SOURCE) {
+                "Original caption language"
+            } else {
+                "Translate to"
+            },
+            choices = choices,
+            selectedCode = if (activePicker == LanguagePickerMode.SOURCE) sourcePreference else targetLanguage,
+            searchQuery = searchQuery,
+            onSearchQueryChange = { searchQuery = it },
+            onChoice = { choice ->
+                if (activePicker == LanguagePickerMode.SOURCE) {
+                    onSourceChange(choice.code)
+                } else {
+                    onTargetChange(choice.code)
+                }
+                pickerMode = null
+                searchQuery = ""
+            },
+            onDismiss = {
+                pickerMode = null
+                searchQuery = ""
+            },
+            testTagPrefix = activePicker.name.lowercase(),
+        )
+    } else {
+        val sourceLabel = if (sourcePreference == "auto") {
+            "Auto (recommended)"
+        } else {
+            sourceChoices.firstOrNull {
+                TranslationLanguages.normalize(it.code) == TranslationLanguages.normalize(sourcePreference)
+            }?.label ?: TranslationLanguages.displayName(sourcePreference)
+        }
+        AlertDialog(
+            onDismissRequest = onDismiss,
+            title = { Text("Dual-subtitle settings") },
+            text = {
+                Column {
+                    Text("Original captions")
+                    Spacer(Modifier.height(6.dp))
+                    OutlinedButton(
+                        onClick = {
+                            pickerMode = LanguagePickerMode.SOURCE
+                            searchQuery = ""
+                        },
+                        modifier = Modifier.fillMaxWidth().testTag("source_language_picker"),
+                    ) {
+                        Text(sourceLabel, maxLines = 1, overflow = TextOverflow.Ellipsis)
+                    }
+                    Spacer(Modifier.height(14.dp))
+                    Text("Translate to")
+                    Spacer(Modifier.height(6.dp))
+                    OutlinedButton(
+                        onClick = {
+                            pickerMode = LanguagePickerMode.TARGET
+                            searchQuery = ""
+                        },
+                        modifier = Modifier.fillMaxWidth().testTag("target_language_picker"),
+                    ) {
+                        Text(TranslationLanguages.displayName(targetLanguage))
+                    }
+                    Text(
+                        "A language model downloads only when it is needed.",
+                        modifier = Modifier.padding(top = 6.dp),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    Spacer(Modifier.height(14.dp))
+                    Text("Text size: ${(fontScale * 100).toInt()}%")
+                    Slider(value = fontScale, onValueChange = onFontScaleChange, valueRange = 0.8f..1.5f)
+                    Text(
+                        "Swipe the panel header down to hide it. Captions keep tracking while hidden.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            },
+            confirmButton = { TextButton(onClick = onDismiss) { Text("Done") } },
+        )
+    }
+}
+
+private enum class LanguagePickerMode { SOURCE, TARGET }
+
+private data class LanguageChoice(val code: String, val label: String)
+
+@Composable
+private fun LanguagePickerDialog(
+    title: String,
+    choices: List<LanguageChoice>,
+    selectedCode: String,
+    searchQuery: String,
+    onSearchQueryChange: (String) -> Unit,
+    onChoice: (LanguageChoice) -> Unit,
+    onDismiss: () -> Unit,
+    testTagPrefix: String,
+) {
+    val filteredChoices = choices.filter { choice ->
+        searchQuery.isBlank() ||
+            choice.label.contains(searchQuery.trim(), ignoreCase = true) ||
+            choice.code.contains(searchQuery.trim(), ignoreCase = true)
+    }
     AlertDialog(
         onDismissRequest = onDismiss,
-        title = { Text("Dual-subtitle settings") },
+        title = { Text(title) },
         text = {
             Column {
-                Text("Original language")
-                Spacer(Modifier.height(6.dp))
-                Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
-                    listOf("auto" to "Auto", "en" to "English", "ja" to "Japanese").forEach { (code, label) ->
-                        FilterChip(
-                            selected = sourcePreference == code,
-                            onClick = { onSourceChange(code) },
-                            label = { Text(label) },
-                        )
+                OutlinedTextField(
+                    value = searchQuery,
+                    onValueChange = onSearchQueryChange,
+                    modifier = Modifier.fillMaxWidth().testTag("language_search"),
+                    label = { Text("Search languages") },
+                    singleLine = true,
+                )
+                Spacer(Modifier.height(8.dp))
+                LazyColumn(Modifier.fillMaxWidth().heightIn(max = 360.dp)) {
+                    itemsIndexed(filteredChoices, key = { _, choice -> choice.code }) { _, choice ->
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clickable { onChoice(choice) }
+                                .testTag("language_option_${testTagPrefix}_${choice.code}")
+                                .padding(horizontal = 8.dp, vertical = 12.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            Text(choice.label, modifier = Modifier.weight(1f))
+                            if (
+                                TranslationLanguages.normalize(choice.code) ==
+                                TranslationLanguages.normalize(selectedCode)
+                            ) {
+                                Text("Selected", style = MaterialTheme.typography.labelSmall)
+                            }
+                        }
                     }
                 }
-                Spacer(Modifier.height(14.dp))
-                Text("Translation: Vietnamese")
-                Spacer(Modifier.height(14.dp))
-                Text("Text size: ${(fontScale * 100).toInt()}%")
-                Slider(value = fontScale, onValueChange = onFontScaleChange, valueRange = 0.8f..1.5f)
-                Text(
-                    "Captions continue tracking while the panel is hidden.",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
             }
         },
-        confirmButton = { TextButton(onClick = onDismiss) { Text("Done") } },
+        confirmButton = { TextButton(onClick = onDismiss) { Text("Back") } },
     )
 }
 
 private fun sourceDescription(state: DualSubUiState): String {
-    val source = when (state.resolvedSourceLanguage?.substringBefore('-')) {
-        "en" -> "English"
-        "ja" -> "Japanese"
-        null -> "Finding captions"
-        else -> state.resolvedSourceLanguage.orEmpty().uppercase()
-    }
+    val source = state.resolvedSourceLanguage?.let { resolved ->
+        state.availableSourceLanguages.firstOrNull {
+            TranslationLanguages.normalize(it.code) == TranslationLanguages.normalize(resolved)
+        }?.name ?: TranslationLanguages.displayName(resolved)
+    } ?: "Finding captions"
     val generated = if (state.generatedCaptions) " (auto-generated)" else ""
-    return "$source$generated  →  Vietnamese"
+    return "$source$generated  →  ${TranslationLanguages.displayName(state.targetLanguage)}"
 }

--- a/app/src/test/java/com/kienhoang/dualsubreplay/translation/TranslationLanguagesTest.kt
+++ b/app/src/test/java/com/kienhoang/dualsubreplay/translation/TranslationLanguagesTest.kt
@@ -1,0 +1,18 @@
+package com.kienhoang.dualsubreplay.translation
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TranslationLanguagesTest {
+    @Test
+    fun exposesUniqueMlKitLanguageCodes() {
+        assertTrue(TranslationLanguages.all.size > 50)
+        assertEquals(
+            TranslationLanguages.all.size,
+            TranslationLanguages.all.map { it.code }.distinct().size,
+        )
+        assertEquals("Vietnamese", TranslationLanguages.displayName("vi-VN"))
+        assertEquals("Hebrew", TranslationLanguages.displayName("iw"))
+    }
+}

--- a/app/src/test/java/com/kienhoang/dualsubreplay/ui/PlaybackArchitectureTest.kt
+++ b/app/src/test/java/com/kienhoang/dualsubreplay/ui/PlaybackArchitectureTest.kt
@@ -107,4 +107,20 @@ class PlaybackArchitectureTest {
         assertFalse(shouldPromoteActiveSubtitle(-1, listOf(4, 5, 6, 7)))
         assertFalse(shouldPromoteActiveSubtitle(7, emptyList()))
     }
+
+    @Test
+    fun subtitlePanelHidesAfterEnoughDistanceOrAFastDownwardFling() {
+        assertTrue(shouldHideSubtitlePanel(200f, 1_000f, 0f, 72f))
+        assertTrue(shouldHideSubtitlePanel(20f, 1_000f, 1_600f, 72f))
+        assertFalse(shouldHideSubtitlePanel(100f, 1_000f, 400f, 72f))
+        assertFalse(shouldHideSubtitlePanel(200f, 1_000f, -2_000f, 220f))
+    }
+
+    @Test
+    fun sourcePreferenceUsesTheChosenCaptionAndFallsBackToAuto() {
+        assertEquals(emptyList<String>(), preferredCaptionLanguages("auto"))
+        assertEquals(listOf("ja"), preferredCaptionLanguages("ja"))
+        assertEquals("ja", resolvedSourcePreference("ja", "ja-JP"))
+        assertEquals("auto", resolvedSourcePreference("ja", "en-US"))
+    }
 }


### PR DESCRIPTION
## What changed

- lists the caption languages available on the current YouTube video
- adds a searchable target-language picker for every Google ML Kit translation language
- downloads translation models only when the selected pair needs them and remembers the target language
- retranslates existing captions without reloading the single YouTube WebView
- lets users drag the subtitle panel header downward to hide it, with distance and fling thresholds
- keeps the close button and floating CC restore button as accessible alternatives
- bumps the app and preview artifact version to 0.3.1

## Why

The app was limited to English/Japanese captions translated into Vietnamese, and the visible drag handle did not respond to gestures. These changes make the subtitle layer useful for many more language pairs while preserving the existing single-WebView playback architecture.

## Validation

- added unit coverage for language metadata, caption preference fallback, and swipe-dismiss thresholds
- updated Compose UI coverage for source and target language selection
- `git diff --check` passes
- local Gradle execution was blocked because the sandbox cannot download the Gradle 9.5 distribution; GitHub Actions is the authoritative compile, lint, APK, and managed-emulator validation