### PR TITLE
Add landscape split view: video left, dual subtitles right

### DIFF
--- a/app/src/androidTest/java/com/kienhoang/dualsubreplay/ui/SubtitleUiTest.kt
+++ b/app/src/androidTest/java/com/kienhoang/dualsubreplay/ui/SubtitleUiTest.kt
@@ -36,9 +36,11 @@ class SubtitleUiTest {
                         CaptionLanguage("ja", "Japanese"),
                     ),
                     fontScale = 1f,
+                    landscapeSplitEnabled = false,
                     onSourceChange = { selectedLanguage = it },
                     onTargetChange = { selectedTarget = it },
                     onFontScaleChange = {},
+                    onLandscapeSplitChange = {},
                     onDismiss = { dismissed = true },
                 )
             }

--- a/app/src/main/java/com/kienhoang/dualsubreplay/ui/AppViewModel.kt
+++ b/app/src/main/java/com/kienhoang/dualsubreplay/ui/AppViewModel.kt
@@ -39,7 +39,7 @@ data class DualSubUiState(
     val segments: List<SubtitleSegment> = emptyList(),
     val currentIndex: Int = -1,
     val fontScale: Float = 1f,
-    val landscapeSplitEnabled: Boolean = false,
+    val landscapeSplitEnabled: Boolean = true,
     val stage: LoadStage = LoadStage.IDLE,
     val statusMessage: String? = null,
     val errorMessage: String? = null,
@@ -160,7 +160,7 @@ class AppViewModel(application: Application) : AndroidViewModel(application) {
                 ?.takeIf(TranslationLanguages::isSupported)
                 ?: "vi",
             onboardingCompleted = preferences.getBoolean("onboarding_completed", false),
-            landscapeSplitEnabled = preferences.getBoolean("landscape_split_enabled", false),
+            landscapeSplitEnabled = preferences.getBoolean("landscape_split_enabled", true),
         ),
     )
     val state: StateFlow<DualSubUiState> = _state.asStateFlow()

--- a/app/src/main/java/com/kienhoang/dualsubreplay/ui/AppViewModel.kt
+++ b/app/src/main/java/com/kienhoang/dualsubreplay/ui/AppViewModel.kt
@@ -39,6 +39,7 @@ data class DualSubUiState(
     val segments: List<SubtitleSegment> = emptyList(),
     val currentIndex: Int = -1,
     val fontScale: Float = 1f,
+    val landscapeSplitEnabled: Boolean = false,
     val stage: LoadStage = LoadStage.IDLE,
     val statusMessage: String? = null,
     val errorMessage: String? = null,
@@ -159,6 +160,7 @@ class AppViewModel(application: Application) : AndroidViewModel(application) {
                 ?.takeIf(TranslationLanguages::isSupported)
                 ?: "vi",
             onboardingCompleted = preferences.getBoolean("onboarding_completed", false),
+            landscapeSplitEnabled = preferences.getBoolean("landscape_split_enabled", false),
         ),
     )
     val state: StateFlow<DualSubUiState> = _state.asStateFlow()
