### PR TITLE
Bump version to 0.4.0 for official release

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -49,13 +49,13 @@ jobs:
         run: bash ./gradlew testDebugUnitTest lintDebug assembleDebug assembleDebugAndroidTest --stacktrace
 
       - name: Name preview APK
-        run: cp app/build/outputs/apk/debug/app-debug.apk DualSub-Replay-v0.3.4-preview.apk
+        run: cp app/build/outputs/apk/debug/app-debug.apk DualSub-Replay-v0.4.0-preview.apk
 
       - name: Upload APK artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: DualSub-Replay-v0.3.4-preview
-          path: DualSub-Replay-v0.3.4-preview.apk
+          name: DualSub-Replay-v0.4.0-preview
+          path: DualSub-Replay-v0.4.0-preview.apk
           if-no-files-found: error
 
   managed-device-tests:
@@ -119,7 +119,7 @@ jobs:
       - name: Download verified preview APK
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
-          name: DualSub-Replay-v0.3.4-preview
+          name: DualSub-Replay-v0.4.0-preview
           path: release
 
       - name: Remove obsolete preview APKs
@@ -140,6 +140,7 @@ jobs:
           gh release delete-asset preview DualSub-Replay-v0.3.1-preview.apk --yes || true
           gh release delete-asset preview DualSub-Replay-v0.3.2-preview.apk --yes || true
           gh release delete-asset preview DualSub-Replay-v0.3.3-preview.apk --yes || true
+          gh release delete-asset preview DualSub-Replay-v0.3.4-preview.apk --yes || true
 
       - name: Publish rolling preview release
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
@@ -153,10 +154,10 @@ jobs:
 
             Most people should install the [latest official release](https://github.com/${{ github.repository }}/releases/latest) instead.
 
-            v0.3.4 includes WebView and CI security hardening while preserving the existing Google/YouTube verification flow, browsing, captions, fullscreen, and subtitle replay behavior.
+            v0.4.0 includes position-aware translation batching and a subtitle timeline that follows playback seeks while preserving the existing Google/YouTube verification flow, browsing, captions, fullscreen, and subtitle replay behavior.
 
             This APK uses a CI debug signature. Uninstall an older preview first if Android reports a signature mismatch.
-          files: release/DualSub-Replay-v0.3.4-preview.apk
+          files: release/DualSub-Replay-v0.4.0-preview.apk
           overwrite_files: true
 
   publish-release:

--- a/.github/workflows/release-on-main.yml
+++ b/.github/workflows/release-on-main.yml
@@ -117,13 +117,11 @@ jobs:
 
             **Preview users:** uninstall the preview build once before installing this official release because the official app uses a production signing key.
 
-            ## v0.3.4 highlights
+            ## v0.4.0 highlights
 
-            - Harden WebView navigation and origin validation.
-            - Safely reject malformed or oversized shared input.
-            - Validate caption origins and cap remote responses at 8 MiB.
-            - Harden GitHub Actions permissions and pin third-party actions to immutable commits.
-            - Preserve normal YouTube browsing, sign-in verification flow, captions, fullscreen, and subtitle replay.
+            - Translate subtitles in batches nearest to the current playback position so translations appear where you are watching first.
+            - Subtitle timeline now follows playback jumps immediately, with instant scrolling for large seeks.
+            - Auto-scroll defers to manual scrolling and animates smoothly for nearby paragraphs.
 
             The `.sha256` file can be used to verify the APK download.
           files: |

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -32,8 +32,8 @@ android {
         applicationId = "com.kienhoang.dualsubreplay"
         minSdk = 26
         targetSdk = 36
-        versionCode = 15
-        versionName = "0.3.4"
+        versionCode = 16
+        versionName = "0.4.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }


### PR DESCRIPTION
## Summary

- Bump \ersionCode\ 15 → 16 and \ersionName\ 0.3.4 → 0.4.0 in \pp/build.gradle.kts\
- Update all hardcoded \0.3.4-preview\ strings in \.github/workflows/android.yml\ (copy step, artifact upload/download, preview asset) to \0.4.0-preview\
- Add \DualSub-Replay-v0.3.4-preview.apk\ to the obsolete preview asset cleanup list
- Refresh release body highlights in both workflows for v0.4.0 (position-aware translation batching, seek-following subtitle timeline)

## Verification

- Local: \	estDebugUnitTest assembleDebug\ — BUILD SUCCESSFUL

Merging this triggers the standard automation: rolling preview refresh + official production-signed **DualSub Replay v0.4.0** release (tag \0.4.0\ does not exist yet).