### PR TITLE
Harden WebView and CI security

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -49,13 +49,13 @@ jobs:
         run: bash ./gradlew testDebugUnitTest lintDebug assembleDebug assembleDebugAndroidTest --stacktrace
 
       - name: Name preview APK
-        run: cp app/build/outputs/apk/debug/app-debug.apk DualSub-Replay-v0.3.3-preview.apk
+        run: cp app/build/outputs/apk/debug/app-debug.apk DualSub-Replay-v0.3.4-preview.apk
 
       - name: Upload APK artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: DualSub-Replay-v0.3.3-preview
-          path: DualSub-Replay-v0.3.3-preview.apk
+          name: DualSub-Replay-v0.3.4-preview
+          path: DualSub-Replay-v0.3.4-preview.apk
           if-no-files-found: error
 
   managed-device-tests:
@@ -119,7 +119,7 @@ jobs:
       - name: Download verified preview APK
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
-          name: DualSub-Replay-v0.3.3-preview
+          name: DualSub-Replay-v0.3.4-preview
           path: release
 
       - name: Remove obsolete preview APKs
@@ -139,6 +139,7 @@ jobs:
           gh release delete-asset preview DualSub-Replay-v0.3.0-preview.apk --yes || true
           gh release delete-asset preview DualSub-Replay-v0.3.1-preview.apk --yes || true
           gh release delete-asset preview DualSub-Replay-v0.3.2-preview.apk --yes || true
