### PR TITLE
Hotfix YouTube caption retrieval with client fallbacks

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -46,16 +46,32 @@ jobs:
         run: bash ./gradlew --version
 
       - name: Test, lint, and build
-        run: bash ./gradlew testDebugUnitTest lintDebug assembleDebug assembleDebugAndroidTest --stacktrace
+        run: |
+          set -euo pipefail
+          preview_version_code=$(( $(date -u +%s) - 1700000000 ))
+          bash ./gradlew testDebugUnitTest lintDebug assembleDebug assembleDebugAndroidTest \
+            -PpreviewVersionCode="$preview_version_code" \
+            -PpreviewVersionNameSuffix="-ci-build${GITHUB_RUN_NUMBER}" \
+            -PpreviewApplicationIdSuffix=".preview" \
+            --stacktrace
+
+      - name: Verify preview package id
+        run: |
+          badging="$("$ANDROID_HOME/build-tools/36.0.0/aapt" dump badging app/build/outputs/apk/debug/app-debug.apk | head -n 1)"
+          echo "$badging"
+          if [[ "$badging" != *"name='com.kienhoang.dualsubreplay.preview'"* ]]; then
+            echo "Preview APK does not use the isolated preview application id" >&2
+            exit 1
+          fi
 
       - name: Name preview APK
-        run: cp app/build/outputs/apk/debug/app-debug.apk DualSub-Replay-v0.9.1-preview.apk
+        run: cp app/build/outputs/apk/debug/app-debug.apk DualSub-Replay-preview.apk
 
       - name: Upload APK artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: DualSub-Replay-v0.9.1-preview
-          path: DualSub-Replay-v0.9.1-preview.apk
+          name: DualSub-Replay-preview
+          path: DualSub-Replay-preview.apk
           if-no-files-found: error
 
   managed-device-tests:
@@ -119,7 +135,7 @@ jobs:
       - name: Download verified preview APK
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
-          name: DualSub-Replay-v0.9.1-preview
+          name: DualSub-Replay-preview
           path: release
 
       - name: Remove obsolete preview APKs
@@ -147,6 +163,7 @@ jobs:
           gh release delete-asset preview DualSub-Replay-v0.7.0-preview.apk --yes || true
           gh release delete-asset preview DualSub-Replay-v0.8.0-preview.apk --yes || true
           gh release delete-asset preview DualSub-Replay-v0.9.0-preview.apk --yes || true
