### PR TITLE
Add first-launch language setup screen

### DIFF
--- a/app/src/androidTest/java/com/kienhoang/dualsubreplay/ui/LanguageSetupScreenTest.kt
+++ b/app/src/androidTest/java/com/kienhoang/dualsubreplay/ui/LanguageSetupScreenTest.kt
@@ -1,0 +1,87 @@
+package com.kienhoang.dualsubreplay.ui
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
+import com.kienhoang.dualsubreplay.ui.theme.DualSubTheme
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+class LanguageSetupScreenTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun continueRequiresBothLanguagesAndReportsChoices() {
+        var completed: Pair<String, String>? = null
+        composeRule.setContent {
+            DualSubTheme {
+                LanguageSetupScreen(
+                    onComplete = { native, learning -> completed = native to learning },
+                    onSkip = {},
+                )
+            }
+        }
+
+        composeRule.onNodeWithTag("language_setup_screen").assertIsDisplayed()
+        composeRule.onNodeWithTag("onboarding_continue").assertIsNotEnabled()
+
+        composeRule.onNodeWithTag("native_language_picker").performClick()
+        composeRule.onNodeWithText("Your native language").assertIsDisplayed()
+        composeRule.onNodeWithTag("language_option_native_vi").performClick()
+        composeRule.onNodeWithText("Vietnamese").assertIsDisplayed()
+        composeRule.onNodeWithTag("onboarding_continue").assertIsNotEnabled()
+
+        composeRule.onNodeWithTag("learning_language_picker").performClick()
+        composeRule.onNodeWithTag("language_search").performTextInput("Japanese")
+        composeRule.onNodeWithTag("language_option_learning_ja").performClick()
+        composeRule.onNodeWithText("Japanese").assertIsDisplayed()
+        composeRule.onNodeWithTag("onboarding_continue").assertIsEnabled()
+
+        composeRule.onNodeWithTag("onboarding_continue").performClick()
+        composeRule.runOnIdle { assertEquals("vi" to "ja", completed) }
+    }
+
+    @Test
+    fun skipFinishesWithoutSelections() {
+        var skipped = false
+        var completed: Pair<String, String>? = null
+        composeRule.setContent {
+            DualSubTheme {
+                LanguageSetupScreen(
+                    onComplete = { native, learning -> completed = native to learning },
+                    onSkip = { skipped = true },
+                )
+            }
+        }
+
+        composeRule.onNodeWithTag("onboarding_skip").performClick()
+        composeRule.runOnIdle {
+            assertTrue(skipped)
+            assertEquals(null, completed)
+        }
+    }
+
+    @Test
+    fun changingNativeLanguageUpdatesSelection() {
+        composeRule.setContent {
+            DualSubTheme {
+                LanguageSetupScreen(onComplete = { _, _ -> }, onSkip = {})
+            }
+        }
+
+        composeRule.onNodeWithTag("native_language_picker").performClick()
+        composeRule.onNodeWithTag("language_option_native_en").performClick()
+        composeRule.onNodeWithText("English").assertIsDisplayed()
+        composeRule.onNodeWithTag("native_language_picker").performClick()
+        composeRule.onNodeWithTag("language_option_native_ja").performClick()
+        composeRule.onNodeWithText("Japanese").assertIsDisplayed()
+    }
+}