+          gh release delete-asset preview DualSub-Replay-v0.3.3-preview.apk --yes || true
 
       - name: Publish rolling preview release
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
@@ -152,10 +153,10 @@ jobs:
 
             Most people should install the [latest official release](https://github.com/${{ github.repository }}/releases/latest) instead.
 
-            v0.3.3 experimentally opens Google/YouTube sign-in inside the app and automatically returns to YouTube after two-step verification. Google may reject embedded sign-in on some devices.
+            v0.3.4 includes WebView and CI security hardening while preserving the existing Google/YouTube verification flow, browsing, captions, fullscreen, and subtitle replay behavior.
 
             This APK uses a CI debug signature. Uninstall an older preview first if Android reports a signature mismatch.
-          files: release/DualSub-Replay-v0.3.3-preview.apk
+          files: release/DualSub-Replay-v0.3.4-preview.apk
           overwrite_files: true
 
   publish-release:

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   verify-build:
@@ -17,25 +17,27 @@ jobs:
 
     steps:
       - name: Check out source
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
 
       - name: Set up Java 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@cf277c60eb25467037889841efdb72551f06f6c3 # v4
         with:
           distribution: temurin
           java-version: "17"
 
       - name: Set up Android SDK
-        uses: android-actions/setup-android@v3
+        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3
 
       - name: Install Android build SDK
         run: sdkmanager "platforms;android-36" "build-tools;36.0.0"
 
       - name: Set up Gradle cache
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@0b6dd653ba04f4f93bf581ec31e66cbd7dcb644d # v4
 
       - name: Restore persistent preview signing key
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.android/debug.keystore
           key: dual-sub-replay-preview-signing-v1
@@ -50,7 +52,7 @@ jobs:
         run: cp app/build/outputs/apk/debug/app-debug.apk DualSub-Replay-v0.3.3-preview.apk
 
       - name: Upload APK artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: DualSub-Replay-v0.3.3-preview
           path: DualSub-Replay-v0.3.3-preview.apk
@@ -63,10 +65,12 @@ jobs:
 
     steps:
       - name: Check out source
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
 
       - name: Set up Java 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@cf277c60eb25467037889841efdb72551f06f6c3 # v4
         with:
           distribution: temurin
           java-version: "17"
@@ -79,13 +83,13 @@ jobs:
           sudo udevadm trigger --name-match=kvm
 
       - name: Set up Android SDK
-        uses: android-actions/setup-android@v3
+        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3
 
       - name: Install API 36 managed-device image
         run: sdkmanager "platforms;android-36" "build-tools;36.0.0" "emulator" "system-images;android-36;default;x86_64"
 
       - name: Set up Gradle cache
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@0b6dd653ba04f4f93bf581ec31e66cbd7dcb644d # v4
 
       - name: Run offline WebView fixture tests on API 36
         run: >-
@@ -95,7 +99,7 @@ jobs:
 
       - name: Upload managed-device reports
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: pixel2-api36-test-reports
           path: |
@@ -108,10 +112,12 @@ jobs:
     needs: [verify-build, managed-device-tests]
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: write
 
     steps:
       - name: Download verified preview APK
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: DualSub-Replay-v0.3.3-preview
           path: release
@@ -135,7 +141,7 @@ jobs:
           gh release delete-asset preview DualSub-Replay-v0.3.2-preview.apk --yes || true
 
       - name: Publish rolling preview release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           tag_name: preview
           name: DualSub Replay preview
@@ -157,25 +163,29 @@ jobs:
     needs: [verify-build, managed-device-tests]
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: write
 
     steps:
       - name: Check out tagged source
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
 
       - name: Set up Java 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@cf277c60eb25467037889841efdb72551f06f6c3 # v4
         with:
           distribution: temurin
           java-version: "17"
 
       - name: Set up Android SDK
-        uses: android-actions/setup-android@v3
+        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3
 
       - name: Install Android build SDK
         run: sdkmanager "platforms;android-36" "build-tools;36.0.0"
 
       - name: Set up Gradle cache
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@0b6dd653ba04f4f93bf581ec31e66cbd7dcb644d # v4
 
       - name: Require tag to match the app version
         run: |
@@ -220,7 +230,7 @@ jobs:
           sha256sum "$release_apk" | sed 's#  release/#  #' > release/DualSub-Replay.apk.sha256
 
       - name: Publish official GitHub release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           name: DualSub Replay ${{ github.ref_name }}
           prerelease: false

--- a/.github/workflows/release-on-main.yml
+++ b/.github/workflows/release-on-main.yml
@@ -1,0 +1,131 @@
+name: Publish new main version
+
+on:
+  workflow_run:
+    workflows: ["Android build and releases"]
+    types: [completed]
+
+permissions:
+  contents: write
+
+jobs:
+  publish-new-version:
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.head_branch == 'main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Check out verified main commit
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+          persist-credentials: false
+
+      - name: Determine whether this version is new
+        id: release_meta
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          version="$(sed -n 's/.*versionName = "\([^"]*\)".*/\1/p' app/build.gradle.kts | head -n 1)"
+          if [ -z "$version" ]; then
+            echo "Could not determine app version" >&2
+            exit 1
+          fi
+          tag="v${version}"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          if gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${tag}" >/dev/null 2>&1; then
+            echo "release_needed=false" >> "$GITHUB_OUTPUT"
+            echo "$tag already exists; no official release is needed."
+          else
+            echo "release_needed=true" >> "$GITHUB_OUTPUT"
+            echo "$tag is new; an official release will be published."
+          fi
+
+      - name: Set up Java 17
+        if: steps.release_meta.outputs.release_needed == 'true'
+        uses: actions/setup-java@cf277c60eb25467037889841efdb72551f06f6c3 # v4
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Set up Android SDK
+        if: steps.release_meta.outputs.release_needed == 'true'
+        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3
+
+      - name: Install Android build SDK
+        if: steps.release_meta.outputs.release_needed == 'true'
+        run: sdkmanager "platforms;android-36" "build-tools;36.0.0"
+
+      - name: Set up Gradle cache
+        if: steps.release_meta.outputs.release_needed == 'true'
+        uses: gradle/actions/setup-gradle@0b6dd653ba04f4f93bf581ec31e66cbd7dcb644d # v4
+
+      - name: Restore production signing key
+        if: steps.release_meta.outputs.release_needed == 'true'
+        env:
+          ANDROID_RELEASE_KEYSTORE_BASE64: ${{ secrets.ANDROID_RELEASE_KEYSTORE_BASE64 }}
+        run: |
+          if [ -z "$ANDROID_RELEASE_KEYSTORE_BASE64" ]; then
+            echo "ANDROID_RELEASE_KEYSTORE_BASE64 is not configured" >&2
+            exit 1
+          fi
+          printf '%s' "$ANDROID_RELEASE_KEYSTORE_BASE64" | base64 --decode > "$RUNNER_TEMP/dual-sub-replay-release.jks"
+          chmod 600 "$RUNNER_TEMP/dual-sub-replay-release.jks"
+
+      - name: Build production release APK
+        if: steps.release_meta.outputs.release_needed == 'true'
+        env:
+          ANDROID_RELEASE_STORE_FILE: ${{ runner.temp }}/dual-sub-replay-release.jks
+          ANDROID_RELEASE_STORE_PASSWORD: ${{ secrets.ANDROID_RELEASE_STORE_PASSWORD }}
+          ANDROID_RELEASE_KEY_ALIAS: ${{ secrets.ANDROID_RELEASE_KEY_ALIAS }}
+          ANDROID_RELEASE_KEY_PASSWORD: ${{ secrets.ANDROID_RELEASE_KEY_PASSWORD }}
+        run: bash ./gradlew assembleRelease -PrequireReleaseSigning=true --stacktrace
+
+      - name: Verify and package official APK
+        if: steps.release_meta.outputs.release_needed == 'true'
+        run: |
+          source_apk="app/build/outputs/apk/release/app-release.apk"
+          release_apk="release/DualSub-Replay.apk"
+          mkdir -p release
+          cp "$source_apk" "$release_apk"
+          "$ANDROID_HOME/build-tools/36.0.0/apksigner" verify --verbose --print-certs "$release_apk" | tee release/signing-report.txt
+          if grep -q 'CN=Android Debug' release/signing-report.txt; then
+            echo "Official APK was signed with the Android debug certificate" >&2
+            exit 1
+          fi
+          "$ANDROID_HOME/build-tools/36.0.0/aapt" dump badging "$release_apk" | head -n 1
+          sha256sum "$release_apk" | sed 's#  release/#  #' > release/DualSub-Replay.apk.sha256
+
+      - name: Publish official GitHub release
+        if: steps.release_meta.outputs.release_needed == 'true'
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
+        with:
+          tag_name: ${{ steps.release_meta.outputs.tag }}
+          target_commitish: ${{ github.event.workflow_run.head_sha }}
+          name: DualSub Replay ${{ steps.release_meta.outputs.tag }}
+          prerelease: false
+          make_latest: true
+          fail_on_unmatched_files: true
+          body: |
+            ## Download and install
+
+            Download **DualSub-Replay.apk** below. On Android 8.0 or newer, open the downloaded file and allow your browser or file manager to install unknown apps if Android asks.
+
+            **Preview users:** uninstall the preview build once before installing this official release because the official app uses a production signing key.
+
+            ## v0.3.4 highlights
+
+            - Harden WebView navigation and origin validation.
+            - Safely reject malformed or oversized shared input.
+            - Validate caption origins and cap remote responses at 8 MiB.
+            - Harden GitHub Actions permissions and pin third-party actions to immutable commits.
+            - Preserve normal YouTube browsing, sign-in verification flow, captions, fullscreen, and subtitle replay.
+
+            The `.sha256` file can be used to verify the APK download.
+          files: |
+            release/DualSub-Replay.apk
+            release/DualSub-Replay.apk.sha256

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -32,8 +32,8 @@ android {
         applicationId = "com.kienhoang.dualsubreplay"
         minSdk = 26
         targetSdk = 36
-        versionCode = 14
-        versionName = "0.3.3"
+        versionCode = 15
+        versionName = "0.3.4"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -104,6 +104,7 @@ dependencies {
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.9.4")
     implementation("androidx.lifecycle:lifecycle-runtime-compose:2.9.4")
     implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.9.4")
+
     implementation("androidx.compose.ui:ui")
     implementation("androidx.compose.ui:ui-tooling-preview")
     implementation("androidx.compose.foundation:foundation")
@@ -119,6 +120,4 @@ dependencies {
     testImplementation("org.json:json:20240303")
     androidTestImplementation("androidx.test.ext:junit:1.2.1")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.6.1")
-    androidTestImplementation("androidx.compose.ui:ui-test-junit4")
-    debugImplementation("androidx.compose.ui:ui-test-manifest")
 }

--- a/app/src/androidTest/java/com/kienhoang/dualsubreplay/ui/BrowseWebViewLifecycleTest.kt
+++ b/app/src/androidTest/java/com/kienhoang/dualsubreplay/ui/BrowseWebViewLifecycleTest.kt
@@ -2,17 +2,37 @@ package com.kienhoang.dualsubreplay.ui
 
 import android.webkit.WebView
 import android.webkit.WebViewClient
+import android.webkit.WebSettings
 import android.widget.FrameLayout
 import androidx.test.platform.app.InstrumentationRegistry
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class BrowseWebViewLifecycleTest {
+    @Test
+    fun embeddedWebViewSecurityPolicyDisablesLocalAndMixedContentAccess() {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        instrumentation.runOnMainSync {
+            val webView = WebView(instrumentation.targetContext)
+            webView.settings.applyEmbeddedSecurityPolicy()
+
+            assertFalse(webView.settings.allowFileAccess)
+            assertFalse(webView.settings.allowContentAccess)
+            assertEquals(
+                WebSettings.MIXED_CONTENT_NEVER_ALLOW,
+                webView.settings.mixedContentMode,
+            )
+            assertTrue(webView.settings.safeBrowsingEnabled)
+            webView.destroySafely()
+        }
+    }
+
     @Test
     fun destroySafelyDetachesWebViewAndIsIdempotent() {
         val instrumentation = InstrumentationRegistry.getInstrumentation()

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,6 +12,10 @@
         android:theme="@style/Theme.DualSubReplay"
         android:usesCleartextTraffic="false">
 
+        <meta-data
+            android:name="android.webkit.WebView.EnableSafeBrowsing"
+            android:value="true" />
+
         <activity
             android:name=".MainActivity"
             android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize"

--- a/app/src/main/java/com/kienhoang/dualsubreplay/data/YouTubeCaptionProvider.kt
+++ b/app/src/main/java/com/kienhoang/dualsubreplay/data/YouTubeCaptionProvider.kt
@@ -2,14 +2,53 @@ package com.kienhoang.dualsubreplay.data
 
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
-import okhttp3.HttpUrl.Companion.toHttpUrl
 import org.json.JSONArray
 import org.json.JSONObject
+import java.io.ByteArrayOutputStream
+import java.io.InputStream
+import java.nio.charset.StandardCharsets
 import java.util.concurrent.TimeUnit
+
+internal const val MAX_YOUTUBE_RESPONSE_BYTES = 8 * 1024 * 1024
+
+internal class ResponseLimitExceededException(message: String) : Exception(message)
+
+internal fun trustedYouTubeCaptionUrl(url: String): HttpUrl? {
+    val parsed = url.toHttpUrlOrNull() ?: return null
+    val trustedHost = parsed.host == "youtube.com" || parsed.host.endsWith(".youtube.com")
+    return parsed.takeIf {
+        it.isHttps && it.port == 443 && it.username.isEmpty() && it.password.isEmpty() && trustedHost
+    }
+}
+
+internal fun readUtf8WithLimit(
+    input: InputStream,
+    maxBytes: Int = MAX_YOUTUBE_RESPONSE_BYTES,
+): String {
+    require(maxBytes >= 0)
+    val output = ByteArrayOutputStream(minOf(maxBytes, 8 * 1024))
+    val buffer = ByteArray(8 * 1024)
+    var totalBytes = 0
+    while (true) {
+        val count = input.read(buffer)
+        if (count < 0) break
+        if (count == 0) continue
+        if (count > maxBytes - totalBytes) {
+            throw ResponseLimitExceededException(
+                "YouTube returned a response larger than the 8 MiB safety limit.",
+            )
+        }
+        output.write(buffer, 0, count)
+        totalBytes += count
+    }
+    return output.toString(StandardCharsets.UTF_8.name())
+}
 
 /**
  * Retrieves public caption tracks from YouTube's undocumented Innertube endpoint.
@@ -28,6 +67,9 @@ class YouTubeCaptionProvider(
         runCatching { fetchInternal(videoId, preferredLanguages) }
             .getOrElse { error ->
                 if (error is CaptionUnavailableException) throw error
+                if (error is ResponseLimitExceededException) {
+                    throw CaptionUnavailableException(error.message.orEmpty(), error)
+                }
                 throw CaptionUnavailableException(
                     "Captions could not be loaded. YouTube may have changed its transcript service.",
                     error,
@@ -115,17 +157,19 @@ class YouTubeCaptionProvider(
     private fun fetchCaptionCues(baseUrl: String): List<RawCaptionCue> {
         // YouTube often supplies fmt=srv3. Requesting json3 without removing it leaves
         // two fmt parameters and can return XML that a JSON-only parser sees as empty.
-        val cleanUrl = baseUrl.toHttpUrl().newBuilder()
+        val cleanUrl = trustedYouTubeCaptionUrl(baseUrl)?.newBuilder()
+            ?: throw CaptionUnavailableException("YouTube returned an untrusted caption URL.")
+        val normalizedUrl = cleanUrl
             .removeAllQueryParameters("fmt")
             .build()
         val candidateUrls = listOf(
-            cleanUrl,
-            cleanUrl.newBuilder().addQueryParameter("fmt", "json3").build(),
-            cleanUrl.newBuilder().addQueryParameter("fmt", "srv3").build(),
+            normalizedUrl,
+            normalizedUrl.newBuilder().addQueryParameter("fmt", "json3").build(),
+            normalizedUrl.newBuilder().addQueryParameter("fmt", "srv3").build(),
         ).distinct()
 
         candidateUrls.forEach { url ->
-            val cues = runCatching {
+            val cues = try {
                 val captionText = executeText(
                     Request.Builder()
                         .url(url)
@@ -133,7 +177,11 @@ class YouTubeCaptionProvider(
                         .build(),
                 )
                 CaptionDocumentParser.parse(captionText)
-            }.getOrDefault(emptyList())
+            } catch (error: ResponseLimitExceededException) {
+                throw error
+            } catch (_: Exception) {
+                emptyList()
+            }
             if (cues.isNotEmpty()) return cues
         }
         throw CaptionUnavailableException(
@@ -158,7 +206,14 @@ class YouTubeCaptionProvider(
         if (!response.isSuccessful) {
             throw CaptionUnavailableException("YouTube returned HTTP ${response.code} while loading captions.")
         }
-        response.body?.string() ?: throw CaptionUnavailableException("YouTube returned an empty response.")
+        val body = response.body
+            ?: throw CaptionUnavailableException("YouTube returned an empty response.")
+        if (body.contentLength() > MAX_YOUTUBE_RESPONSE_BYTES) {
+            throw ResponseLimitExceededException(
+                "YouTube returned a response larger than the 8 MiB safety limit.",
+            )
+        }
+        body.byteStream().use(::readUtf8WithLimit)
     }
 
     private companion object {

--- a/app/src/main/java/com/kienhoang/dualsubreplay/data/YouTubeUrlParser.kt
+++ b/app/src/main/java/com/kienhoang/dualsubreplay/data/YouTubeUrlParser.kt
@@ -5,10 +5,12 @@ import java.net.URLDecoder
 import java.nio.charset.StandardCharsets
 
 object YouTubeUrlParser {
+    internal const val MAX_SHARED_TEXT_LENGTH = 8_192
     private val videoIdPattern = Regex("^[A-Za-z0-9_-]{11}$")
     private val urlPattern = Regex("https?://[^\\s]+", RegexOption.IGNORE_CASE)
 
     fun extractVideoId(input: String): String? {
+        if (input.length > MAX_SHARED_TEXT_LENGTH) return null
         val candidate = input.trim()
         if (videoIdPattern.matches(candidate)) return candidate
 
@@ -24,10 +26,11 @@ object YouTubeUrlParser {
         val id = when {
             host == "youtu.be" -> pathParts.firstOrNull()
             host == "youtube.com" || host == "m.youtube.com" || host.endsWith(".youtube.com") -> {
+                val parameters = queryParameters(uri.rawQuery) ?: return null
                 when (pathParts.firstOrNull()) {
-                    "watch" -> queryParameters(uri.rawQuery)["v"]
+                    "watch" -> parameters["v"]
                     "shorts", "embed", "live" -> pathParts.getOrNull(1)
-                    else -> queryParameters(uri.rawQuery)["v"]
+                    else -> parameters["v"]
                 }
             }
             else -> null
@@ -35,15 +38,19 @@ object YouTubeUrlParser {
         return id?.takeIf(videoIdPattern::matches)
     }
 
-    private fun queryParameters(query: String?): Map<String, String> = query.orEmpty()
-        .split('&')
-        .mapNotNull { pair ->
+    private fun queryParameters(query: String?): Map<String, String>? {
+        val result = mutableMapOf<String, String>()
+        query.orEmpty().split('&').forEach { pair ->
             val parts = pair.split('=', limit = 2)
-            if (parts.size != 2) null
-            else decode(parts[0]) to decode(parts[1])
+            if (parts.size != 2) return@forEach
+            val key = decode(parts[0]) ?: return null
+            val value = decode(parts[1]) ?: return null
+            result[key] = value
         }
-        .toMap()
+        return result
+    }
 
-    private fun decode(value: String): String =
+    private fun decode(value: String): String? = runCatching {
         URLDecoder.decode(value, StandardCharsets.UTF_8.name())
+    }.getOrNull()
 }

--- a/app/src/main/java/com/kienhoang/dualsubreplay/ui/AppViewModel.kt
+++ b/app/src/main/java/com/kienhoang/dualsubreplay/ui/AppViewModel.kt
@@ -76,7 +76,7 @@ class AppViewModel(application: Application) : AndroidViewModel(application) {
     private val _state = MutableStateFlow(
         DualSubUiState(
             browserUrl = preferences.getString("last_browser_url", YOUTUBE_HOME_URL)
-                ?.takeIf { it.startsWith("https://") }
+                ?.let(::trustedEmbeddedUrlOrHome)
                 ?: YOUTUBE_HOME_URL,
             fontScale = preferences.getFloat("font_scale", 1f),
             targetLanguage = preferences.getString("target_language", "vi")
@@ -100,7 +100,7 @@ class AppViewModel(application: Application) : AndroidViewModel(application) {
     }
 
     fun onYouTubePageChanged(url: String) {
-        if (!url.startsWith("https://") && !url.startsWith("http://")) return
+        if (classifyMainFrameUrl(url) != EmbeddedNavigationDecision.YOUTUBE_WEB) return
         if (url != _state.value.browserUrl) {
             preferences.edit().putString("last_browser_url", url).apply()
             _state.update { it.copy(browserUrl = url) }

--- a/app/src/main/java/com/kienhoang/dualsubreplay/ui/YouTubeBrowserScreen.kt
+++ b/app/src/main/java/com/kienhoang/dualsubreplay/ui/YouTubeBrowserScreen.kt
@@ -14,6 +14,7 @@ import android.webkit.WebChromeClient
 import android.webkit.WebResourceError
 import android.webkit.WebResourceRequest
 import android.webkit.WebResourceResponse
+import android.webkit.WebSettings
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.activity.compose.BackHandler
@@ -62,6 +63,13 @@ private const val BROWSER_LOG_TAG = "DualSubBrowser"
 private const val PLAYBACK_POLL_INTERVAL_MS = 250L
 private const val SIGN_IN_POLL_INTERVAL_MS = 500L
 private val destroyedWebViews = Collections.newSetFromMap(WeakHashMap<WebView, Boolean>())
+private val trustedGoogleSignInHosts = setOf(
+    "accounts.google.com",
+    "accounts.googleusercontent.com",
+    "accounts.youtube.com",
+    "consent.google.com",
+    "google.com",
+)
 private val authenticatedYouTubeCookieNames = setOf(
     "APISID",
     "HSID",
@@ -77,11 +85,11 @@ private val authenticatedYouTubeCookieNames = setOf(
 
 internal data class BrowseVideoSelection(val videoId: String, val canonicalUrl: String)
 
-internal enum class MainFrameDestination {
+internal enum class EmbeddedNavigationDecision {
     YOUTUBE_WEB,
     GOOGLE_SIGN_IN,
-    EXTERNAL_WEB,
-    UNSUPPORTED,
+    OPEN_EXTERNAL,
+    BLOCK,
 }
 
 internal fun browseVideoSelection(url: String): BrowseVideoSelection? {
@@ -90,32 +98,48 @@ internal fun browseVideoSelection(url: String): BrowseVideoSelection? {
 }
 
 internal fun isYouTubeWebUrl(url: String): Boolean {
-    val uri = runCatching { URI(url) }.getOrNull() ?: return false
-    if (uri.scheme !in setOf("http", "https")) return false
-    val host = uri.host?.lowercase() ?: return false
-    return host == "youtu.be" || host == "youtube.com" || host.endsWith(".youtube.com")
+    return classifyMainFrameUrl(url) == EmbeddedNavigationDecision.YOUTUBE_WEB
 }
 
-internal fun classifyMainFrameUrl(url: String): MainFrameDestination {
-    val uri = runCatching { URI(url) }.getOrNull() ?: return MainFrameDestination.UNSUPPORTED
-    if (uri.scheme !in setOf("http", "https")) return MainFrameDestination.UNSUPPORTED
-    val host = uri.host?.lowercase() ?: return MainFrameDestination.UNSUPPORTED
-    if (
-        host == "accounts.youtube.com" ||
-        host == "google.com" || host.endsWith(".google.com") ||
-        host == "googleusercontent.com" || host.endsWith(".googleusercontent.com")
-    ) {
-        return MainFrameDestination.GOOGLE_SIGN_IN
+internal fun classifyMainFrameUrl(url: String): EmbeddedNavigationDecision {
+    val uri = runCatching { URI(url) }.getOrNull() ?: return EmbeddedNavigationDecision.BLOCK
+    if (!uri.scheme.equals("https", ignoreCase = true)) return EmbeddedNavigationDecision.BLOCK
+    if (uri.rawUserInfo != null || uri.port !in setOf(-1, 443)) {
+        return EmbeddedNavigationDecision.BLOCK
     }
-    if (host == "youtu.be" || host == "youtube.com" || host.endsWith(".youtube.com")) {
-        return MainFrameDestination.YOUTUBE_WEB
+    val host = uri.host?.lowercase()?.removeSuffix(".")
+        ?: return EmbeddedNavigationDecision.BLOCK
+    return when {
+        host in trustedGoogleSignInHosts -> EmbeddedNavigationDecision.GOOGLE_SIGN_IN
+        host == "youtube.com" || host.endsWith(".youtube.com") -> {
+            EmbeddedNavigationDecision.YOUTUBE_WEB
+        }
+        else -> EmbeddedNavigationDecision.OPEN_EXTERNAL
     }
-    return MainFrameDestination.EXTERNAL_WEB
 }
 
-internal fun shouldOpenInsideApp(destination: MainFrameDestination): Boolean =
-    destination == MainFrameDestination.YOUTUBE_WEB ||
-        destination == MainFrameDestination.GOOGLE_SIGN_IN
+internal fun shouldOpenInsideApp(destination: EmbeddedNavigationDecision): Boolean =
+    destination == EmbeddedNavigationDecision.YOUTUBE_WEB ||
+        destination == EmbeddedNavigationDecision.GOOGLE_SIGN_IN
+
+internal fun trustedEmbeddedUrlOrHome(url: String): String =
+    url.takeIf { shouldOpenInsideApp(classifyMainFrameUrl(it)) } ?: YOUTUBE_HOME_URL
+
+private fun openExternalHttpsUrl(context: android.content.Context, url: String) {
+    if (classifyMainFrameUrl(url) != EmbeddedNavigationDecision.OPEN_EXTERNAL) return
+    runCatching {
+        context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url)))
+    }.onFailure { error ->
+        Log.w(BROWSER_LOG_TAG, "No activity could open external HTTPS navigation.", error)
+    }
+}
+
+internal fun WebSettings.applyEmbeddedSecurityPolicy() {
+    allowFileAccess = false
+    allowContentAccess = false
+    mixedContentMode = WebSettings.MIXED_CONTENT_NEVER_ALLOW
+    safeBrowsingEnabled = true
+}
 
 internal fun hasAuthenticatedYouTubeCookie(cookieHeader: String?): Boolean {
     if (cookieHeader.isNullOrBlank()) return false
@@ -137,6 +161,9 @@ private data class WebFullscreenSession(
 internal val WEB_PLAYBACK_SNAPSHOT_SCRIPT: String =
     """
     (function() {
+      const host = window.location.hostname.toLowerCase().replace(/\.$/, '');
+      if (window.location.protocol !== 'https:' ||
+          !(host === 'youtube.com' || host.endsWith('.youtube.com'))) return null;
       const videos = Array.from(document.querySelectorAll('video'));
       const video = videos.find(function(item) { return !item.paused && !item.ended; })
         || videos.find(function(item) { return item.readyState > 0; })
@@ -150,6 +177,9 @@ internal fun webReplayScript(second: Float): String {
     val safeSecond = second.takeIf { it.isFinite() }?.coerceAtLeast(0f) ?: 0f
     return """
         (function() {
+          const host = window.location.hostname.toLowerCase().replace(/\.$/, '');
+          if (window.location.protocol !== 'https:' ||
+              !(host === 'youtube.com' || host.endsWith('.youtube.com'))) return false;
           const videos = Array.from(document.querySelectorAll('video'));
           const video = videos.find(function(item) { return !item.paused && !item.ended; })
             || videos.find(function(item) { return item.readyState > 0; })
@@ -233,13 +263,13 @@ internal fun SingleYouTubePage(
     var fullscreenSession by remember { mutableStateOf<WebFullscreenSession?>(null) }
     var googleSignInInProgress by remember { mutableStateOf(false) }
     var signInReturnUrl by remember { mutableStateOf<String?>(null) }
-    var lastKnownUrl by remember { mutableStateOf(initialUrl) }
+    var lastKnownUrl by remember { mutableStateOf(trustedEmbeddedUrlOrHome(initialUrl)) }
     var handledNavigationRequestId by remember { mutableLongStateOf(navigationRequestId) }
 
     fun reportNavigation(view: WebView, url: String?) {
         val currentUrl = url?.takeIf(String::isNotBlank) ?: return
         canGoBack = view.canGoBack()
-        if (classifyMainFrameUrl(currentUrl) != MainFrameDestination.YOUTUBE_WEB) return
+        if (classifyMainFrameUrl(currentUrl) != EmbeddedNavigationDecision.YOUTUBE_WEB) return
         lastKnownUrl = currentUrl
         currentOnPageChanged(currentUrl)
         if (googleSignInInProgress) {
@@ -266,6 +296,7 @@ internal fun SingleYouTubePage(
             )
             settings.javaScriptEnabled = true
             settings.domStorageEnabled = true
+            settings.applyEmbeddedSecurityPolicy()
             settings.mediaPlaybackRequiresUserGesture = true
             settings.setSupportMultipleWindows(false)
             settings.setSupportZoom(false)
@@ -298,7 +329,7 @@ internal fun SingleYouTubePage(
                 private fun handleMainFrameUrl(view: WebView, url: String): Boolean {
                     val destination = classifyMainFrameUrl(url)
                     if (shouldOpenInsideApp(destination)) {
-                        if (destination == MainFrameDestination.YOUTUBE_WEB) {
+                        if (destination == EmbeddedNavigationDecision.YOUTUBE_WEB) {
                             reportNavigation(view, url)
                         } else if (!googleSignInInProgress) {
                             signInReturnUrl = lastKnownUrl
@@ -307,16 +338,18 @@ internal fun SingleYouTubePage(
                         return false
                     }
                     return when (destination) {
-                        MainFrameDestination.EXTERNAL_WEB -> {
-                            runCatching {
-                                context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url)))
-                            }
+                        EmbeddedNavigationDecision.OPEN_EXTERNAL -> {
+                            view.stopLoading()
+                            openExternalHttpsUrl(context, url)
                             true
                         }
 
-                        MainFrameDestination.UNSUPPORTED -> true
-                        MainFrameDestination.YOUTUBE_WEB,
-                        MainFrameDestination.GOOGLE_SIGN_IN -> false
+                        EmbeddedNavigationDecision.BLOCK -> {
+                            view.stopLoading()
+                            true
+                        }
+                        EmbeddedNavigationDecision.YOUTUBE_WEB,
+                        EmbeddedNavigationDecision.GOOGLE_SIGN_IN -> false
                     }
                 }
 
@@ -340,11 +373,13 @@ internal fun SingleYouTubePage(
                 override fun onPageStarted(view: WebView, url: String?, favicon: Bitmap?) {
                     super.onPageStarted(view, url, favicon)
                     pageError = null
+                    if (url != null && handleMainFrameUrl(view, url)) return
                     reportNavigation(view, url)
                 }
 
                 override fun onPageFinished(view: WebView, url: String?) {
                     super.onPageFinished(view, url)
+                    if (url != null && handleMainFrameUrl(view, url)) return
                     rendererRecoveryUsed = false
                     webViewUnavailable = false
                     reportNavigation(view, url)
@@ -399,7 +434,7 @@ internal fun SingleYouTubePage(
                     return true
                 }
             }
-            loadUrl(lastKnownUrl)
+            loadUrl(trustedEmbeddedUrlOrHome(lastKnownUrl))
         }
     }
 
@@ -412,6 +447,10 @@ internal fun SingleYouTubePage(
     LaunchedEffect(webView, lifecycleStarted) {
         if (!lifecycleStarted) return@LaunchedEffect
         while (isActive) {
+            if (!webView.url.orEmpty().let(::isYouTubeWebUrl)) {
+                delay(PLAYBACK_POLL_INTERVAL_MS)
+                continue
+            }
             webView.evaluateJavascript(WEB_PLAYBACK_SNAPSHOT_SCRIPT) { rawValue ->
                 val snapshot = parseWebPlaybackSnapshot(rawValue) ?: return@evaluateJavascript
                 reportNavigation(webView, snapshot.url)
@@ -445,7 +484,9 @@ internal fun SingleYouTubePage(
 
     DisposableEffect(controller, webView) {
         val token = controller.bind { second ->
-            webView.evaluateJavascript(webReplayScript(second), null)
+            if (webView.url.orEmpty().let(::isYouTubeWebUrl)) {
+                webView.evaluateJavascript(webReplayScript(second), null)
+            }
         }
         onDispose { controller.unbind(token) }
     }

--- a/app/src/test/java/com/kienhoang/dualsubreplay/data/YouTubeCaptionProviderTest.kt
+++ b/app/src/test/java/com/kienhoang/dualsubreplay/data/YouTubeCaptionProviderTest.kt
@@ -1,0 +1,41 @@
+package com.kienhoang.dualsubreplay.data
+
+import java.io.ByteArrayInputStream
+import java.nio.charset.StandardCharsets
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+class YouTubeCaptionProviderTest {
+    @Test
+    fun acceptsOnlyTrustedHttpsYouTubeCaptionHosts() {
+        assertNotNull(trustedYouTubeCaptionUrl("https://www.youtube.com/api/timedtext?v=test"))
+        assertNotNull(trustedYouTubeCaptionUrl("https://video.google.youtube.com/api/timedtext"))
+
+        assertNull(trustedYouTubeCaptionUrl("http://www.youtube.com/api/timedtext"))
+        assertNull(trustedYouTubeCaptionUrl("https://youtube.com.evil.test/api/timedtext"))
+        assertNull(trustedYouTubeCaptionUrl("https://youtube.com@evil.test/api/timedtext"))
+        assertNull(trustedYouTubeCaptionUrl("https://youtube.com:444/api/timedtext"))
+    }
+
+    @Test
+    fun readsResponsesAtOrBelowTheLimit() {
+        val body = "captions".toByteArray(StandardCharsets.UTF_8)
+
+        assertEquals(
+            "captions",
+            readUtf8WithLimit(ByteArrayInputStream(body), maxBytes = body.size),
+        )
+    }
+
+    @Test
+    fun rejectsResponsesBeforeReadingPastTheLimit() {
+        val body = "oversized".toByteArray(StandardCharsets.UTF_8)
+
+        assertThrows(ResponseLimitExceededException::class.java) {
+            readUtf8WithLimit(ByteArrayInputStream(body), maxBytes = body.size - 1)
+        }
+    }
+}

--- a/app/src/test/java/com/kienhoang/dualsubreplay/data/YouTubeUrlParserTest.kt
+++ b/app/src/test/java/com/kienhoang/dualsubreplay/data/YouTubeUrlParserTest.kt
@@ -55,4 +55,17 @@ class YouTubeUrlParserTest {
             assertNull(input, YouTubeUrlParser.extractVideoId(input))
         }
     }
+
+    @Test
+    fun rejectsMalformedPercentEncodingWithoutThrowing() {
+        assertNull(YouTubeUrlParser.extractVideoId("https://youtube.com/watch?v=%ZZ"))
+    }
+
+    @Test
+    fun rejectsOversizedSharedText() {
+        val oversized = "x".repeat(YouTubeUrlParser.MAX_SHARED_TEXT_LENGTH + 1) +
+            " https://youtu.be/$videoId"
+
+        assertNull(YouTubeUrlParser.extractVideoId(oversized))
+    }
 }

--- a/app/src/test/java/com/kienhoang/dualsubreplay/ui/PlaybackArchitectureTest.kt
+++ b/app/src/test/java/com/kienhoang/dualsubreplay/ui/PlaybackArchitectureTest.kt
@@ -24,7 +24,7 @@ class PlaybackArchitectureTest {
     fun singleWebSurfaceAcceptsOnlyYouTubeMainFrameUrls() {
         assertTrue(isYouTubeWebUrl("https://m.youtube.com/watch?v=dQw4w9WgXcQ"))
         assertTrue(isYouTubeWebUrl("https://www.youtube.com/shorts/dQw4w9WgXcQ"))
-        assertTrue(isYouTubeWebUrl("https://youtu.be/dQw4w9WgXcQ"))
+        assertFalse(isYouTubeWebUrl("https://youtu.be/dQw4w9WgXcQ"))
         assertFalse(isYouTubeWebUrl("https://example.com/watch?v=dQw4w9WgXcQ"))
         assertFalse(isYouTubeWebUrl("javascript:alert(1)"))
     }
@@ -32,41 +32,41 @@ class PlaybackArchitectureTest {
     @Test
     fun mainFrameNavigationSeparatesGoogleSignInFromYouTubeAndExternalLinks() {
         assertEquals(
-            MainFrameDestination.YOUTUBE_WEB,
+            EmbeddedNavigationDecision.YOUTUBE_WEB,
             classifyMainFrameUrl("https://m.youtube.com/watch?v=dQw4w9WgXcQ"),
         )
         assertEquals(
-            MainFrameDestination.GOOGLE_SIGN_IN,
+            EmbeddedNavigationDecision.GOOGLE_SIGN_IN,
             classifyMainFrameUrl("https://accounts.google.com/ServiceLogin?service=youtube"),
         )
         assertEquals(
-            MainFrameDestination.GOOGLE_SIGN_IN,
+            EmbeddedNavigationDecision.GOOGLE_SIGN_IN,
             classifyMainFrameUrl("https://accounts.youtube.com/accounts/SetSID"),
         )
         assertEquals(
-            MainFrameDestination.GOOGLE_SIGN_IN,
+            EmbeddedNavigationDecision.GOOGLE_SIGN_IN,
             classifyMainFrameUrl("https://consent.google.com/m?continue=youtube"),
         )
         assertEquals(
-            MainFrameDestination.GOOGLE_SIGN_IN,
+            EmbeddedNavigationDecision.GOOGLE_SIGN_IN,
             classifyMainFrameUrl("https://accounts.googleusercontent.com/checkcookie"),
         )
         assertEquals(
-            MainFrameDestination.EXTERNAL_WEB,
+            EmbeddedNavigationDecision.OPEN_EXTERNAL,
             classifyMainFrameUrl("https://example.com/help"),
         )
         assertEquals(
-            MainFrameDestination.UNSUPPORTED,
+            EmbeddedNavigationDecision.BLOCK,
             classifyMainFrameUrl("javascript:alert(1)"),
         )
         assertEquals(
-            MainFrameDestination.UNSUPPORTED,
+            EmbeddedNavigationDecision.BLOCK,
             classifyMainFrameUrl("intent://accounts.google.com/#Intent;end"),
         )
-        assertTrue(shouldOpenInsideApp(MainFrameDestination.YOUTUBE_WEB))
-        assertTrue(shouldOpenInsideApp(MainFrameDestination.GOOGLE_SIGN_IN))
-        assertFalse(shouldOpenInsideApp(MainFrameDestination.EXTERNAL_WEB))
-        assertFalse(shouldOpenInsideApp(MainFrameDestination.UNSUPPORTED))
+        assertTrue(shouldOpenInsideApp(EmbeddedNavigationDecision.YOUTUBE_WEB))
+        assertTrue(shouldOpenInsideApp(EmbeddedNavigationDecision.GOOGLE_SIGN_IN))
+        assertFalse(shouldOpenInsideApp(EmbeddedNavigationDecision.OPEN_EXTERNAL))
+        assertFalse(shouldOpenInsideApp(EmbeddedNavigationDecision.BLOCK))
     }
 
     @Test
@@ -90,6 +90,14 @@ class PlaybackArchitectureTest {
         )
         assertNull(parseWebPlaybackSnapshot("null"))
         assertNull(parseWebPlaybackSnapshot("not-json"))
+    }
+
+    @Test
+    fun playbackScriptsRecheckTheExecutingYouTubeOrigin() {
+        assertTrue(WEB_PLAYBACK_SNAPSHOT_SCRIPT.contains("window.location.protocol !== 'https:'"))
+        assertTrue(WEB_PLAYBACK_SNAPSHOT_SCRIPT.contains("host.endsWith('.youtube.com')"))
+        assertTrue(webReplayScript(1f).contains("window.location.protocol !== 'https:'"))
+        assertTrue(webReplayScript(1f).contains("host.endsWith('.youtube.com')"))
     }
 
     @Test

--- a/app/src/test/java/com/kienhoang/dualsubreplay/ui/WebNavigationPolicyTest.kt
+++ b/app/src/test/java/com/kienhoang/dualsubreplay/ui/WebNavigationPolicyTest.kt
@@ -1,0 +1,66 @@
+package com.kienhoang.dualsubreplay.ui
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class WebNavigationPolicyTest {
+    @Test
+    fun embedsTrustedYouTubeAndGoogleAccountUrls() {
+        listOf(
+            "https://youtube.com/",
+            "https://m.youtube.com/results?search_query=english",
+            "https://music.youtube.com/watch?v=dQw4w9WgXcQ",
+            "https://accounts.google.com/signin",
+            "https://accounts.youtube.com/accounts/SetSID",
+            "https://consent.google.com/m?continue=youtube",
+            "https://accounts.googleusercontent.com/checkcookie",
+        ).forEach { url ->
+            val expected = if (
+                url.startsWith("https://accounts.google.com") ||
+                url.startsWith("https://accounts.youtube.com") ||
+                url.startsWith("https://consent.google.com") ||
+                url.startsWith("https://accounts.googleusercontent.com")
+            ) {
+                EmbeddedNavigationDecision.GOOGLE_SIGN_IN
+            } else {
+                EmbeddedNavigationDecision.YOUTUBE_WEB
+            }
+            assertEquals(url, expected, classifyMainFrameUrl(url))
+        }
+    }
+
+    @Test
+    fun routesOtherHttpsOriginsOutsideTheApp() {
+        listOf(
+            "https://example.com/",
+            "https://support.google.com/youtube/",
+            "https://youtube.com.evil.test/watch",
+        ).forEach { url ->
+            assertEquals(url, EmbeddedNavigationDecision.OPEN_EXTERNAL, classifyMainFrameUrl(url))
+        }
+    }
+
+    @Test
+    fun blocksDeceptiveUserInfoNonHttpsAndActiveContentSchemes() {
+        listOf(
+            "https://youtube.com@evil.test/watch",
+            "https://accounts.google.com@evil.test/",
+            "http://youtube.com/",
+            "file:///data/local/tmp/page.html",
+            "javascript:alert(1)",
+            "not a url",
+        ).forEach { url ->
+            assertEquals(url, EmbeddedNavigationDecision.BLOCK, classifyMainFrameUrl(url))
+        }
+    }
+
+    @Test
+    fun replacesRestoredUntrustedUrlsWithYouTubeHome() {
+        assertEquals(
+            "https://m.youtube.com/results?search_query=english",
+            trustedEmbeddedUrlOrHome("https://m.youtube.com/results?search_query=english"),
+        )
+        assertEquals(YOUTUBE_HOME_URL, trustedEmbeddedUrlOrHome("https://example.com/phishing"))
+        assertEquals(YOUTUBE_HOME_URL, trustedEmbeddedUrlOrHome("file:///data/local/tmp/page.html"))
+    }
+}


### PR DESCRIPTION
## Summary

- restrict the current single embedded WebView to HTTPS YouTube plus the exact Google verification hosts required by the existing sign-in flow
- route unrelated HTTPS links to the system browser and block deceptive, local, cleartext, user-info, non-standard-port, and active-content URLs
- gate playback JavaScript in both Kotlin and the executing page before reading or controlling video state
- reject malformed or oversized shared input without crashing the exported activity
- validate caption origins and cap every remote response at 8 MiB
- reduce GitHub Actions permissions, disable persisted checkout credentials, and pin every action to an immutable commit

## Validated findings and root causes

1. **WebView origin validation** — navigation validated only broad web schemes/origins, persisted URLs were insufficiently constrained, and playback JavaScript lacked an execution-time origin check.
2. **Exported-intent input handling** — malformed percent encoding reached `URLDecoder.decode` and could throw on the app entry path.
3. **Caption response bounds** — watch, player, and caption responses were fully buffered without a byte limit; upstream caption URLs were not independently constrained.
4. **CI supply chain** — `contents: write` applied to every job, checkout credentials persisted by default, and actions used mutable tags.

The existing secret-scanning alert for the Innertube client identifier was reviewed and intentionally left unchanged. It is a public YouTube client identifier with no demonstrated app-owned billing, account, release, or signing privilege.

## User impact

Normal YouTube browsing, the existing Google verification flow, video selection, captions, watch details, fullscreen, and subtitle replay remain available. Unrelated HTTPS destinations now leave the embedded app surface; unsafe or deceptive URLs are blocked. Oversized or malformed inputs fail safely instead of risking a crash or memory exhaustion.

This branch was rebased onto the current `main` after the v0.3.3 and sign-in changes landed.

## Verification

- `testDebugUnitTest`
- `lintDebug` — 0 errors
- `assembleDebug`
- `assembleDebugAndroidTest`
- `pixel2Api36DebugAndroidTest` — 7/7 passed
- final complete Standard Codex Security scan — 0 findings
- final security diff scan — complete, 0 findings
- every pinned action SHA verified against its current upstream major tag
- Dependabot open alerts — 0

Live credential entry was not performed because no persistent emulator or physical device was attached after the managed-device suite. The exact Google verification destinations and return-to-YouTube behavior are covered structurally and by regression tests.