### PR TITLE
Fix v0.3.4 release build

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Want to test the newest development build? See the [preview release](https://git
 
 Sharing a YouTube watch, Short, live, embed, or `youtu.be` URL to DualSub Replay navigates the same WebView directly to it.
 
-The v0.3.3 preview experimentally keeps the Google/YouTube sign-in flow inside the same WebView, persists its WebView cookies, and automatically returns to the previous YouTube page after two-step verification completes. Google officially does not support account authentication in embedded WebViews, so Google may still reject the login with a “browser or app may not be secure” message. No user-agent spoofing or cookie copying is used.
+Starting with v0.3.3, the app experimentally keeps the Google/YouTube sign-in flow inside the same WebView, persists its WebView cookies, and automatically returns to the previous YouTube page after two-step verification completes. Google officially does not support account authentication in embedded WebViews, so Google may still reject the login with a “browser or app may not be secure” message. No user-agent spoofing or cookie copying is used.
 
 ## Important limitations
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -120,4 +120,6 @@ dependencies {
     testImplementation("org.json:json:20240303")
     androidTestImplementation("androidx.test.ext:junit:1.2.1")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.6.1")
+    androidTestImplementation("androidx.compose.ui:ui-test-junit4")
+    debugImplementation("androidx.compose.ui:ui-test-manifest")
 }


### PR DESCRIPTION
## What changed

- restore the Compose UI-test dependencies removed during v0.3.4 preparation
- update the README so the embedded sign-in wording applies to current official releases

## Root cause and impact

The v0.3.4 version-bump commit accidentally removed `ui-test-junit4` and `ui-test-manifest`. As a result, `SubtitleUiTest.kt` could not compile in CI, blocking the verified preview and official release workflows. Runtime application behavior is unchanged.

## Validation

- `testDebugUnitTest lintDebug assembleDebug assembleDebugAndroidTest`
- `pixel2Api36DebugAndroidTest` — 7/7 passed
- production `assembleRelease -PrequireReleaseSigning=true`
- APK reports version 0.3.4/code 15 and is not Android Debug signed
- production certificate matches official v0.3.3
- v0.3.3 upgraded in place to v0.3.4 on API 36
- cold launch completed with `MainActivity` resumed, live process, and empty crash buffer