### PR TITLE
Handle YouTube sign-in securely

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ Want to test the newest development build? See the [preview release](https://git
 
 Sharing a YouTube watch, Short, live, embed, or `youtu.be` URL to DualSub Replay navigates the same WebView directly to it.
 
+Google blocks account authentication inside embedded WebViews. If YouTube requests sign-in, DualSub Replay explains this security boundary and continues in the system browser or YouTube app. After choosing a video there, use **Share > DualSub Replay** to return to the dual-subtitle experience. The Google account session remains in the browser or YouTube app and is never copied into DualSub Replay.
+
 ## Important limitations
 
 YouTube's official Data API does not allow ordinary viewers to download captions from arbitrary public videos. To provide automatic captions, this prototype uses YouTube's undocumented Innertube transcript endpoint. It can stop working when YouTube changes its internal API, and its use may be restricted by YouTube's terms. The extraction code is isolated in `YouTubeCaptionProvider` so it can be replaced without rewriting the app.

--- a/app/src/androidTest/java/com/kienhoang/dualsubreplay/ui/SubtitleUiTest.kt
+++ b/app/src/androidTest/java/com/kienhoang/dualsubreplay/ui/SubtitleUiTest.kt
@@ -78,14 +78,13 @@ class SubtitleUiTest {
     }
 
     @Test
-    fun googleSignInDialogExplainsSecureHandoffAndSupportsBothActions() {
+    fun googleSignInDialogExplainsSecureHandoffAndContinues() {
         var continued = false
-        var dismissed = false
         composeRule.setContent {
             DualSubTheme {
                 GoogleSignInDialog(
                     onContinue = { continued = true },
-                    onDismiss = { dismissed = true },
+                    onDismiss = {},
                 )
             }
         }
@@ -93,11 +92,15 @@ class SubtitleUiTest {
         composeRule.onNodeWithText("Sign in securely").assertIsDisplayed()
         composeRule.onNodeWithText("Continue securely").performClick()
         composeRule.runOnIdle { assertTrue(continued) }
+    }
 
+    @Test
+    fun googleSignInDialogCanBeDismissed() {
+        var dismissed = false
         composeRule.setContent {
             DualSubTheme {
                 GoogleSignInDialog(
-                    onContinue = { continued = true },
+                    onContinue = {},
                     onDismiss = { dismissed = true },
                 )
             }

--- a/app/src/androidTest/java/com/kienhoang/dualsubreplay/ui/SubtitleUiTest.kt
+++ b/app/src/androidTest/java/com/kienhoang/dualsubreplay/ui/SubtitleUiTest.kt
@@ -78,6 +78,35 @@ class SubtitleUiTest {
     }
 
     @Test
+    fun googleSignInDialogExplainsSecureHandoffAndSupportsBothActions() {
+        var continued = false
+        var dismissed = false
+        composeRule.setContent {
+            DualSubTheme {
+                GoogleSignInDialog(
+                    onContinue = { continued = true },
+                    onDismiss = { dismissed = true },
+                )
+            }
+        }
+
+        composeRule.onNodeWithText("Sign in securely").assertIsDisplayed()
+        composeRule.onNodeWithText("Continue securely").performClick()
+        composeRule.runOnIdle { assertTrue(continued) }
+
+        composeRule.setContent {
+            DualSubTheme {
+                GoogleSignInDialog(
+                    onContinue = { continued = true },
+                    onDismiss = { dismissed = true },
+                )
+            }
+        }
+        composeRule.onNodeWithText("Not now").performClick()
+        composeRule.runOnIdle { assertTrue(dismissed) }
+    }
+
+    @Test
     fun activeSubtitleIsIdentifiedAndReplays() {
         var replayed = false
         composeRule.setContent {

--- a/app/src/main/java/com/kienhoang/dualsubreplay/ui/YouTubeBrowserScreen.kt
+++ b/app/src/main/java/com/kienhoang/dualsubreplay/ui/YouTubeBrowserScreen.kt
@@ -24,9 +24,11 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.material3.Button
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
@@ -41,6 +43,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.compose.ui.window.Dialog
@@ -64,6 +67,13 @@ private val destroyedWebViews = Collections.newSetFromMap(WeakHashMap<WebView, B
 
 internal data class BrowseVideoSelection(val videoId: String, val canonicalUrl: String)
 
+internal enum class MainFrameDestination {
+    YOUTUBE_WEB,
+    GOOGLE_SIGN_IN,
+    EXTERNAL_WEB,
+    UNSUPPORTED,
+}
+
 internal fun browseVideoSelection(url: String): BrowseVideoSelection? {
     val videoId = YouTubeUrlParser.extractVideoId(url) ?: return null
     return BrowseVideoSelection(videoId, "https://www.youtube.com/watch?v=$videoId")
@@ -74,6 +84,19 @@ internal fun isYouTubeWebUrl(url: String): Boolean {
     if (uri.scheme !in setOf("http", "https")) return false
     val host = uri.host?.lowercase() ?: return false
     return host == "youtu.be" || host == "youtube.com" || host.endsWith(".youtube.com")
+}
+
+internal fun classifyMainFrameUrl(url: String): MainFrameDestination {
+    val uri = runCatching { URI(url) }.getOrNull() ?: return MainFrameDestination.UNSUPPORTED
+    if (uri.scheme !in setOf("http", "https")) return MainFrameDestination.UNSUPPORTED
+    val host = uri.host?.lowercase() ?: return MainFrameDestination.UNSUPPORTED
+    if (host in setOf("accounts.google.com", "myaccount.google.com", "accounts.youtube.com")) {
+        return MainFrameDestination.GOOGLE_SIGN_IN
+    }
+    if (host == "youtu.be" || host == "youtube.com" || host.endsWith(".youtube.com")) {
+        return MainFrameDestination.YOUTUBE_WEB
+    }
+    return MainFrameDestination.EXTERNAL_WEB
 }
 
 internal data class WebPlaybackSnapshot(
@@ -183,6 +206,7 @@ internal fun SingleYouTubePage(
     var webViewUnavailable by remember { mutableStateOf(false) }
     var pageError by remember { mutableStateOf<String?>(null) }
     var fullscreenSession by remember { mutableStateOf<WebFullscreenSession?>(null) }
+    var pendingGoogleSignInUrl by remember { mutableStateOf<String?>(null) }
     var lastKnownUrl by remember { mutableStateOf(initialUrl) }
     var handledNavigationRequestId by remember { mutableLongStateOf(navigationRequestId) }
 
@@ -241,14 +265,26 @@ internal fun SingleYouTubePage(
 
             webViewClient = object : WebViewClient() {
                 private fun handleMainFrameUrl(view: WebView, url: String): Boolean {
-                    if (isYouTubeWebUrl(url)) {
-                        reportNavigation(view, url)
-                        return false
+                    return when (classifyMainFrameUrl(url)) {
+                        MainFrameDestination.YOUTUBE_WEB -> {
+                            reportNavigation(view, url)
+                            false
+                        }
+
+                        MainFrameDestination.GOOGLE_SIGN_IN -> {
+                            pendingGoogleSignInUrl = url
+                            true
+                        }
+
+                        MainFrameDestination.EXTERNAL_WEB -> {
+                            runCatching {
+                                context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url)))
+                            }
+                            true
+                        }
+
+                        MainFrameDestination.UNSUPPORTED -> true
                     }
-                    runCatching {
-                        context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url)))
-                    }
-                    return true
                 }
 
                 override fun shouldOverrideUrlLoading(
@@ -422,6 +458,50 @@ internal fun SingleYouTubePage(
             )
         }
     }
+
+    pendingGoogleSignInUrl?.let { signInUrl ->
+        GoogleSignInDialog(
+            onContinue = {
+                pendingGoogleSignInUrl = null
+                runCatching {
+                    context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(signInUrl)))
+                }.onFailure {
+                    pageError = "No secure browser is available for Google sign-in."
+                }
+            },
+            onDismiss = { pendingGoogleSignInUrl = null },
+        )
+    }
+}
+
+@Composable
+internal fun GoogleSignInDialog(
+    onContinue: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        modifier = Modifier.testTag("google_sign_in_dialog"),
+        onDismissRequest = onDismiss,
+        title = { Text("Sign in securely") },
+        text = {
+            Text(
+                "Google does not allow account sign-in inside embedded browsers. " +
+                    "Continue in your browser or the YouTube app, choose a video, then use " +
+                    "Share > DualSub Replay to watch it here with dual subtitles. " +
+                    "Your account will remain signed in only in the browser or YouTube app.",
+            )
+        },
+        confirmButton = {
+            TextButton(onClick = onContinue) {
+                Text("Continue securely")
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text("Not now")
+            }
+        },
+    )
 }
 
 internal fun WebView.destroySafely() {

--- a/app/src/test/java/com/kienhoang/dualsubreplay/ui/PlaybackArchitectureTest.kt
+++ b/app/src/test/java/com/kienhoang/dualsubreplay/ui/PlaybackArchitectureTest.kt
@@ -30,6 +30,34 @@ class PlaybackArchitectureTest {
     }
 
     @Test
+    fun mainFrameNavigationSeparatesGoogleSignInFromYouTubeAndExternalLinks() {
+        assertEquals(
+            MainFrameDestination.YOUTUBE_WEB,
+            classifyMainFrameUrl("https://m.youtube.com/watch?v=dQw4w9WgXcQ"),
+        )
+        assertEquals(
+            MainFrameDestination.GOOGLE_SIGN_IN,
+            classifyMainFrameUrl("https://accounts.google.com/ServiceLogin?service=youtube"),
+        )
+        assertEquals(
+            MainFrameDestination.GOOGLE_SIGN_IN,
+            classifyMainFrameUrl("https://accounts.youtube.com/accounts/SetSID"),
+        )
+        assertEquals(
+            MainFrameDestination.EXTERNAL_WEB,
+            classifyMainFrameUrl("https://example.com/help"),
+        )
+        assertEquals(
+            MainFrameDestination.UNSUPPORTED,
+            classifyMainFrameUrl("javascript:alert(1)"),
+        )
+        assertEquals(
+            MainFrameDestination.UNSUPPORTED,
+            classifyMainFrameUrl("intent://accounts.google.com/#Intent;end"),
+        )
+    }
+
+    @Test
     fun playbackSnapshotParsesWebViewJavascriptResult() {
         val raw = "\"{\\\"url\\\":\\\"https://m.youtube.com/watch?v=dQw4w9WgXcQ\\\",\\\"currentSecond\\\":12.5}\""
 


### PR DESCRIPTION
## What changed

- Detect Google account authentication separately from ordinary external links.
- Stop trying to complete Google sign-in inside the embedded YouTube WebView.
- Show a clear security explanation before opening the sign-in URL in the system browser or YouTube app.
- Guide users to select a video externally and return through **Share > DualSub Replay**.
- Keep YouTube browsing, playback, subtitle timing, and replay inside the existing single WebView.
- Document that account cookies remain outside DualSub Replay.

## Root cause

The WebView navigation handler only allowed YouTube hosts. YouTube sign-in redirects to `accounts.google.com`, so that navigation was cancelled and opened externally. Chrome/YouTube cookies cannot be transferred back into the app WebView. Google also prohibits authentication inside embedded WebViews.

## User impact

Tapping YouTube sign-in now produces an intentional, understandable, secure handoff instead of appearing broken. Users can browse personalized YouTube content in their signed-in browser or YouTube app and share a chosen video back to DualSub Replay.

## Validation

- Added unit coverage for YouTube, Google sign-in, ordinary external, and unsupported navigation targets.
- Added Compose UI coverage for the secure handoff explanation, Continue, and Not now actions.
- Existing playback/replay and WebView lifecycle tests remain unchanged.
- `git diff --check` passes locally.
- Full Gradle, lint, APK assembly, and managed-emulator execution are delegated to this PR's GitHub Actions because the local workspace lacks the Android SDK/emulator and cannot download Gradle.