@@ -249,6 +251,11 @@ class AppViewModel(application: Application) : AndroidViewModel(application) {
         val safeScale = scale.coerceIn(0.8f, 1.5f)
         preferences.edit().putFloat("font_scale", safeScale).apply()
         _state.update { it.copy(fontScale = safeScale) }
+    }
+
+    fun setLandscapeSplitEnabled(enabled: Boolean) {
+        preferences.edit().putBoolean("landscape_split_enabled", enabled).apply()
+        _state.update { it.copy(landscapeSplitEnabled = enabled) }
     }
 
     fun retryCaptions() {

--- a/app/src/main/java/com/kienhoang/dualsubreplay/ui/DualSubApp.kt
+++ b/app/src/main/java/com/kienhoang/dualsubreplay/ui/DualSubApp.kt
@@ -67,6 +67,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalDensity
@@ -418,37 +419,29 @@ private fun SideSubtitlePanel(
     Surface(
         modifier = modifier
             .onSizeChanged { panelWidthPx = it.width.toFloat() }
-            .offset { IntOffset(panelOffsetX.roundToInt(), 0) }
-            .shadow(18.dp, RoundedCornerShape(topStart = 18.dp, bottomStart = 18.dp)),
-        shape = RoundedCornerShape(topStart = 18.dp, bottomStart = 18.dp),
+            .offset { IntOffset(panelOffsetX.roundToInt(), 0) },
+        shape = RectangleShape,
         color = Color(0xFF061719),
         contentColor = Color(0xFFF3FAFA),
         tonalElevation = 8.dp,
     ) {
         Column(Modifier.fillMaxSize()) {
             Column(headerDragModifier) {
-                Box(
-                    Modifier
-                        .padding(start = 6.dp)
-                        .size(width = 4.dp, height = 42.dp),
-                ) {
-                    Surface(Modifier.fillMaxSize(), shape = CircleShape, color = Color(0xFF607477)) {}
-                }
-
                 Row(
-                    modifier = Modifier.fillMaxWidth().height(52.dp).padding(start = 12.dp, end = 4.dp),
+                    modifier = Modifier.fillMaxWidth().height(44.dp).padding(start = 10.dp, end = 2.dp),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
                     Icon(
                         Icons.Default.ClosedCaption,
                         contentDescription = null,
                         tint = MaterialTheme.colorScheme.primary,
+                        modifier = Modifier.size(20.dp),
                     )
-                    Spacer(Modifier.size(10.dp))
+                    Spacer(Modifier.size(8.dp))
                     Column(Modifier.weight(1f)) {
                         Text(
                             text = sourceDescription(state),
-                            style = MaterialTheme.typography.labelLarge,
+                            style = MaterialTheme.typography.labelMedium,
                             color = Color(0xFFF3FAFA),
                             maxLines = 1,
                             overflow = TextOverflow.Ellipsis,
@@ -461,18 +454,20 @@ private fun SideSubtitlePanel(
                             overflow = TextOverflow.Ellipsis,
                         )
                     }
-                    IconButton(onClick = onSettings) {
+                    IconButton(onClick = onSettings, modifier = Modifier.size(36.dp)) {
                         Icon(
                             Icons.Default.Settings,
                             contentDescription = "Subtitle settings",
                             tint = Color(0xFFE5F2F3),
+                            modifier = Modifier.size(20.dp),
                         )
                     }
-                    IconButton(onClick = onHide) {
+                    IconButton(onClick = onHide, modifier = Modifier.size(36.dp)) {
                         Icon(
                             Icons.Default.Close,
                             contentDescription = "Hide dual subtitles",
                             tint = Color(0xFFE5F2F3),
+                            modifier = Modifier.size(20.dp),
                         )
                     }
                 }

--- a/app/src/main/java/com/kienhoang/dualsubreplay/ui/DualSubApp.kt
+++ b/app/src/main/java/com/kienhoang/dualsubreplay/ui/DualSubApp.kt
@@ -1,5 +1,6 @@
 package com.kienhoang.dualsubreplay.ui
 
+import android.content.res.Configuration
 import androidx.compose.animation.core.animate
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.BorderStroke
@@ -49,6 +50,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Slider
 import androidx.compose.material3.SmallFloatingActionButton
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -66,6 +68,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.stateDescription
@@ -107,6 +110,7 @@ fun DualSubApp(viewModel: AppViewModel) {
                 onSourceChange = viewModel::setSourcePreference,
                 onTargetChange = viewModel::setTargetLanguage,
                 onFontScaleChange = viewModel::setFontScale,
+                onLandscapeSplitChange = viewModel::setLandscapeSplitEnabled,
             )
         }
     }
@@ -123,9 +127,17 @@ private fun DualSubExperience(
     onSourceChange: (String) -> Unit,
     onTargetChange: (String) -> Unit,
     onFontScaleChange: (Float) -> Unit,
+    onLandscapeSplitChange: (Boolean) -> Unit,
 ) {
     var showSettings by remember { mutableStateOf(false) }
     val webController = rememberYouTubeWebController()
+    val configuration = LocalConfiguration.current
+    val sideBySide = shouldUseLandscapeSplit(
+        splitEnabled = state.landscapeSplitEnabled,
+        subtitlePanelVisible = state.subtitlePanelVisible,
+        hasActiveVideo = state.activeVideoId != null,
+        orientation = configuration.orientation,
+    )
 
     Scaffold(contentWindowInsets = WindowInsets.safeDrawing) { innerPadding ->
         Box(
@@ -134,16 +146,39 @@ private fun DualSubExperience(
                 .padding(innerPadding)
                 .consumeWindowInsets(innerPadding),
         ) {
-            SingleYouTubePage(
-                initialUrl = state.browserUrl,
-                navigationRequestId = state.browserNavigationRequestId,
-                controller = webController,
-                onPageChanged = onPageChanged,
-                onPlaybackSecond = onPlaybackSecond,
-                modifier = Modifier.fillMaxSize().testTag("youtube_web_app"),
-            )
+            // Single call site on purpose: branching around SingleYouTubePage would
+            // leave composition and destroy the persistent WebView on every rotation.
+            Row(Modifier.fillMaxSize()) {
+                SingleYouTubePage(
+                    initialUrl = state.browserUrl,
+                    navigationRequestId = state.browserNavigationRequestId,
+                    controller = webController,
+                    onPageChanged = onPageChanged,
+                    onPlaybackSecond = onPlaybackSecond,
+                    modifier = Modifier
+                        .weight(if (sideBySide) 2f else 1f)
+                        .fillMaxHeight()
+                        .testTag("youtube_web_app"),
+                )
 
-            if (state.activeVideoId != null && state.subtitlePanelVisible) {
+                if (sideBySide) {
+                    SideSubtitlePanel(
+                        state = state,
+                        modifier = Modifier
+                            .weight(1f)
+                            .fillMaxHeight()
+                            .testTag("subtitle_timeline"),
+                        onHide = onHideSubtitles,
+                        onSettings = { showSettings = true },
+                        onRetry = onRetry,
+                        onReplay = { segment ->
+                            webController.replayFrom(segment.startMs / 1_000f)
+                        },
+                    )
+                }
+            }
+
+            if (!sideBySide && state.activeVideoId != null && state.subtitlePanelVisible) {
                 SubtitlePanel(
                     state = state,
                     modifier = Modifier
@@ -158,7 +193,7 @@ private fun DualSubExperience(
                         webController.replayFrom(segment.startMs / 1_000f)
                     },
                 )
-            } else if (state.activeVideoId != null) {
+            } else if (!sideBySide && state.activeVideoId != null) {
                 SmallFloatingActionButton(
                     onClick = onShowSubtitles,
                     modifier = Modifier
@@ -181,9 +216,11 @@ private fun DualSubExperience(
             targetLanguage = state.targetLanguage,
             availableSourceLanguages = state.availableSourceLanguages,
             fontScale = state.fontScale,
+            landscapeSplitEnabled = state.landscapeSplitEnabled,
             onSourceChange = onSourceChange,
             onTargetChange = onTargetChange,
             onFontScaleChange = onFontScaleChange,
+            onLandscapeSplitChange = onLandscapeSplitChange,
             onDismiss = { showSettings = false },
         )
     }
@@ -313,6 +350,142 @@ internal fun shouldHideSubtitlePanel(
 ): Boolean {
     val distanceThreshold = max(minimumDistancePx, panelHeightPx * 0.18f)
     return dragOffsetPx >= distanceThreshold || velocityPxPerSecond >= 1_500f
+}
+
+/**
+ * Landscape split shows the persistent WebView at a fixed 2:1 ratio beside the
+ * dual-subtitle panel. Every condition must hold so portrait, hidden panels,
+ * and idle browsing keep today's stacked layout.
+ */
+internal fun shouldUseLandscapeSplit(
+    splitEnabled: Boolean,
+    subtitlePanelVisible: Boolean,
+    hasActiveVideo: Boolean,
+    orientation: Int,
+): Boolean = splitEnabled &&
+    subtitlePanelVisible &&
+    hasActiveVideo &&
+    orientation == Configuration.ORIENTATION_LANDSCAPE
+
+internal const val SIDE_PANEL_SWIPE_VELOCITY_THRESHOLD = 1_500f
+
+internal fun shouldCollapseSidePanel(
+    dragOffsetPx: Float,
+    velocityPxPerSecond: Float,
+    minimumDistancePx: Float,
+): Boolean = dragOffsetPx >= minimumDistancePx ||
+    velocityPxPerSecond >= SIDE_PANEL_SWIPE_VELOCITY_THRESHOLD
+
+@Composable
+private fun SideSubtitlePanel(
+    state: DualSubUiState,
+    modifier: Modifier,
+    onHide: () -> Unit,
+    onSettings: () -> Unit,
+    onRetry: () -> Unit,
+    onReplay: (SubtitleSegment) -> Unit,
+) {
+    var panelOffsetX by remember { mutableFloatStateOf(0f) }
+    var panelWidthPx by remember { mutableFloatStateOf(0f) }
+    val minimumDismissDistancePx = with(LocalDensity.current) { 72.dp.toPx() }
+    val scope = rememberCoroutineScope()
+    val dragState = rememberDraggableState { delta ->
+        val maximum = panelWidthPx.takeIf { it > 0f } ?: Float.MAX_VALUE
+        panelOffsetX = (panelOffsetX + delta).coerceIn(0f, maximum)
+    }
+    val headerDragModifier = Modifier
+        .draggable(
+            state = dragState,
+            orientation = Orientation.Horizontal,
+            onDragStopped = { velocity ->
+                val hide = shouldCollapseSidePanel(
+                    dragOffsetPx = panelOffsetX,
+                    velocityPxPerSecond = velocity,
+                    minimumDistancePx = minimumDismissDistancePx,
+                )
+                scope.launch {
+                    val target = if (hide) panelWidthPx.coerceAtLeast(panelOffsetX) else 0f
+                    animate(
+                        initialValue = panelOffsetX,
+                        targetValue = target,
+                        animationSpec = tween(durationMillis = if (hide) 160 else 220),
+                    ) { value, _ -> panelOffsetX = value }
+                    if (hide) onHide()
+                }
+            },
+        )
+
+    Surface(
+        modifier = modifier
+            .onSizeChanged { panelWidthPx = it.width.toFloat() }
+            .offset { IntOffset(panelOffsetX.roundToInt(), 0) }
+            .shadow(18.dp, RoundedCornerShape(topStart = 18.dp, bottomStart = 18.dp)),
+        shape = RoundedCornerShape(topStart = 18.dp, bottomStart = 18.dp),
+        color = Color(0xFF061719),
+        contentColor = Color(0xFFF3FAFA),
+        tonalElevation = 8.dp,
+    ) {
+        Column(Modifier.fillMaxSize()) {
+            Column(headerDragModifier) {
+                Box(
+                    Modifier
+                        .padding(start = 6.dp)
+                        .size(width = 4.dp, height = 42.dp),
+                ) {
+                    Surface(Modifier.fillMaxSize(), shape = CircleShape, color = Color(0xFF607477)) {}
+                }
+
+                Row(
+                    modifier = Modifier.fillMaxWidth().height(52.dp).padding(start = 12.dp, end = 4.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Icon(
+                        Icons.Default.ClosedCaption,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.primary,
+                    )
+                    Spacer(Modifier.size(10.dp))
+                    Column(Modifier.weight(1f)) {
+                        Text(
+                            text = sourceDescription(state),
+                            style = MaterialTheme.typography.labelLarge,
+                            color = Color(0xFFF3FAFA),
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                        Text(
+                            text = state.statusMessage ?: "Tap a paragraph to replay it",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = Color(0xFFB7CED1),
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                    }
+                    IconButton(onClick = onSettings) {
+                        Icon(
+                            Icons.Default.Settings,
+                            contentDescription = "Subtitle settings",
+                            tint = Color(0xFFE5F2F3),
+                        )
+                    }
+                    IconButton(onClick = onHide) {
+                        Icon(
+                            Icons.Default.Close,
+                            contentDescription = "Hide dual subtitles",
+                            tint = Color(0xFFE5F2F3),
+                        )
+                    }
+                }
+            }
+            HorizontalDivider(color = Color(0xFF244044))
+
+            when {
+                state.errorMessage != null -> CompactErrorPanel(state.errorMessage, onRetry)
+                state.segments.isEmpty() -> CompactLoadingPanel(state.statusMessage ?: "Loading captions…")
+                else -> SubtitleTimeline(state, onReplay)
+            }
+        }
+    }
 }
 
 @Composable
@@ -483,9 +656,11 @@ internal fun SubtitleSettingsDialog(
     targetLanguage: String,
     availableSourceLanguages: List<CaptionLanguage>,
     fontScale: Float,
+    landscapeSplitEnabled: Boolean,
     onSourceChange: (String) -> Unit,
     onTargetChange: (String) -> Unit,
     onFontScaleChange: (Float) -> Unit,
+    onLandscapeSplitChange: (Boolean) -> Unit,
     onDismiss: () -> Unit,
 ) {
     var pickerMode by remember { mutableStateOf<LanguagePickerMode?>(null) }
@@ -567,8 +742,27 @@ internal fun SubtitleSettingsDialog(
                     Spacer(Modifier.height(14.dp))
                     Text("Text size: ${(fontScale * 100).toInt()}%")
                     Slider(value = fontScale, onValueChange = onFontScaleChange, valueRange = 0.8f..1.5f)
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Column(Modifier.weight(1f)) {
+                            Text("Landscape split view")
+                            Text(
+                                "Rotate the phone to place subtitles beside a bigger video.",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                        Switch(
+                            checked = landscapeSplitEnabled,
+                            onCheckedChange = onLandscapeSplitChange,
+                            modifier = Modifier.testTag("landscape_split_switch"),
+                        )
+                    }
                     Text(
-                        "Swipe the panel header down to hide it. Captions keep tracking while hidden.",
+                        "Swipe the panel header down (or right in split view) to hide it. " +
+                            "Captions keep tracking while hidden.",
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )

--- a/app/src/main/java/com/kienhoang/dualsubreplay/ui/DualSubApp.kt
+++ b/app/src/main/java/com/kienhoang/dualsubreplay/ui/DualSubApp.kt
@@ -27,8 +27,10 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.ClosedCaption
@@ -704,7 +706,12 @@ internal fun SubtitleSettingsDialog(
             onDismissRequest = onDismiss,
             title = { Text("Dual-subtitle settings") },
             text = {
-                Column {
+                val bodyMaxHeight = LocalConfiguration.current.screenHeightDp.dp * 0.55f
+                Column(
+                    modifier = Modifier
+                        .heightIn(max = bodyMaxHeight)
+                        .verticalScroll(rememberScrollState()),
+                ) {
                     Text("Original captions")
                     Spacer(Modifier.height(6.dp))
                     OutlinedButton(
@@ -801,7 +808,8 @@ internal fun LanguagePickerDialog(
                     singleLine = true,
                 )
                 Spacer(Modifier.height(8.dp))
-                LazyColumn(Modifier.fillMaxWidth().heightIn(max = 360.dp)) {
+                val listMaxHeight = minOf(360.dp, LocalConfiguration.current.screenHeightDp.dp * 0.45f)
+                LazyColumn(Modifier.fillMaxWidth().heightIn(max = listMaxHeight)) {
                     itemsIndexed(filteredChoices, key = { _, choice -> choice.code }) { _, choice ->
                         Row(
                             modifier = Modifier

--- a/app/src/test/java/com/kienhoang/dualsubreplay/ui/LandscapeSplitViewTest.kt
+++ b/app/src/test/java/com/kienhoang/dualsubreplay/ui/LandscapeSplitViewTest.kt
@@ -1,0 +1,103 @@
+package com.kienhoang.dualsubreplay.ui
+
+import android.content.res.Configuration
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class LandscapeSplitViewTest {
+
+    @Test fun usesSplitWhenEnabledVisibleAndLandscape() {
+        assertTrue(
+            shouldUseLandscapeSplit(
+                splitEnabled = true,
+                subtitlePanelVisible = true,
+                hasActiveVideo = true,
+                orientation = Configuration.ORIENTATION_LANDSCAPE,
+            ),
+        )
+    }
+
+    @Test fun keepsStackedLayoutInPortrait() {
+        assertFalse(
+            shouldUseLandscapeSplit(
+                splitEnabled = true,
+                subtitlePanelVisible = true,
+                hasActiveVideo = true,
+                orientation = Configuration.ORIENTATION_PORTRAIT,
+            ),
+        )
+    }
+
+    @Test fun requiresEveryConditionToHold() {
+        assertFalse(
+            shouldUseLandscapeSplit(
+                splitEnabled = false,
+                subtitlePanelVisible = true,
+                hasActiveVideo = true,
+                orientation = Configuration.ORIENTATION_LANDSCAPE,
+            ),
+        )
+        assertFalse(
+            shouldUseLandscapeSplit(
+                splitEnabled = true,
+                subtitlePanelVisible = false,
+                hasActiveVideo = true,
+                orientation = Configuration.ORIENTATION_LANDSCAPE,
+            ),
+        )
+        assertFalse(
+            shouldUseLandscapeSplit(
+                splitEnabled = true,
+                subtitlePanelVisible = true,
+                hasActiveVideo = false,
+                orientation = Configuration.ORIENTATION_LANDSCAPE,
+            ),
+        )
+    }
+
+    @Test fun undefinedOrientationNeverSplits() {
+        assertFalse(
+            shouldUseLandscapeSplit(
+                splitEnabled = true,
+                subtitlePanelVisible = true,
+                hasActiveVideo = true,
+                orientation = Configuration.ORIENTATION_UNDEFINED,
+            ),
+        )
+    }
+
+    @Test fun collapseNeedsDistanceOrFastSwipe() {
+        assertFalse(
+            shouldCollapseSidePanel(
+                dragOffsetPx = 0f,
+                velocityPxPerSecond = 0f,
+                minimumDistancePx = 100f,
+            ),
+        )
+        assertTrue(
+            shouldCollapseSidePanel(
+                dragOffsetPx = 120f,
+                velocityPxPerSecond = 0f,
+                minimumDistancePx = 100f,
+            ),
+        )
+        assertTrue(
+            shouldCollapseSidePanel(
+                dragOffsetPx = 40f,
+                velocityPxPerSecond = SIDE_PANEL_SWIPE_VELOCITY_THRESHOLD + 1f,
+                minimumDistancePx = 100f,
+            ),
+        )
+    }
+
+    @Test fun slowShortDragsKeepThePanelOpen() {
+        assertFalse(
+            shouldCollapseSidePanel(
+                dragOffsetPx = 40f,
+                velocityPxPerSecond = 500f,
+                minimumDistancePx = 100f,
+            ),
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Adds an opt-in **landscape split view**: when the device is rotated to landscape and the setting is enabled, the video takes the left ~2/3 of the screen and the dual-subtitle panel fills the right ~1/3 — like YouTube theater mode, but with subtitles instead of live chat.

![before/after intent](https://raw.githubusercontent.com/github/explore/main/.github/octocat.png)

## What changed

### Setting (`AppViewModel.kt`)
- New `landscapeSplitEnabled` field in `DualSubUiState`, persisted as `"landscape_split_enabled"` in `dual_sub_preferences` (default **off**)
- `setLandscapeSplitEnabled()` setter mirrors the existing `setFontScale` pattern

### Layout (`DualSubApp.kt`)
- `DualSubExperience` now renders a single `Row`: WebView gets `weight(2f)`, side panel gets `weight(1f)` when split is active; otherwise the WebView keeps the full screen and the portrait bottom-sheet layout is untouched
- **Single call site for `SingleYouTubePage`** — critical detail: branching around it would leave composition on rotation and trigger `destroySafely()` + page reload. Instead only the modifier changes, so the persistent WebView survives rotation (also guaranteed by the manifest's existing `configChanges`)
- New `SideSubtitlePanel`: full-height column reusing `SubtitleTimeline`/error/loading panels; collapses via **horizontal swipe right** on its header or the ✕ button
- Collapse decision extracted to testable `internal fun shouldCollapseSidePanel` (does not touch the architecture-tested `shouldHideSubtitlePanel`)
- Split gating extracted to `internal fun shouldUseLandscapeSplit(splitEnabled, subtitlePanelVisible, hasActiveVideo, orientation)` — split only activates when enabled + panel visible + a video is open + actually landscape
- When collapsed in landscape, video expands to full width and the existing CC FAB brings subtitles back

### Settings dialog
- Added a "Landscape split view" switch with description, plus updated hide-gesture hint text

## Architecture invariants respected
- Exactly one WebView, resized in place — no second player/WebView
- No changes to playback/replay JS scripts, `classifyMainFrameUrl`, or caption pipeline (`PlaybackArchitectureTest` untouched and passing)

## Tests
- New `LandscapeSplitViewTest`: 6 JUnit4 tests covering split gating (portrait/disabled/hidden/no-video/undefined orientation) and swipe-collapse thresholds
- Updated `SubtitleUiTest` for the new dialog signature
- Full local verification passed: `testDebugUnitTest lintDebug assembleDebug assembleDebugAndroidTest`

## How to test manually
1. Open any video → tap ⚙️ in the subtitle panel
2. Enable **Landscape split view**
3. Rotate to landscape → video left, dual subs right (fixed 2:1)
4. Swipe the panel header right (or ✕) → panel collapses, video goes full width, FAB restores it
5. Rotate back to portrait → classic stacked layout returns