--- a/app/src/androidTest/java/com/kienhoang/dualsubreplay/ui/LanguageSetupScreenTest.kt
+++ b/app/src/androidTest/java/com/kienhoang/dualsubreplay/ui/LanguageSetupScreenTest.kt
@@ -34,7 +34,7 @@ class LanguageSetupScreenTest {
         composeRule.onNodeWithTag("onboarding_continue").assertIsNotEnabled()
 
         composeRule.onNodeWithTag("native_language_picker").performClick()
-        composeRule.onNodeWithText("Your native language").assertIsDisplayed()
+        composeRule.onNodeWithTag("language_search").performTextInput("Viet")
         composeRule.onNodeWithTag("language_option_native_vi").performClick()
         composeRule.onNodeWithText("Vietnamese").assertIsDisplayed()
         composeRule.onNodeWithTag("onboarding_continue").assertIsNotEnabled()
@@ -43,9 +43,8 @@ class LanguageSetupScreenTest {
         composeRule.onNodeWithTag("language_search").performTextInput("Japanese")
         composeRule.onNodeWithTag("language_option_learning_ja").performClick()
         composeRule.onNodeWithText("Japanese").assertIsDisplayed()
-        composeRule.onNodeWithTag("onboarding_continue").assertIsEnabled()
 
-        composeRule.onNodeWithTag("onboarding_continue").performClick()
+        composeRule.onNodeWithTag("onboarding_continue").assertIsEnabled().performClick()
         composeRule.runOnIdle { assertEquals("vi" to "ja", completed) }
     }
 
@@ -78,9 +77,12 @@ class LanguageSetupScreenTest {
         }
 
         composeRule.onNodeWithTag("native_language_picker").performClick()
+        composeRule.onNodeWithTag("language_search").performTextInput("Engl")
         composeRule.onNodeWithTag("language_option_native_en").performClick()
         composeRule.onNodeWithText("English").assertIsDisplayed()
+
         composeRule.onNodeWithTag("native_language_picker").performClick()
+        composeRule.onNodeWithTag("language_search").performTextInput("Jap")
         composeRule.onNodeWithTag("language_option_native_ja").performClick()
         composeRule.onNodeWithText("Japanese").assertIsDisplayed()
     }

--- a/app/src/main/java/com/kienhoang/dualsubreplay/ui/AppViewModel.kt
+++ b/app/src/main/java/com/kienhoang/dualsubreplay/ui/AppViewModel.kt
@@ -32,6 +32,7 @@ data class DualSubUiState(
     val subtitlePanelVisible: Boolean = true,
     val sourcePreference: String = "auto",
     val targetLanguage: String = "vi",
+    val onboardingCompleted: Boolean = false,
     val availableSourceLanguages: List<CaptionLanguage> = emptyList(),
     val resolvedSourceLanguage: String? = null,
     val generatedCaptions: Boolean = false,
@@ -116,6 +117,27 @@ internal fun resolvedSourcePreference(requested: String, resolved: String): Stri
         it == "auto" || TranslationLanguages.normalize(it) == TranslationLanguages.normalize(resolved)
     } ?: "auto"
 
+internal fun storedSourcePreference(raw: String?): String =
+    raw?.takeIf { it != "auto" }
+        ?.let(::normalizeSupportedLanguage)
+        ?: "auto"
+
+private fun normalizeSupportedLanguage(code: String): String? {
+    val normalized = TranslationLanguages.normalize(code)
+    return normalized.takeIf(TranslationLanguages::isSupported)
+}
+
+internal fun normalizedOnboardingLanguages(
+    nativeLanguage: String,
+    learningLanguage: String,
+): Pair<String, String>? {
+    val native = TranslationLanguages.normalize(nativeLanguage).takeIf(TranslationLanguages::isSupported)
+        ?: return null
+    val learning = TranslationLanguages.normalize(learningLanguage).takeIf(TranslationLanguages::isSupported)
+        ?: return null
+    return native to learning
+}
+
 class AppViewModel(application: Application) : AndroidViewModel(application) {
     private val preferences = application.getSharedPreferences("dual_sub_preferences", 0)
     private val captionProvider: CaptionProvider = YouTubeCaptionProvider()
@@ -130,9 +152,13 @@ class AppViewModel(application: Application) : AndroidViewModel(application) {
                 ?.let(::trustedEmbeddedUrlOrHome)
                 ?: YOUTUBE_HOME_URL,
             fontScale = preferences.getFloat("font_scale", 1f),
+            sourcePreference = storedSourcePreference(
+                preferences.getString("preferred_caption_language", "auto"),
+            ),
             targetLanguage = preferences.getString("target_language", "vi")
                 ?.takeIf(TranslationLanguages::isSupported)
                 ?: "vi",
+            onboardingCompleted = preferences.getBoolean("onboarding_completed", false),
         ),
     )
     val state: StateFlow<DualSubUiState> = _state.asStateFlow()