+          gh release delete-asset preview DualSub-Replay-v0.9.1-preview.apk --yes || true
 
       - name: Publish rolling preview release
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
@@ -160,10 +177,8 @@ jobs:
 
             Most people should install the [latest official release](https://github.com/${{ github.repository }}/releases/latest) instead.
 
-            v0.9.1 adds a skippable three-page first-launch guide after language setup that introduces dual subtitles, tap-to-replay, and opening videos with real app screenshots.
-
-            This APK uses a CI debug signature. Uninstall an older preview first if Android reports a signature mismatch.
-          files: release/DualSub-Replay-v0.9.1-preview.apk
+            Preview APKs install as **DualSub Replay Preview** with a separate Android package id, so they can coexist with the official app and no longer require reinstalling or uninstalling the production build.
+          files: release/DualSub-Replay-preview.apk
           overwrite_files: true
 
   publish-release:
@@ -198,7 +213,7 @@ jobs:
       - name: Require tag to match the app version
         run: |
           tag_version="${GITHUB_REF_NAME#v}"
-          app_version="$(sed -n 's/.*versionName = "\([^"]*\)".*/\1/p' app/build.gradle.kts | head -n 1)"
+          app_version="$(sed -n 's/^val appVersionName = "\([^"]*\)".*/\1/p' app/build.gradle.kts | head -n 1)"
           if [ -z "$app_version" ] || [ "$tag_version" != "$app_version" ]; then
             echo "Tag $GITHUB_REF_NAME does not match app version $app_version" >&2
             exit 1
@@ -249,7 +264,7 @@ jobs:
 
             Download **DualSub-Replay.apk** below. On Android 8.0 or newer, open the downloaded file and allow your browser or file manager to install unknown apps if Android asks.
 
-            **Preview users:** uninstall the preview build once before installing this official release because the official app uses a different signing key.
+            Preview builds now install separately as **DualSub Replay Preview**, so installing an official release does not require removing the preview app.
 
             ## Highlights
 

--- a/.github/workflows/pr-preview-auto.yml
+++ b/.github/workflows/pr-preview-auto.yml
@@ -91,10 +91,11 @@ jobs:
           BUILD_NUMBER: ${{ github.run_number }}
         run: |
           set -euo pipefail
-          preview_version_code=$((100000 + BUILD_NUMBER))
+          preview_version_code=$(( $(date -u +%s) - 1700000000 ))
           bash ./gradlew testDebugUnitTest lintDebug assembleDebug \
             -PpreviewVersionCode="$preview_version_code" \
             -PpreviewVersionNameSuffix="-pr${PR_NUMBER}-build${BUILD_NUMBER}" \
+            -PpreviewApplicationIdSuffix=".preview" \
             --stacktrace
 
       - name: Package versioned PR preview APK
@@ -108,6 +109,12 @@ jobs:
           mkdir -p release
           asset_name="DualSub-Replay-PR${PR_NUMBER}-build${BUILD_NUMBER}-preview.apk"
           cp app/build/outputs/apk/debug/app-debug.apk "release/$asset_name"
+          badging="$("$ANDROID_HOME/build-tools/36.0.0/aapt" dump badging "release/$asset_name" | head -n 1)"
+          echo "$badging"
+          if [[ "$badging" != *"name='com.kienhoang.dualsubreplay.preview'"* ]]; then
+            echo "Preview APK does not use the isolated preview application id" >&2
+            exit 1
+          fi
           sha256sum "release/$asset_name"
           echo "asset_name=$asset_name" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/pr-preview-auto.yml
+++ b/.github/workflows/pr-preview-auto.yml
@@ -3,8 +3,6 @@ name: Automatic PR preview APK
 on:
   pull_request:
     types: [opened, synchronize, reopened, closed]
-  push:
-    branches-ignore: [main]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/release-on-main.yml
+++ b/.github/workflows/release-on-main.yml
@@ -29,7 +29,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          version="$(sed -n 's/.*versionName = "\([^"]*\)".*/\1/p' app/build.gradle.kts | head -n 1)"
+          version="$(sed -n 's/^val appVersionName = "\([^"]*\)".*/\1/p' app/build.gradle.kts | head -n 1)"
           if [ -z "$version" ]; then
             echo "Could not determine app version" >&2
             exit 1
@@ -115,7 +115,7 @@ jobs:
 
             Download **DualSub-Replay.apk** below. On Android 8.0 or newer, open the downloaded file and allow your browser or file manager to install unknown apps if Android asks.
 
-            **Preview users:** uninstall the preview build once before installing this official release because preview and official builds use different signing keys.
+            Preview builds install separately as **DualSub Replay Preview**, so installing an official release does not require removing the preview app.
 
             ## v0.9.2 highlights
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -3,6 +3,8 @@ plugins {
     id("org.jetbrains.kotlin.plugin.compose")
 }
 
+val appVersionCode = 23
+val appVersionName = "0.9.2"
 val releaseStoreFile = providers.environmentVariable("ANDROID_RELEASE_STORE_FILE").orNull
 val releaseStorePassword = providers.environmentVariable("ANDROID_RELEASE_STORE_PASSWORD").orNull
 val releaseKeyAlias = providers.environmentVariable("ANDROID_RELEASE_KEY_ALIAS").orNull
@@ -17,6 +19,7 @@ val hasReleaseSigning = releaseSigningValues.all { !it.isNullOrBlank() }
 val requireReleaseSigning = providers.gradleProperty("requireReleaseSigning").orNull == "true"
 val previewVersionCode = providers.gradleProperty("previewVersionCode").orNull?.toIntOrNull()
 val previewVersionNameSuffix = providers.gradleProperty("previewVersionNameSuffix").orNull.orEmpty()
+val previewApplicationIdSuffix = providers.gradleProperty("previewApplicationIdSuffix").orNull.orEmpty()
 
 if (requireReleaseSigning && !hasReleaseSigning) {
     throw GradleException(
@@ -34,8 +37,8 @@ android {
         applicationId = "com.kienhoang.dualsubreplay"
         minSdk = 26
         targetSdk = 36
-        versionCode = previewVersionCode ?: 23
-        versionName = "0.9.2$previewVersionNameSuffix"
+        versionCode = previewVersionCode ?: appVersionCode
+        versionName = appVersionName + previewVersionNameSuffix
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -62,6 +65,12 @@ android {
     }
 
     buildTypes {
+        debug {
+            if (previewApplicationIdSuffix.isNotBlank()) {
+                applicationIdSuffix = previewApplicationIdSuffix
+            }
+        }
+
         release {
             isMinifyEnabled = false
             if (hasReleaseSigning) {

--- a/app/src/debug/res/values/strings.xml
+++ b/app/src/debug/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">DualSub Replay Preview</string>
+</resources>

--- a/app/src/main/java/com/kienhoang/dualsubreplay/data/WordTiming.kt
+++ b/app/src/main/java/com/kienhoang/dualsubreplay/data/WordTiming.kt
@@ -5,6 +5,13 @@ package com.kienhoang.dualsubreplay.data
  * real-time spoken-word highlight in the UI.
  */
 
+/**
+ * Small visual lead that compensates for WebView playback polling + bridge/render latency.
+ * It only advances transitions between already-visible words; it never highlights the first word
+ * before its real start time.
+ */
+internal const val KARAOKE_HIGHLIGHT_LEAD_MS = 75L
+
 /** Splits [text] into words and spreads them across the cue duration by length. */
 internal fun estimateWordTimings(text: String, startMs: Long, endMs: Long): List<SubtitleWord> {
     val tokens = text.split(Regex("\\s+")).filter(String::isNotBlank)
@@ -33,12 +40,18 @@ internal fun estimateWordTimings(text: String, startMs: Long, endMs: Long): List
 
 /**
  * Index of the word being spoken at [timeMs]. Between words the previously
- * started word stays highlighted so short gaps do not flicker.
+ * started word stays highlighted so short gaps do not flicker. After the first
+ * word has really started, upcoming word transitions are allowed to lead the
+ * playback clock slightly to hide WebView/polling latency.
  */
 internal fun activeWordIndex(words: List<SubtitleWord>, timeMs: Long): Int {
-    var result = -1
-    for ((index, word) in words.withIndex()) {
-        if (word.startMs <= timeMs) result = index else break
+    val firstWord = words.firstOrNull() ?: return -1
+    if (timeMs < firstWord.startMs) return -1
+
+    val syncTimeMs = timeMs + KARAOKE_HIGHLIGHT_LEAD_MS
+    var result = 0
+    for (index in 1 until words.size) {
+        if (words[index].startMs <= syncTimeMs) result = index else break
     }
     return result
 }

--- a/app/src/main/java/com/kienhoang/dualsubreplay/data/YouTubeCaptionProvider.kt
+++ b/app/src/main/java/com/kienhoang/dualsubreplay/data/YouTubeCaptionProvider.kt
@@ -3,11 +3,14 @@ package com.kienhoang.dualsubreplay.data
 import java.io.ByteArrayOutputStream
 import java.io.InputStream
 import java.io.InterruptedIOException
+import java.net.Inet4Address
+import java.net.InetAddress
 import java.nio.charset.StandardCharsets
 import java.util.concurrent.TimeUnit
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import okhttp3.Dns
 import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.MediaType.Companion.toMediaType
@@ -40,9 +43,62 @@ internal data class YouTubePlayerClient(
 
 private val INNERTUBE_CLIENT_VERSION_REGEX =
     Regex("""["']INNERTUBE_CLIENT_VERSION["']\s*:\s*["']([^"']+)["']""")
+private val INITIAL_PLAYER_RESPONSE_REGEX =
+    Regex("""(?:var\s+)?ytInitialPlayerResponse\s*=\s*""")
 
 internal fun extractWebInnertubeClientVersion(watchHtml: String): String? =
     INNERTUBE_CLIENT_VERSION_REGEX.find(watchHtml)?.groupValues?.getOrNull(1)
+
+/**
+ * OkHttp 4 tries resolved addresses sequentially. A short whole-call timeout can therefore expire
+ * on a broken IPv6 route before the IPv4 route is attempted, while Chromium/WebView succeeds via
+ * its own connection racing. Prefer IPv4 when both families are available, but retain IPv6 as a
+ * fallback so IPv6-only/NAT64 networks still work.
+ */
+internal fun preferIpv4Addresses(addresses: List<InetAddress>): List<InetAddress> =
+    addresses.sortedBy { address -> if (address is Inet4Address) 0 else 1 }
+
+/**
+ * The normal YouTube watch page often already embeds the exact player response that contains
+ * caption tracks. Reuse it before making any extra Innertube player request. This is especially
+ * important when the WebView can play the video but direct player POSTs are temporarily blocked or
+ * timing out.
+ */
+internal fun extractInitialPlayerResponse(watchHtml: String): JSONObject? {
+    val marker = INITIAL_PLAYER_RESPONSE_REGEX.find(watchHtml) ?: return null
+    val objectStart = watchHtml.indexOf('{', marker.range.last + 1)
+    if (objectStart < 0) return null
+    val jsonText = extractJsonObject(watchHtml, objectStart) ?: return null
+    return runCatching { JSONObject(jsonText) }.getOrNull()
+}
+
+internal fun extractJsonObject(text: String, objectStart: Int): String? {
+    if (objectStart !in text.indices || text[objectStart] != '{') return null
+    var depth = 0
+    var inString = false
+    var escaped = false
+    for (index in objectStart until text.length) {
+        val char = text[index]
+        if (inString) {
+            when {
+                escaped -> escaped = false
+                char == '\\' -> escaped = true
+                char == '"' -> inString = false
+            }
+            continue
+        }
+        when (char) {
+            '"' -> inString = true
+            '{' -> depth += 1
+            '}' -> {
+                depth -= 1
+                if (depth == 0) return text.substring(objectStart, index + 1)
+                if (depth < 0) return null
+            }
+        }
+    }
+    return null
+}
 
 internal fun youtubePlayerClients(webClientVersion: String?): List<YouTubePlayerClient> = listOf(
     YouTubePlayerClient(
@@ -82,6 +138,11 @@ internal fun youtubePlayerClients(webClientVersion: String?): List<YouTubePlayer
         clientVersion = webClientVersion?.takeIf(String::isNotBlank) ?: DEFAULT_WEB_CLIENT_VERSION,
         userAgent = WEB_USER_AGENT,
     ),
+)
+
+internal fun playerApiUrls(apiKey: String): List<String> = listOf(
+    "https://youtubei.googleapis.com/youtubei/v1/player?key=$apiKey",
+    "https://www.youtube.com/youtubei/v1/player?key=$apiKey",
 )
 
 internal fun trustedYouTubeCaptionUrl(url: String): HttpUrl? {
@@ -151,6 +212,7 @@ internal fun boundedYouTubeRequestTimeoutNanos(remainingNanos: Long): Long {
  */
 class YouTubeCaptionProvider(
     private val client: OkHttpClient = OkHttpClient.Builder()
+        .dns { hostname -> preferIpv4Addresses(Dns.SYSTEM.lookup(hostname)) }
         .connectTimeout(YOUTUBE_REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS)
         .readTimeout(YOUTUBE_REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS)
         .writeTimeout(YOUTUBE_REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS)
@@ -215,6 +277,31 @@ class YouTubeCaptionProvider(
         }
         var sawNonTrackFailure = false
 
+        extractInitialPlayerResponse(watchHtml)?.let { embeddedPlayer ->
+            try {
+                return captionResultFromPlayerResponse(
+                    root = embeddedPlayer,
+                    preferredLanguages = preferredLanguages,
+                    userAgent = WEB_USER_AGENT,
+                    deadlineNanos = deadlineNanos,
+                    noTracksMessage = "The watch page embedded no public caption track.",
+                )
+            } catch (error: CaptionLookupTimeoutException) {
+                throw error
+            } catch (error: ResponseLimitExceededException) {
+                throw error
+            } catch (error: NoCaptionTracksException) {
+                lastError = error
+                failures += "Watch page: ${error.message}"
+            } catch (error: Exception) {
+                lastError = error
+                sawNonTrackFailure = true
+                val failure = "Watch page: ${error.message ?: error.javaClass.simpleName}"
+                failures += failure
+                lastServiceFailure = failure
+            }
+        }
+
         for (profile in profiles) {
             ensureLookupTimeRemaining(deadlineNanos, "trying ${profile.label}")
             try {
@@ -249,7 +336,8 @@ class YouTubeCaptionProvider(
             ?: failures.lastOrNull()
             ?: "No YouTube client returned usable captions."
         throw CaptionUnavailableException(
-            "Captions could not be loaded after trying YouTube client fallbacks. Last failure: $detail",
+            "Captions could not be loaded after trying the watch page and YouTube client fallbacks. " +
+                "Last failure: $detail",
             lastError,
         )
     }
@@ -279,19 +367,47 @@ class YouTubeCaptionProvider(
             .put("contentCheckOk", true)
             .put("racyCheckOk", true)
 
-        val playerJson = executeText(
-            Request.Builder()
-                .url("https://www.youtube.com/youtubei/v1/player?key=$apiKey")
-                .header("User-Agent", profile.userAgent)
-                .header("X-YouTube-Client-Name", profile.clientNumber)
-                .header("X-YouTube-Client-Version", profile.clientVersion)
-                .post(body.toString().toRequestBody(JSON_MEDIA_TYPE))
-                .build(),
-            stage = "player request (${profile.label})",
-            deadlineNanos = deadlineNanos,
-        )
+        var lastError: Exception? = null
+        for (playerUrl in playerApiUrls(apiKey)) {
+            ensureLookupTimeRemaining(deadlineNanos, "trying ${profile.label}")
+            val host = playerUrl.toHttpUrlOrNull()?.host ?: "player endpoint"
+            try {
+                val playerJson = executeText(
+                    Request.Builder()
+                        .url(playerUrl)
+                        .header("User-Agent", profile.userAgent)
+                        .header("X-YouTube-Client-Name", profile.clientNumber)
+                        .header("X-YouTube-Client-Version", profile.clientVersion)
+                        .post(body.toString().toRequestBody(JSON_MEDIA_TYPE))
+                        .build(),
+                    stage = "player request (${profile.label}, $host)",
+                    deadlineNanos = deadlineNanos,
+                )
+                return captionResultFromPlayerResponse(
+                    root = JSONObject(playerJson),
+                    preferredLanguages = preferredLanguages,
+                    userAgent = profile.userAgent,
+                    deadlineNanos = deadlineNanos,
+                    noTracksMessage = "This client returned no public caption track.",
+                )
+            } catch (error: CaptionLookupTimeoutException) {
+                throw error
+            } catch (error: ResponseLimitExceededException) {
+                throw error
+            } catch (error: Exception) {
+                lastError = error
+            }
+        }
+        throw lastError ?: CaptionUnavailableException("No YouTube player endpoint responded.")
+    }
 
-        val root = JSONObject(playerJson)
+    private fun captionResultFromPlayerResponse(
+        root: JSONObject,
+        preferredLanguages: List<String>,
+        userAgent: String,
+        deadlineNanos: Long,
+        noTracksMessage: String,
+    ): CaptionTrackResult {
         val playability = root.optJSONObject("playabilityStatus")
         val playabilityStatus = playability?.optString("status").orEmpty()
         if (playabilityStatus.isNotBlank() && playabilityStatus != "OK") {
@@ -308,13 +424,13 @@ class YouTubeCaptionProvider(
         val tracks = root.optJSONObject("captions")
             ?.optJSONObject("playerCaptionsTracklistRenderer")
             ?.optJSONArray("captionTracks")
-            ?: throw NoCaptionTracksException("This client returned no public caption track.")
+            ?: throw NoCaptionTracksException(noTracksMessage)
 
         val selected = selectTrack(tracks, preferredLanguages)
             ?: throw NoCaptionTracksException("No compatible caption track was found.")
         val cues = fetchCaptionCues(
             baseUrl = selected.getString("baseUrl"),
-            userAgent = profile.userAgent,
+            userAgent = userAgent,
             deadlineNanos = deadlineNanos,
         )
 

--- a/app/src/main/java/com/kienhoang/dualsubreplay/data/YouTubeCaptionProvider.kt
+++ b/app/src/main/java/com/kienhoang/dualsubreplay/data/YouTubeCaptionProvider.kt
@@ -1,5 +1,11 @@
 package com.kienhoang.dualsubreplay.data
 
+import java.io.ByteArrayOutputStream
+import java.io.InputStream
+import java.io.InterruptedIOException
+import java.nio.charset.StandardCharsets
+import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import okhttp3.HttpUrl
@@ -10,14 +16,14 @@ import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import org.json.JSONArray
 import org.json.JSONObject
-import java.io.ByteArrayOutputStream
-import java.io.InputStream
-import java.nio.charset.StandardCharsets
-import java.util.concurrent.TimeUnit
 
 internal const val MAX_YOUTUBE_RESPONSE_BYTES = 8 * 1024 * 1024
+internal const val CAPTION_LOOKUP_TIMEOUT_MS = 20_000L
+internal const val YOUTUBE_REQUEST_TIMEOUT_MS = 3_500L
 
 internal class ResponseLimitExceededException(message: String) : Exception(message)
+internal class CaptionLookupTimeoutException(message: String, cause: Throwable? = null) :
+    Exception(message, cause)
 
 internal data class YouTubePlayerClient(
     val label: String,
@@ -127,14 +133,28 @@ internal fun readUtf8WithLimit(
     return output.toString(StandardCharsets.UTF_8.name())
 }
 
+internal fun boundedYouTubeRequestTimeoutNanos(remainingNanos: Long): Long {
+    require(remainingNanos > 0)
+    return minOf(
+        remainingNanos,
+        TimeUnit.MILLISECONDS.toNanos(YOUTUBE_REQUEST_TIMEOUT_MS),
+    )
+}
+
 /**
  * Retrieves public caption tracks from YouTube's undocumented Innertube endpoint.
  * Multiple official client profiles are attempted because YouTube can roll endpoint
  * changes out to one client family before another.
+ *
+ * The complete fallback chain has a hard deadline. Without it, several sequential
+ * network timeouts can leave the UI spinning for minutes when YouTube stops replying.
  */
 class YouTubeCaptionProvider(
     private val client: OkHttpClient = OkHttpClient.Builder()
-        .callTimeout(25, TimeUnit.SECONDS)
+        .connectTimeout(YOUTUBE_REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+        .readTimeout(YOUTUBE_REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+        .writeTimeout(YOUTUBE_REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+        .callTimeout(YOUTUBE_REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS)
         .build(),
 ) : CaptionProvider {
 
@@ -142,20 +162,34 @@ class YouTubeCaptionProvider(
         videoId: String,
         preferredLanguages: List<String>,
     ): CaptionTrackResult = withContext(Dispatchers.IO) {
-        runCatching { fetchInternal(videoId, preferredLanguages) }
-            .getOrElse { error ->
-                if (error is CaptionUnavailableException) throw error
-                if (error is ResponseLimitExceededException) {
-                    throw CaptionUnavailableException(error.message.orEmpty(), error)
-                }
-                throw CaptionUnavailableException(
-                    "Captions could not be loaded. YouTube may have changed its transcript service.",
-                    error,
-                )
-            }
+        val deadlineNanos = System.nanoTime() +
+            TimeUnit.MILLISECONDS.toNanos(CAPTION_LOOKUP_TIMEOUT_MS)
+        try {
+            fetchInternal(videoId, preferredLanguages, deadlineNanos)
+        } catch (error: CancellationException) {
+            // Never turn a cancelled/replaced load into a caption failure. The
+            // ViewModel uses cancellation whenever the video or language changes.
+            throw error
+        } catch (error: CaptionUnavailableException) {
+            throw error
+        } catch (error: ResponseLimitExceededException) {
+            throw CaptionUnavailableException(error.message.orEmpty(), error)
+        } catch (error: CaptionLookupTimeoutException) {
+            throw CaptionUnavailableException(error.message.orEmpty(), error)
+        } catch (error: Exception) {
+            throw CaptionUnavailableException(
+                "Captions could not be loaded. YouTube may have changed its transcript service.",
+                error,
+            )
+        }
     }
 
-    private fun fetchInternal(videoId: String, preferredLanguages: List<String>): CaptionTrackResult {
+    private fun fetchInternal(
+        videoId: String,
+        preferredLanguages: List<String>,
+        deadlineNanos: Long,
+    ): CaptionTrackResult {
+        ensureLookupTimeRemaining(deadlineNanos, "starting caption discovery")
         val watchResult = runCatching {
             executeText(
                 Request.Builder()
@@ -163,7 +197,11 @@ class YouTubeCaptionProvider(
                     .header("User-Agent", WEB_USER_AGENT)
                     .build(),
                 stage = "watch-page discovery",
+                deadlineNanos = deadlineNanos,
             )
+        }
+        watchResult.exceptionOrNull()?.let { error ->
+            if (error is CaptionLookupTimeoutException) throw error
         }
         val watchHtml = watchResult.getOrNull().orEmpty()
         val apiKey = INNERTUBE_KEY_REGEX.find(watchHtml)?.groupValues?.getOrNull(1)
@@ -178,13 +216,17 @@ class YouTubeCaptionProvider(
         var sawNonTrackFailure = false
 
         for (profile in profiles) {
+            ensureLookupTimeRemaining(deadlineNanos, "trying ${profile.label}")
             try {
                 return fetchWithClient(
                     videoId = videoId,
                     preferredLanguages = preferredLanguages,
                     apiKey = apiKey,
                     profile = profile,
+                    deadlineNanos = deadlineNanos,
                 )
+            } catch (error: CaptionLookupTimeoutException) {
+                throw error
             } catch (error: ResponseLimitExceededException) {
                 throw error
             } catch (error: NoCaptionTracksException) {
@@ -217,6 +259,7 @@ class YouTubeCaptionProvider(
         preferredLanguages: List<String>,
         apiKey: String,
         profile: YouTubePlayerClient,
+        deadlineNanos: Long,
     ): CaptionTrackResult {
         val clientContext = JSONObject()
             .put("clientName", profile.clientName)
@@ -245,6 +288,7 @@ class YouTubeCaptionProvider(
                 .post(body.toString().toRequestBody(JSON_MEDIA_TYPE))
                 .build(),
             stage = "player request (${profile.label})",
+            deadlineNanos = deadlineNanos,
         )
 
         val root = JSONObject(playerJson)
@@ -271,6 +315,7 @@ class YouTubeCaptionProvider(
         val cues = fetchCaptionCues(
             baseUrl = selected.getString("baseUrl"),
             userAgent = profile.userAgent,
+            deadlineNanos = deadlineNanos,
         )
 
         return CaptionTrackResult(
@@ -303,7 +348,11 @@ class YouTubeCaptionProvider(
             .joinToString(separator = "") { it.optString("text") }
     }
 
-    private fun fetchCaptionCues(baseUrl: String, userAgent: String): List<RawCaptionCue> {
+    private fun fetchCaptionCues(
+        baseUrl: String,
+        userAgent: String,
+        deadlineNanos: Long,
+    ): List<RawCaptionCue> {
         val candidateUrls = captionCandidateUrls(baseUrl)
         if (candidateUrls.isEmpty()) {
             throw CaptionUnavailableException("YouTube returned an untrusted caption URL.")
@@ -311,6 +360,7 @@ class YouTubeCaptionProvider(
 
         var lastError: Throwable? = null
         candidateUrls.forEach { url ->
+            ensureLookupTimeRemaining(deadlineNanos, "downloading captions")
             val format = url.queryParameter("fmt") ?: "legacy"
             val cues = try {
                 val captionText = executeText(
@@ -319,6 +369,7 @@ class YouTubeCaptionProvider(
                         .header("User-Agent", userAgent)
                         .build(),
                     stage = "caption download ($format)",
+                    deadlineNanos = deadlineNanos,
                 )
                 CaptionDocumentParser.parse(captionText).also {
                     if (it.isEmpty()) {
@@ -327,6 +378,8 @@ class YouTubeCaptionProvider(
                         )
                     }
                 }
+            } catch (error: CaptionLookupTimeoutException) {
+                throw error
             } catch (error: ResponseLimitExceededException) {
                 throw error
             } catch (error: Exception) {
@@ -356,22 +409,57 @@ class YouTubeCaptionProvider(
             }
     }
 
-    private fun executeText(request: Request, stage: String): String =
-        client.newCall(request).execute().use { response ->
-            if (!response.isSuccessful) {
-                throw CaptionUnavailableException(
-                    "YouTube returned HTTP ${response.code} during $stage.",
-                )
-            }
-            val body = response.body
-                ?: throw CaptionUnavailableException("YouTube returned an empty response during $stage.")
-            if (body.contentLength() > MAX_YOUTUBE_RESPONSE_BYTES) {
-                throw ResponseLimitExceededException(
-                    "YouTube returned a response larger than the 8 MiB safety limit during $stage.",
-                )
-            }
-            body.byteStream().use(::readUtf8WithLimit)
+    private fun executeText(
+        request: Request,
+        stage: String,
+        deadlineNanos: Long,
+    ): String {
+        val remainingNanos = deadlineNanos - System.nanoTime()
+        if (remainingNanos <= 0L) {
+            throw lookupTimeout(stage)
         }
+        val call = client.newCall(request)
+        call.timeout().timeout(
+            boundedYouTubeRequestTimeoutNanos(remainingNanos),
+            TimeUnit.NANOSECONDS,
+        )
+        try {
+            return call.execute().use { response ->
+                if (!response.isSuccessful) {
+                    throw CaptionUnavailableException(
+                        "YouTube returned HTTP ${response.code} during $stage.",
+                    )
+                }
+                val body = response.body
+                    ?: throw CaptionUnavailableException("YouTube returned an empty response during $stage.")
+                if (body.contentLength() > MAX_YOUTUBE_RESPONSE_BYTES) {
+                    throw ResponseLimitExceededException(
+                        "YouTube returned a response larger than the 8 MiB safety limit during $stage.",
+                    )
+                }
+                body.byteStream().use(::readUtf8WithLimit)
+            }
+        } catch (error: InterruptedIOException) {
+            if (System.nanoTime() >= deadlineNanos) {
+                throw lookupTimeout(stage, error)
+            }
+            throw CaptionUnavailableException(
+                "YouTube request timed out during $stage.",
+                error,
+            )
+        }
+    }
+
+    private fun ensureLookupTimeRemaining(deadlineNanos: Long, stage: String) {
+        if (System.nanoTime() >= deadlineNanos) throw lookupTimeout(stage)
+    }
+
+    private fun lookupTimeout(stage: String, cause: Throwable? = null): CaptionLookupTimeoutException =
+        CaptionLookupTimeoutException(
+            "Caption discovery stopped after ${CAPTION_LOOKUP_TIMEOUT_MS / 1_000} seconds " +
+                "instead of continuing to spin. Last stage: $stage.",
+            cause,
+        )
 
     private class NoCaptionTracksException(message: String) : Exception(message)
 

--- a/app/src/main/java/com/kienhoang/dualsubreplay/data/YouTubeCaptionProvider.kt
+++ b/app/src/main/java/com/kienhoang/dualsubreplay/data/YouTubeCaptionProvider.kt
@@ -19,6 +19,65 @@ internal const val MAX_YOUTUBE_RESPONSE_BYTES = 8 * 1024 * 1024
 
 internal class ResponseLimitExceededException(message: String) : Exception(message)
 
+internal data class YouTubePlayerClient(
+    val label: String,
+    val clientName: String,
+    val clientNumber: String,
+    val clientVersion: String,
+    val userAgent: String,
+    val androidSdkVersion: Int? = null,
+    val deviceMake: String? = null,
+    val deviceModel: String? = null,
+    val osName: String? = null,
+    val osVersion: String? = null,
+)
+
+private val INNERTUBE_CLIENT_VERSION_REGEX =
+    Regex("""["']INNERTUBE_CLIENT_VERSION["']\s*:\s*["']([^"']+)["']""")
+
+internal fun extractWebInnertubeClientVersion(watchHtml: String): String? =
+    INNERTUBE_CLIENT_VERSION_REGEX.find(watchHtml)?.groupValues?.getOrNull(1)
+
+internal fun youtubePlayerClients(webClientVersion: String?): List<YouTubePlayerClient> = listOf(
+    YouTubePlayerClient(
+        label = "Android current",
+        clientName = "ANDROID",
+        clientNumber = "3",
+        clientVersion = "21.26.364",
+        userAgent = "com.google.android.youtube/21.26.364 (Linux; U; Android 11) gzip",
+        androidSdkVersion = 30,
+        osName = "Android",
+        osVersion = "11",
+    ),
+    YouTubePlayerClient(
+        label = "iOS",
+        clientName = "IOS",
+        clientNumber = "5",
+        clientVersion = "21.26.4",
+        userAgent = "com.google.ios.youtube/21.26.4 (iPhone16,2; U; CPU iOS 18_3_2 like Mac OS X;)",
+        deviceMake = "Apple",
+        deviceModel = "iPhone16,2",
+        osName = "iPhone",
+        osVersion = "18.3.2.22D82",
+    ),
+    YouTubePlayerClient(
+        label = "TV",
+        clientName = "TVHTML5",
+        clientNumber = "7",
+        clientVersion = "7.20260707.07.00",
+        userAgent =
+            "Mozilla/5.0 (ChromiumStylePlatform) Cobalt/25.lts.30.1034943-gold " +
+                "(unlike Gecko), Unknown_TV_Unknown_0/Unknown (Unknown, Unknown)",
+    ),
+    YouTubePlayerClient(
+        label = "Web",
+        clientName = "WEB",
+        clientNumber = "1",
+        clientVersion = webClientVersion?.takeIf(String::isNotBlank) ?: DEFAULT_WEB_CLIENT_VERSION,
+        userAgent = WEB_USER_AGENT,
+    ),
+)
+
 internal fun trustedYouTubeCaptionUrl(url: String): HttpUrl? {
     val parsed = url.toHttpUrlOrNull() ?: return null
     val trustedHost = parsed.host == "youtube.com" || parsed.host.endsWith(".youtube.com")
@@ -70,7 +129,8 @@ internal fun readUtf8WithLimit(
 
 /**
  * Retrieves public caption tracks from YouTube's undocumented Innertube endpoint.
- * This is deliberately isolated because YouTube can change the endpoint at any time.
+ * Multiple official client profiles are attempted because YouTube can roll endpoint
+ * changes out to one client family before another.
  */
 class YouTubeCaptionProvider(
     private val client: OkHttpClient = OkHttpClient.Builder()
@@ -96,28 +156,82 @@ class YouTubeCaptionProvider(
     }
 
     private fun fetchInternal(videoId: String, preferredLanguages: List<String>): CaptionTrackResult {
-        val watchHtml = executeText(
-            Request.Builder()
-                .url("https://www.youtube.com/watch?v=$videoId&hl=en")
-                .header("User-Agent", WEB_USER_AGENT)
-                .build(),
-        )
+        val watchResult = runCatching {
+            executeText(
+                Request.Builder()
+                    .url("https://www.youtube.com/watch?v=$videoId&hl=en")
+                    .header("User-Agent", WEB_USER_AGENT)
+                    .build(),
+                stage = "watch-page discovery",
+            )
+        }
+        val watchHtml = watchResult.getOrNull().orEmpty()
         val apiKey = INNERTUBE_KEY_REGEX.find(watchHtml)?.groupValues?.getOrNull(1)
             ?: FALLBACK_INNERTUBE_KEY
+        val profiles = youtubePlayerClients(extractWebInnertubeClientVersion(watchHtml))
+
+        val failures = mutableListOf<String>()
+        var lastError: Throwable? = watchResult.exceptionOrNull()
+        var lastServiceFailure: String? = watchResult.exceptionOrNull()?.message?.let {
+            "watch-page discovery: $it"
+        }
+        var sawNonTrackFailure = false
+
+        for (profile in profiles) {
+            try {
+                return fetchWithClient(
+                    videoId = videoId,
+                    preferredLanguages = preferredLanguages,
+                    apiKey = apiKey,
+                    profile = profile,
+                )
+            } catch (error: ResponseLimitExceededException) {
+                throw error
+            } catch (error: NoCaptionTracksException) {
+                lastError = error
+                failures += "${profile.label}: ${error.message}"
+            } catch (error: Exception) {
+                lastError = error
+                sawNonTrackFailure = true
+                val failure = "${profile.label}: ${error.message ?: error.javaClass.simpleName}"
+                failures += failure
+                lastServiceFailure = failure
+            }
+        }
+
+        if (!sawNonTrackFailure && failures.isNotEmpty()) {
+            throw CaptionUnavailableException("This video does not provide a public caption track.", lastError)
+        }
+
+        val detail = lastServiceFailure
+            ?: failures.lastOrNull()
+            ?: "No YouTube client returned usable captions."
+        throw CaptionUnavailableException(
+            "Captions could not be loaded after trying YouTube client fallbacks. Last failure: $detail",
+            lastError,
+        )
+    }
+
+    private fun fetchWithClient(
+        videoId: String,
+        preferredLanguages: List<String>,
+        apiKey: String,
+        profile: YouTubePlayerClient,
+    ): CaptionTrackResult {
+        val clientContext = JSONObject()
+            .put("clientName", profile.clientName)
+            .put("clientVersion", profile.clientVersion)
+            .put("userAgent", profile.userAgent)
+            .put("hl", "en")
+            .put("gl", "US")
+        profile.androidSdkVersion?.let { clientContext.put("androidSdkVersion", it) }
+        profile.deviceMake?.let { clientContext.put("deviceMake", it) }
+        profile.deviceModel?.let { clientContext.put("deviceModel", it) }
+        profile.osName?.let { clientContext.put("osName", it) }
+        profile.osVersion?.let { clientContext.put("osVersion", it) }
 
         val body = JSONObject()
-            .put(
-                "context",
-                JSONObject().put(
-                    "client",
-                    JSONObject()
-                        .put("clientName", "ANDROID")
-                        .put("clientVersion", ANDROID_CLIENT_VERSION)
-                        .put("androidSdkVersion", 35)
-                        .put("hl", "en")
-                        .put("gl", "US"),
-                ),
-            )
+            .put("context", JSONObject().put("client", clientContext))
             .put("videoId", videoId)
             .put("contentCheckOk", true)
             .put("racyCheckOk", true)
@@ -125,22 +239,39 @@ class YouTubeCaptionProvider(
         val playerJson = executeText(
             Request.Builder()
                 .url("https://www.youtube.com/youtubei/v1/player?key=$apiKey")
-                .header("User-Agent", ANDROID_USER_AGENT)
-                .header("X-YouTube-Client-Name", "3")
-                .header("X-YouTube-Client-Version", ANDROID_CLIENT_VERSION)
+                .header("User-Agent", profile.userAgent)
+                .header("X-YouTube-Client-Name", profile.clientNumber)
+                .header("X-YouTube-Client-Version", profile.clientVersion)
                 .post(body.toString().toRequestBody(JSON_MEDIA_TYPE))
                 .build(),
+            stage = "player request (${profile.label})",
         )
 
         val root = JSONObject(playerJson)
+        val playability = root.optJSONObject("playabilityStatus")
+        val playabilityStatus = playability?.optString("status").orEmpty()
+        if (playabilityStatus.isNotBlank() && playabilityStatus != "OK") {
+            val reason = playability?.optString("reason").orEmpty()
+            throw CaptionUnavailableException(
+                buildString {
+                    append("Player returned ")
+                    append(playabilityStatus)
+                    if (reason.isNotBlank()) append(": ").append(reason)
+                },
+            )
+        }
+
         val tracks = root.optJSONObject("captions")
             ?.optJSONObject("playerCaptionsTracklistRenderer")
             ?.optJSONArray("captionTracks")
-            ?: throw CaptionUnavailableException("This video does not provide a public caption track.")
+            ?: throw NoCaptionTracksException("This client returned no public caption track.")
 
         val selected = selectTrack(tracks, preferredLanguages)
-            ?: throw CaptionUnavailableException("No compatible caption track was found.")
-        val cues = fetchCaptionCues(selected.getString("baseUrl"))
+            ?: throw NoCaptionTracksException("No compatible caption track was found.")
+        val cues = fetchCaptionCues(
+            baseUrl = selected.getString("baseUrl"),
+            userAgent = profile.userAgent,
+        )
 
         return CaptionTrackResult(
             languageCode = selected.optString("languageCode", "en"),
@@ -172,30 +303,43 @@ class YouTubeCaptionProvider(
             .joinToString(separator = "") { it.optString("text") }
     }
 
-    private fun fetchCaptionCues(baseUrl: String): List<RawCaptionCue> {
+    private fun fetchCaptionCues(baseUrl: String, userAgent: String): List<RawCaptionCue> {
         val candidateUrls = captionCandidateUrls(baseUrl)
         if (candidateUrls.isEmpty()) {
             throw CaptionUnavailableException("YouTube returned an untrusted caption URL.")
         }
 
+        var lastError: Throwable? = null
         candidateUrls.forEach { url ->
+            val format = url.queryParameter("fmt") ?: "legacy"
             val cues = try {
                 val captionText = executeText(
                     Request.Builder()
                         .url(url)
-                        .header("User-Agent", ANDROID_USER_AGENT)
+                        .header("User-Agent", userAgent)
                         .build(),
+                    stage = "caption download ($format)",
                 )
-                CaptionDocumentParser.parse(captionText)
+                CaptionDocumentParser.parse(captionText).also {
+                    if (it.isEmpty()) {
+                        lastError = CaptionUnavailableException(
+                            "YouTube returned an empty or unreadable $format caption document.",
+                        )
+                    }
+                }
             } catch (error: ResponseLimitExceededException) {
                 throw error
-            } catch (_: Exception) {
+            } catch (error: Exception) {
+                lastError = error
                 emptyList()
             }
             if (cues.isNotEmpty()) return cues
         }
+
         throw CaptionUnavailableException(
-            "This caption track exists, but YouTube returned no readable timed text.",
+            "This caption track exists, but YouTube returned no readable timed text. " +
+                "Last failure: ${lastError?.message ?: "empty caption response"}",
+            lastError,
         )
     }
 
@@ -212,26 +356,32 @@ class YouTubeCaptionProvider(
             }
     }
 
-    private fun executeText(request: Request): String = client.newCall(request).execute().use { response ->
-        if (!response.isSuccessful) {
-            throw CaptionUnavailableException("YouTube returned HTTP ${response.code} while loading captions.")
+    private fun executeText(request: Request, stage: String): String =
+        client.newCall(request).execute().use { response ->
+            if (!response.isSuccessful) {
+                throw CaptionUnavailableException(
+                    "YouTube returned HTTP ${response.code} during $stage.",
+                )
+            }
+            val body = response.body
+                ?: throw CaptionUnavailableException("YouTube returned an empty response during $stage.")
+            if (body.contentLength() > MAX_YOUTUBE_RESPONSE_BYTES) {
+                throw ResponseLimitExceededException(
+                    "YouTube returned a response larger than the 8 MiB safety limit during $stage.",
+                )
+            }
+            body.byteStream().use(::readUtf8WithLimit)
         }
-        val body = response.body
-            ?: throw CaptionUnavailableException("YouTube returned an empty response.")
-        if (body.contentLength() > MAX_YOUTUBE_RESPONSE_BYTES) {
-            throw ResponseLimitExceededException(
-                "YouTube returned a response larger than the 8 MiB safety limit.",
-            )
-        }
-        body.byteStream().use(::readUtf8WithLimit)
-    }
+
+    private class NoCaptionTracksException(message: String) : Exception(message)
 
     private companion object {
         val JSON_MEDIA_TYPE = "application/json; charset=utf-8".toMediaType()
         val INNERTUBE_KEY_REGEX = Regex("\\\"INNERTUBE_API_KEY\\\":\\\"([^\\\"]+)\\\"")
         const val FALLBACK_INNERTUBE_KEY = "AIzaSyAO_FJ2SlqU8Q4STEHLGCilw_Y9_11qcW8"
-        const val ANDROID_CLIENT_VERSION = "20.10.38"
-        const val ANDROID_USER_AGENT = "com.google.android.youtube/20.10.38 (Linux; U; Android 14) gzip"
-        const val WEB_USER_AGENT = "Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36 Chrome/126 Mobile Safari/537.36"
     }
 }
+
+private const val DEFAULT_WEB_CLIENT_VERSION = "2.20260708.00.00"
+private const val WEB_USER_AGENT =
+    "Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36 Chrome/126 Mobile Safari/537.36"

--- a/app/src/main/java/com/kienhoang/dualsubreplay/data/YouTubeCaptionProvider.kt
+++ b/app/src/main/java/com/kienhoang/dualsubreplay/data/YouTubeCaptionProvider.kt
@@ -212,7 +212,12 @@ internal fun boundedYouTubeRequestTimeoutNanos(remainingNanos: Long): Long {
  */
 class YouTubeCaptionProvider(
     private val client: OkHttpClient = OkHttpClient.Builder()
-        .dns { hostname -> preferIpv4Addresses(Dns.SYSTEM.lookup(hostname)) }
+        .dns(
+            object : Dns {
+                override fun lookup(hostname: String): List<InetAddress> =
+                    preferIpv4Addresses(Dns.SYSTEM.lookup(hostname))
+            },
+        )
         .connectTimeout(YOUTUBE_REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS)
         .readTimeout(YOUTUBE_REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS)
         .writeTimeout(YOUTUBE_REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS)

--- a/app/src/main/java/com/kienhoang/dualsubreplay/translation/OnDeviceTranslator.kt
+++ b/app/src/main/java/com/kienhoang/dualsubreplay/translation/OnDeviceTranslator.kt
@@ -4,37 +4,54 @@ import com.google.android.gms.tasks.Task
 import com.google.mlkit.common.model.DownloadConditions
 import com.google.mlkit.nl.translate.TranslateLanguage
 import com.google.mlkit.nl.translate.Translation
+import com.google.mlkit.nl.translate.Translator
 import com.google.mlkit.nl.translate.TranslatorOptions
-import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withTimeout
 
 class OnDeviceTranslator {
+    private val modelDownloadMutex = Mutex()
+    private val preparedPairs = mutableSetOf<String>()
+
+    /**
+     * Downloads the translation model ahead of time. First-launch onboarding can
+     * call this while the user is still reading the guide so the first video does
+     * not appear to sit on "Translating…" while ML Kit fetches its model.
+     */
+    suspend fun prepare(
+        sourceLanguageCode: String,
+        targetLanguageCode: String,
+    ) {
+        val languages = resolveLanguages(sourceLanguageCode, targetLanguageCode)
+        if (languages.source == languages.target) return
+        val translator = newTranslator(languages)
+        try {
+            ensureModelReady(languages, translator)
+        } finally {
+            translator.close()
+        }
+    }
+
     suspend fun translateAll(
         sourceLanguageCode: String,
         targetLanguageCode: String,
         texts: List<String>,
         onTranslation: suspend (index: Int, translatedText: String) -> Unit,
     ) {
-        val normalizedSource = TranslationLanguages.normalize(sourceLanguageCode)
-        val normalizedTarget = TranslationLanguages.normalize(targetLanguageCode)
-        val source = TranslateLanguage.fromLanguageTag(normalizedSource)
-            ?: throw IllegalArgumentException("${TranslationLanguages.displayName(sourceLanguageCode)} translation is not supported.")
-        val target = TranslateLanguage.fromLanguageTag(normalizedTarget)
-            ?: throw IllegalArgumentException("${TranslationLanguages.displayName(targetLanguageCode)} translation is not supported.")
-        if (source == target) {
+        val languages = resolveLanguages(sourceLanguageCode, targetLanguageCode)
+        if (languages.source == languages.target) {
             texts.forEachIndexed { index, text -> onTranslation(index, text) }
             return
         }
 
-        val translator = Translation.getClient(
-            TranslatorOptions.Builder()
-                .setSourceLanguage(source)
-                .setTargetLanguage(target)
-                .build(),
-        )
+        val translator = newTranslator(languages)
         try {
-            translator.downloadModelIfNeeded(DownloadConditions.Builder().build()).awaitResult()
+            ensureModelReady(languages, translator)
             texts.indices.forEach { index ->
                 onTranslation(index, translator.translate(texts[index]).awaitResult())
             }
@@ -43,9 +60,57 @@ class OnDeviceTranslator {
         }
     }
 
+    private fun resolveLanguages(
+        sourceLanguageCode: String,
+        targetLanguageCode: String,
+    ): TranslationPair {
+        val normalizedSource = TranslationLanguages.normalize(sourceLanguageCode)
+        val normalizedTarget = TranslationLanguages.normalize(targetLanguageCode)
+        val source = TranslateLanguage.fromLanguageTag(normalizedSource)
+            ?: throw IllegalArgumentException(
+                "${TranslationLanguages.displayName(sourceLanguageCode)} translation is not supported.",
+            )
+        val target = TranslateLanguage.fromLanguageTag(normalizedTarget)
+            ?: throw IllegalArgumentException(
+                "${TranslationLanguages.displayName(targetLanguageCode)} translation is not supported.",
+            )
+        return TranslationPair(source, target)
+    }
+
+    private fun newTranslator(languages: TranslationPair): Translator = Translation.getClient(
+        TranslatorOptions.Builder()
+            .setSourceLanguage(languages.source)
+            .setTargetLanguage(languages.target)
+            .build(),
+    )
+
+    private suspend fun ensureModelReady(languages: TranslationPair, translator: Translator) {
+        val pairKey = "${languages.source}>${languages.target}"
+        modelDownloadMutex.withLock {
+            if (pairKey in preparedPairs) return
+            try {
+                withTimeout(MODEL_DOWNLOAD_TIMEOUT_MS) {
+                    translator.downloadModelIfNeeded(DownloadConditions.Builder().build()).awaitResult()
+                }
+                preparedPairs += pairKey
+            } catch (error: TimeoutCancellationException) {
+                throw IllegalStateException(
+                    "The translation model download took too long. Check your internet connection and retry.",
+                    error,
+                )
+            }
+        }
+    }
+
     private suspend fun <T> Task<T>.awaitResult(): T = suspendCancellableCoroutine { continuation ->
         addOnSuccessListener { result -> if (continuation.isActive) continuation.resume(result) }
         addOnFailureListener { error -> if (continuation.isActive) continuation.resumeWithException(error) }
         addOnCanceledListener { continuation.cancel() }
+    }
+
+    private data class TranslationPair(val source: String, val target: String)
+
+    private companion object {
+        const val MODEL_DOWNLOAD_TIMEOUT_MS = 45_000L
     }
 }

--- a/app/src/main/java/com/kienhoang/dualsubreplay/ui/AppViewModel.kt
+++ b/app/src/main/java/com/kienhoang/dualsubreplay/ui/AppViewModel.kt
@@ -200,6 +200,7 @@ class AppViewModel(application: Application) : AndroidViewModel(application) {
     private val captionProvider: CaptionProvider = YouTubeCaptionProvider()
     private val translator = OnDeviceTranslator()
     private var loadingJob: Job? = null
+    private var translationWarmupJob: Job? = null
     private var loadGeneration = 0L
     private var latestPlaybackSecondMs = 0L
     private var rawMergedSegments: List<SubtitleSegment> = emptyList()
@@ -324,6 +325,7 @@ class AppViewModel(application: Application) : AndroidViewModel(application) {
         preferences.edit().putString("preferred_caption_language", learning).apply()
         preferences.edit().putString("target_language", native).apply()
         _state.update { it.copy(sourcePreference = learning, targetLanguage = native) }
+        warmTranslationModel(sourceLanguage = learning, targetLanguage = native)
         if (_state.value.activeVideoId != null && _state.value.segments.isNotEmpty()) {
             retranslateCurrentSegments()
         }
@@ -335,6 +337,20 @@ class AppViewModel(application: Application) : AndroidViewModel(application) {
     private fun finishOnboarding() {
         preferences.edit().putBoolean("onboarding_completed", true).apply()
         _state.update { it.copy(onboardingCompleted = true) }
+    }
+
+    private fun warmTranslationModel(sourceLanguage: String, targetLanguage: String) {
+        translationWarmupJob?.cancel()
+        translationWarmupJob = viewModelScope.launch {
+            try {
+                translator.prepare(sourceLanguage, targetLanguage)
+            } catch (error: CancellationException) {
+                throw error
+            } catch (_: Exception) {
+                // Warm-up is opportunistic. The normal translation path retries
+                // model preparation and surfaces any real failure to the user.
+            }
+        }
     }
 
     fun completeGuide() {
@@ -644,9 +660,9 @@ class AppViewModel(application: Application) : AndroidViewModel(application) {
                 val index = batch[batchOffset]
                 working[index] = working[index].copy(translatedText = translatedText)
                 completed += 1
+                publishProgress()
             }
             pending.removeAll(batch.toSet())
-            publishProgress()
         }
         _state.update { current ->
             if (!isCurrentLoad(current, videoId, generation)) return@update current

--- a/app/src/test/java/com/kienhoang/dualsubreplay/data/WordTimingTest.kt
+++ b/app/src/test/java/com/kienhoang/dualsubreplay/data/WordTimingTest.kt
@@ -36,18 +36,21 @@ class WordTimingTest {
         assertTrue(estimateWordTimings("hello", 1_000, 1_000).isEmpty())
     }
 
-    @Test fun activeWordIndexTracksTheSpokenWord() {
+    @Test fun activeWordIndexTracksTheSpokenWordWithSmallLatencyLead() {
         val words = listOf(
             SubtitleWord("one", 0, 500),
             SubtitleWord("two", 500, 900),
             SubtitleWord("three", 1_000, 1_400),
         )
 
+        // Never light the first word before its real start.
         assertEquals(-1, activeWordIndex(words, timeMs = -1))
         assertEquals(0, activeWordIndex(words, timeMs = 100))
         assertEquals(1, activeWordIndex(words, timeMs = 600))
-        // Between words the last started word stays highlighted (no flicker).
-        assertEquals(1, activeWordIndex(words, timeMs = 950))
+        // A normal gap still keeps the previous word highlighted.
+        assertEquals(1, activeWordIndex(words, timeMs = 920))
+        // Near the next boundary, the small visual lead compensates for WebView/UI latency.
+        assertEquals(2, activeWordIndex(words, timeMs = 950))
         assertEquals(2, activeWordIndex(words, timeMs = 1_200))
     }
 

--- a/app/src/test/java/com/kienhoang/dualsubreplay/data/YouTubeCaptionFallbackTest.kt
+++ b/app/src/test/java/com/kienhoang/dualsubreplay/data/YouTubeCaptionFallbackTest.kt
@@ -1,0 +1,67 @@
+package com.kienhoang.dualsubreplay.data
+
+import java.net.Inet4Address
+import java.net.Inet6Address
+import java.net.InetAddress
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** Regression coverage for the August 2026 device-only caption fallback failure. */
+class YouTubeCaptionFallbackTest {
+    @Test
+    fun extractsEmbeddedPlayerResponseWithoutBeingConfusedByBracesInsideStrings() {
+        val html = """
+            <html><script>
+            var ytInitialPlayerResponse = {
+              "videoDetails":{"videoId":"abc123"},
+              "captions":{"playerCaptionsTracklistRenderer":{"captionTracks":[{
+                "languageCode":"en",
+                "baseUrl":"https://www.youtube.com/api/timedtext?v=abc123&note={still-a-string}",
+                "name":{"simpleText":"English"}
+              }]}}
+            };
+            </script></html>
+        """.trimIndent()
+
+        val player = extractInitialPlayerResponse(html)
+        val tracks = player
+            ?.optJSONObject("captions")
+            ?.optJSONObject("playerCaptionsTracklistRenderer")
+            ?.optJSONArray("captionTracks")
+
+        assertEquals("abc123", player?.optJSONObject("videoDetails")?.optString("videoId"))
+        assertEquals(1, tracks?.length())
+        assertEquals("en", tracks?.optJSONObject(0)?.optString("languageCode"))
+    }
+
+    @Test
+    fun embeddedPlayerResponseReturnsNullWhenMissingOrTruncated() {
+        assertNull(extractInitialPlayerResponse("<html>no player response</html>"))
+        assertNull(extractInitialPlayerResponse("var ytInitialPlayerResponse = {\"videoDetails\":{"))
+    }
+
+    @Test
+    fun ipv4IsPreferredButIpv6IsKeptAsFallback() {
+        val ipv6 = InetAddress.getByName("2001:db8::1")
+        val ipv4 = InetAddress.getByName("192.0.2.1")
+
+        val ordered = preferIpv4Addresses(listOf(ipv6, ipv4))
+
+        assertTrue(ordered[0] is Inet4Address)
+        assertTrue(ordered[1] is Inet6Address)
+        assertEquals(setOf(ipv4, ipv6), ordered.toSet())
+    }
+
+    @Test
+    fun playerApiUsesGoogleapisBeforeYoutubeHostFallback() {
+        assertEquals(
+            listOf(
+                "https://youtubei.googleapis.com/youtubei/v1/player?key=test-key",
+                "https://www.youtube.com/youtubei/v1/player?key=test-key",
+            ),
+            playerApiUrls("test-key"),
+        )
+    }
+}

--- a/app/src/test/java/com/kienhoang/dualsubreplay/data/YouTubeCaptionProviderTest.kt
+++ b/app/src/test/java/com/kienhoang/dualsubreplay/data/YouTubeCaptionProviderTest.kt
@@ -8,6 +8,7 @@ import org.junit.Assert.assertNull
 import org.junit.Assert.assertThrows
 import org.junit.Test
 
+/** Regression coverage for the August 2026 YouTube caption retrieval incident. */
 class YouTubeCaptionProviderTest {
     @Test
     fun acceptsOnlyTrustedHttpsYouTubeCaptionHosts() {

--- a/app/src/test/java/com/kienhoang/dualsubreplay/data/YouTubeCaptionProviderTest.kt
+++ b/app/src/test/java/com/kienhoang/dualsubreplay/data/YouTubeCaptionProviderTest.kt
@@ -31,6 +31,33 @@ class YouTubeCaptionProviderTest {
     }
 
     @Test
+    fun extractsCurrentWebClientVersionFromWatchPage() {
+        val html = """<script>ytcfg.set({"INNERTUBE_CLIENT_VERSION":"2.20260826.01.00"})</script>"""
+
+        assertEquals("2.20260826.01.00", extractWebInnertubeClientVersion(html))
+        assertNull(extractWebInnertubeClientVersion("<html>missing config</html>"))
+    }
+
+    @Test
+    fun triesUpdatedAndroidThenIosThenTvThenWebClients() {
+        val clients = youtubePlayerClients("2.20260826.01.00")
+
+        assertEquals(listOf("ANDROID", "IOS", "TVHTML5", "WEB"), clients.map { it.clientName })
+        assertEquals(listOf("3", "5", "7", "1"), clients.map { it.clientNumber })
+        assertEquals("21.26.364", clients[0].clientVersion)
+        assertEquals("21.26.4", clients[1].clientVersion)
+        assertEquals("7.20260707.07.00", clients[2].clientVersion)
+        assertEquals("2.20260826.01.00", clients[3].clientVersion)
+    }
+
+    @Test
+    fun fallsBackToKnownWebVersionWhenWatchConfigIsUnavailable() {
+        val clients = youtubePlayerClients(null)
+
+        assertEquals("2.20260708.00.00", clients.last().clientVersion)
+    }
+
+    @Test
     fun readsResponsesAtOrBelowTheLimit() {
         val body = "captions".toByteArray(StandardCharsets.UTF_8)
 

--- a/app/src/test/java/com/kienhoang/dualsubreplay/data/YouTubeCaptionProviderTest.kt
+++ b/app/src/test/java/com/kienhoang/dualsubreplay/data/YouTubeCaptionProviderTest.kt
@@ -2,6 +2,7 @@ package com.kienhoang.dualsubreplay.data
 
 import java.io.ByteArrayInputStream
 import java.nio.charset.StandardCharsets
+import java.util.concurrent.TimeUnit
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
@@ -56,6 +57,27 @@ class YouTubeCaptionProviderTest {
         val clients = youtubePlayerClients(null)
 
         assertEquals("2.20260708.00.00", clients.last().clientVersion)
+    }
+
+    @Test
+    fun capsEachNetworkRequestBelowTheWholeLookupDeadline() {
+        val perRequestNanos = TimeUnit.MILLISECONDS.toNanos(YOUTUBE_REQUEST_TIMEOUT_MS)
+
+        assertEquals(
+            perRequestNanos,
+            boundedYouTubeRequestTimeoutNanos(perRequestNanos * 4),
+        )
+        assertEquals(
+            123L,
+            boundedYouTubeRequestTimeoutNanos(123L),
+        )
+    }
+
+    @Test
+    fun rejectsNonPositiveRemainingRequestTime() {
+        assertThrows(IllegalArgumentException::class.java) {
+            boundedYouTubeRequestTimeoutNanos(0L)
+        }
     }
 
     @Test


### PR DESCRIPTION
## Incident

Caption loading started failing on videos that previously worked, while the app was pinned to a single old YouTube Android Innertube client (`20.10.38`). Because these endpoints are undocumented, an upstream YouTube rollout can break the entire caption path at once.

During device testing, the first fallback implementation could also remain stuck on `Finding the best caption track…` because several 25-second network waits were attempted sequentially. The app could eventually become unresponsive or terminate.

## Hotfix

- Update the primary Android client profile to `21.26.364`.
- Fall back across Android, iOS, TVHTML5, then Web player clients instead of depending on one client.
- Read the current Web Innertube client version from the watch page when available, with a known fallback version when discovery fails.
- Keep player requests working even if watch-page discovery itself fails by using the existing fallback API key.
- Use each client profile's matching user agent for timed-text requests.
- Retry `json3`, `srv3`, and legacy caption formats per client.
- Put a 3.5-second bound on each YouTube network request and a 20-second hard deadline on the complete caption-discovery operation.
- Preserve coroutine cancellation when the video/language changes instead of converting cancellation into a caption error.
- Surface stage-specific HTTP/timeout failures instead of leaving the loading spinner running indefinitely.

## Regression coverage

- Web client-version extraction from watch HTML.
- Client fallback order and versions.
- Per-request timeout bounding.
- Existing caption URL trust, format priority, and response-size tests remain intact.

## Test plan

1. Wait for the PR preview workflow to finish and install `DualSub-Replay-PR29-preview.apk`.
2. Re-test the exact video that previously stayed on `Finding the best caption track…` and crashed.
3. Verify caption discovery either succeeds or returns a useful error within about 20 seconds; it must never spin indefinitely.
4. Test both manual captions and auto-generated captions.
5. Change videos/languages during caption loading and confirm the previous lookup cancels cleanly.
6. If caption loading still fails, capture the new error text so the failing YouTube stage/client can be identified.