@@ -184,6 +210,7 @@ class AppViewModel(application: Application) : AndroidViewModel(application) {
             }
         ) return
         if (current.sourcePreference == normalized) return
+        preferences.edit().putString("preferred_caption_language", normalized).apply()
         _state.update { it.copy(sourcePreference = normalized) }
         val videoId = _state.value.activeVideoId ?: return
         loadVideo(videoId, showPanel = true)
@@ -197,6 +224,25 @@ class AppViewModel(application: Application) : AndroidViewModel(application) {
         if (_state.value.activeVideoId != null && _state.value.segments.isNotEmpty()) {
             retranslateCurrentSegments()
         }
+    }
+
+    fun completeOnboarding(nativeLanguage: String, learningLanguage: String) {
+        val languages = normalizedOnboardingLanguages(nativeLanguage, learningLanguage) ?: return
+        val (native, learning) = languages
+        preferences.edit().putString("preferred_caption_language", learning).apply()
+        preferences.edit().putString("target_language", native).apply()
+        _state.update { it.copy(sourcePreference = learning, targetLanguage = native) }
+        if (_state.value.activeVideoId != null && _state.value.segments.isNotEmpty()) {
+            retranslateCurrentSegments()
+        }
+        finishOnboarding()
+    }
+
+    fun skipOnboarding() = finishOnboarding()
+
+    private fun finishOnboarding() {
+        preferences.edit().putBoolean("onboarding_completed", true).apply()
+        _state.update { it.copy(onboardingCompleted = true) }
     }
 
     fun setFontScale(scale: Float) {

--- a/app/src/main/java/com/kienhoang/dualsubreplay/ui/DualSubApp.kt
+++ b/app/src/main/java/com/kienhoang/dualsubreplay/ui/DualSubApp.kt
@@ -91,17 +91,24 @@ fun DualSubApp(viewModel: AppViewModel) {
     val state by viewModel.state.collectAsStateWithLifecycle()
 
     DualSubTheme {
-        DualSubExperience(
-            state = state,
-            onPageChanged = viewModel::onYouTubePageChanged,
-            onPlaybackSecond = viewModel::onWebPlaybackSecond,
-            onShowSubtitles = viewModel::showSubtitlePanel,
-            onHideSubtitles = viewModel::hideSubtitlePanel,
-            onRetry = viewModel::retryCaptions,
-            onSourceChange = viewModel::setSourcePreference,
-            onTargetChange = viewModel::setTargetLanguage,
-            onFontScaleChange = viewModel::setFontScale,
-        )
+        if (!state.onboardingCompleted) {
+            LanguageSetupScreen(
+                onComplete = viewModel::completeOnboarding,
+                onSkip = viewModel::skipOnboarding,
+            )
+        } else {
+            DualSubExperience(
+                state = state,
+                onPageChanged = viewModel::onYouTubePageChanged,
+                onPlaybackSecond = viewModel::onWebPlaybackSecond,
+                onShowSubtitles = viewModel::showSubtitlePanel,
+                onHideSubtitles = viewModel::hideSubtitlePanel,
+                onRetry = viewModel::retryCaptions,
+                onSourceChange = viewModel::setSourcePreference,
+                onTargetChange = viewModel::setTargetLanguage,
+                onFontScaleChange = viewModel::setFontScale,
+            )
+        }
     }
 }
 
@@ -574,10 +581,10 @@ internal fun SubtitleSettingsDialog(
 
 private enum class LanguagePickerMode { SOURCE, TARGET }
 
-private data class LanguageChoice(val code: String, val label: String)
+internal data class LanguageChoice(val code: String, val label: String)
 
 @Composable
-private fun LanguagePickerDialog(
+internal fun LanguagePickerDialog(
     title: String,
     choices: List<LanguageChoice>,
     selectedCode: String,

--- a/app/src/main/java/com/kienhoang/dualsubreplay/ui/LanguageSetupScreen.kt
+++ b/app/src/main/java/com/kienhoang/dualsubreplay/ui/LanguageSetupScreen.kt
@@ -1,0 +1,185 @@
+package com.kienhoang.dualsubreplay.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ClosedCaption
+import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.kienhoang.dualsubreplay.translation.TranslationLanguages
+
+private enum class SetupPickerMode { NATIVE, LEARNING }
+
+@Composable
+fun LanguageSetupScreen(
+    onComplete: (nativeLanguage: String, learningLanguage: String) -> Unit,
+    onSkip: () -> Unit,
+) {
+    var nativeLanguage by remember { mutableStateOf<String?>(null) }
+    var learningLanguage by remember { mutableStateOf<String?>(null) }
+    var pickerMode by remember { mutableStateOf<SetupPickerMode?>(null) }
+    var searchQuery by remember { mutableStateOf("") }
+    val choices = TranslationLanguages.all.map { LanguageChoice(it.code, it.name) }
+
+    val activeMode = pickerMode
+    if (activeMode != null) {
+        val selected = if (activeMode == SetupPickerMode.NATIVE) nativeLanguage else learningLanguage
+        LanguagePickerDialog(
+            title = if (activeMode == SetupPickerMode.NATIVE) {
+                "Your native language"
+            } else {
+                "Language you want to learn"
+            },
+            choices = choices,
+            selectedCode = selected.orEmpty(),
+            searchQuery = searchQuery,
+            onSearchQueryChange = { searchQuery = it },
+            onChoice = { choice ->
+                if (activeMode == SetupPickerMode.NATIVE) {
+                    nativeLanguage = TranslationLanguages.normalize(choice.code)
+                } else {
+                    learningLanguage = TranslationLanguages.normalize(choice.code)
+                }
+                pickerMode = null
+                searchQuery = ""
+            },
+            onDismiss = {
+                pickerMode = null
+                searchQuery = ""
+            },
+            testTagPrefix = activeMode.name.lowercase(),
+        )
+    }
+
+    Surface(
+        modifier = Modifier.fillMaxSize().testTag("language_setup_screen"),
+        color = Color(0xFF061719),
+        contentColor = Color(0xFFF3FAFA),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 24.dp, vertical = 32.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Icon(
+                Icons.Default.ClosedCaption,
+                contentDescription = null,
+                modifier = Modifier.size(44.dp),
+                tint = MaterialTheme.colorScheme.primary,
+            )
+            Spacer(Modifier.height(12.dp))
+            Text(
+                text = "Welcome to DualSub Replay",
+                style = MaterialTheme.typography.headlineSmall,
+                color = Color(0xFFF3FAFA),
+            )
+            Spacer(Modifier.height(6.dp))
+            Text(
+                text = "Choose your languages once. You can change them later in subtitle settings.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = Color(0xFFB7CED1),
+            )
+            Spacer(Modifier.height(28.dp))
+
+            SetupLanguageField(
+                label = "Your native language",
+                helper = "Shown as the small translated subtitle.",
+                selection = nativeLanguage?.let(TranslationLanguages::displayName),
+                onClick = {
+                    pickerMode = SetupPickerMode.NATIVE
+                    searchQuery = ""
+                },
+                testTag = "native_language_picker",
+            )
+            Spacer(Modifier.height(18.dp))
+            SetupLanguageField(
+                label = "Language you want to learn",
+                helper = "Preferred caption track; the big subtitle follows the video.",
+                selection = learningLanguage?.let(TranslationLanguages::displayName),
+                onClick = {
+                    pickerMode = SetupPickerMode.LEARNING
+                    searchQuery = ""
+                },
+                testTag = "learning_language_picker",
+            )
+
+            Spacer(Modifier.weight(1f))
+
+            Button(
+                onClick = {
+                    val native = nativeLanguage ?: return@Button
+                    val learning = learningLanguage ?: return@Button
+                    onComplete(native, learning)
+                },
+                enabled = nativeLanguage != null && learningLanguage != null,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .testTag("onboarding_continue"),
+            ) {
+                Text("Continue")
+            }
+            TextButton(
+                onClick = onSkip,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .testTag("onboarding_skip"),
+            ) {
+                Text(
+                    "Skip for now",
+                    color = Color(0xFFB7CED1),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun SetupLanguageField(
+    label: String,
+    helper: String,
+    selection: String?,
+    onClick: () -> Unit,
+    testTag: String,
+) {
+    Column(Modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(6.dp)) {
+        Text(label, style = MaterialTheme.typography.labelLarge, color = Color(0xFFF3FAFA))
+        OutlinedButton(
+            onClick = onClick,
+            modifier = Modifier.fillMaxWidth().testTag(testTag),
+        ) {
+            Text(
+                text = selection ?: "Select language",
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                color = if (selection == null) Color(0xFF9EDCE4) else Color.Unspecified,
+            )
+        }
+        Text(helper, style = MaterialTheme.typography.bodySmall, color = Color(0xFF607477))
+    }
+}

--- a/app/src/test/java/com/kienhoang/dualsubreplay/ui/OnboardingPreferencesTest.kt
+++ b/app/src/test/java/com/kienhoang/dualsubreplay/ui/OnboardingPreferencesTest.kt
@@ -1,0 +1,36 @@
+package com.kienhoang.dualsubreplay.ui
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class OnboardingPreferencesTest {
+
+    @Test fun keepsSupportedOnboardingLanguagePairs() {
+        assertEquals("vi" to "ja", normalizedOnboardingLanguages("vi", "ja"))
+    }
+
+    @Test fun normalizesRegionalTagsInOnboardingChoices() {
+        assertEquals("en" to "zh", normalizedOnboardingLanguages("en-US", "zh-CN"))
+        assertEquals("he" to "en", normalizedOnboardingLanguages("iw", "en"))
+    }
+
+    @Test fun rejectsUnsupportedOnboardingLanguages() {
+        assertNull(normalizedOnboardingLanguages("xx", "ja"))
+        assertNull(normalizedOnboardingLanguages("vi", "zz"))
+        assertNull(normalizedOnboardingLanguages("", ""))
+    }
+
+    @Test fun storedSourcePreferenceFallsBackToAuto() {
+        assertEquals("auto", storedSourcePreference(null))
+        assertEquals("auto", storedSourcePreference(""))
+        assertEquals("auto", storedSourcePreference("klingon"))
+        assertEquals("auto", storedSourcePreference("auto"))
+    }
+
+    @Test fun storedSourcePreferenceKeepsSupportedCaptionTracks() {
+        assertEquals("ja", storedSourcePreference("ja"))
+        assertEquals("pt", storedSourcePreference("pt-BR"))
+        assertEquals("he", storedSourcePreference("iw"))
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a one-screen first-launch flow: choose your **native language** (shown as the small translated subtitle) and the **language you want to learn** (preferred caption track)
- Persists both choices (`target_language`, new `preferred_caption_language`) plus an `onboarding_completed` flag; "Skip for now" keeps current defaults
- Source caption preference now survives restarts (previously reset to auto on every launch)
- Reuses the existing searchable language picker; Material 3 styling matches the app dark-teal palette
- WebView architecture untouched; no version bump

## Tests
- `OnboardingPreferencesTest` (unit): language normalization/validation + stored-preference fallbacks
- `LanguageSetupScreenTest` (instrumented): continue gating, selection callbacks, skip