### PR TITLE
Version PR preview APK filenames

### DIFF
--- a/.github/workflows/pr-preview-auto.yml
+++ b/.github/workflows/pr-preview-auto.yml
@@ -86,23 +86,38 @@ jobs:
 
       - name: Test, lint, and build PR preview
         if: steps.pr.outputs.found == 'true'
-        run: bash ./gradlew testDebugUnitTest lintDebug assembleDebug --stacktrace
-
-      - name: Package PR preview APK
-        if: steps.pr.outputs.found == 'true'
         env:
           PR_NUMBER: ${{ steps.pr.outputs.number }}
+          BUILD_NUMBER: ${{ github.run_number }}
         run: |
-          mkdir -p release
-          cp app/build/outputs/apk/debug/app-debug.apk "release/DualSub-Replay-PR${PR_NUMBER}-preview.apk"
-          sha256sum "release/DualSub-Replay-PR${PR_NUMBER}-preview.apk"
+          set -euo pipefail
+          preview_version_code=$((100000 + BUILD_NUMBER))
+          bash ./gradlew testDebugUnitTest lintDebug assembleDebug \
+            -PpreviewVersionCode="$preview_version_code" \
+            -PpreviewVersionNameSuffix="-pr${PR_NUMBER}-build${BUILD_NUMBER}" \
+            --stacktrace
 
-      - name: Upload PR preview to rolling preview release
+      - name: Package versioned PR preview APK
+        if: steps.pr.outputs.found == 'true'
+        id: package
+        env:
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          BUILD_NUMBER: ${{ github.run_number }}
+        run: |
+          set -euo pipefail
+          mkdir -p release
+          asset_name="DualSub-Replay-PR${PR_NUMBER}-build${BUILD_NUMBER}-preview.apk"
+          cp app/build/outputs/apk/debug/app-debug.apk "release/$asset_name"
+          sha256sum "release/$asset_name"
+          echo "asset_name=$asset_name" >> "$GITHUB_OUTPUT"
+
+      - name: Upload newest PR preview to rolling preview release
         if: steps.pr.outputs.found == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
           PR_NUMBER: ${{ steps.pr.outputs.number }}
+          ASSET_NAME: ${{ steps.package.outputs.asset_name }}
         run: |
           set -euo pipefail
 
@@ -112,8 +127,19 @@ jobs:
             exit 0
           fi
 
-          asset_name="DualSub-Replay-PR${PR_NUMBER}-preview.apk"
-          gh release upload preview "release/$asset_name" --clobber
+          # Remove older previews for this PR so the release always exposes one
+          # clearly versioned APK. This also avoids stale same-URL browser/CDN caches.
+          assets="$(gh release view preview --json assets --jq '.assets[].name' || true)"
+          while IFS= read -r asset; do
+            [[ -z "$asset" ]] && continue
+            if [[ "$asset" =~ ^DualSub-Replay-PR${PR_NUMBER}-(build[0-9]+-)?preview\.apk$ ]] && [[ "$asset" != "$ASSET_NAME" ]]; then
+              gh release delete-asset preview "$asset" --yes
+              echo "Removed older PR #$PR_NUMBER preview: $asset"
+            fi
+          done <<< "$assets"
+
+          gh release upload preview "release/$ASSET_NAME" --clobber
+          echo "Published $ASSET_NAME"
 
   cleanup-pr-preview:
     if: >-
@@ -126,18 +152,25 @@ jobs:
       contents: write
 
     steps:
-      - name: Remove closed PR preview APK
+      - name: Remove closed PR preview APKs
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
-          ASSET_NAME: DualSub-Replay-PR${{ github.event.pull_request.number }}-preview.apk
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set -euo pipefail
 
-          assets="$(gh release view preview --json assets --jq '.assets[].name')"
-          if printf '%s\n' "$assets" | grep -Fxq "$ASSET_NAME"; then
-            gh release delete-asset preview "$ASSET_NAME" --yes
-            echo "Deleted $ASSET_NAME from the preview release."
-          else
-            echo "$ASSET_NAME is already absent from the preview release."
+          assets="$(gh release view preview --json assets --jq '.assets[].name' || true)"
+          removed=false
+          while IFS= read -r asset; do
+            [[ -z "$asset" ]] && continue
+            if [[ "$asset" =~ ^DualSub-Replay-PR${PR_NUMBER}-(build[0-9]+-)?preview\.apk$ ]]; then
+              gh release delete-asset preview "$asset" --yes
+              echo "Deleted $asset from the preview release."
+              removed=true
+            fi
+          done <<< "$assets"
+
+          if [[ "$removed" == "false" ]]; then
+            echo "PR #$PR_NUMBER preview APK is already absent from the preview release."
           fi

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -15,6 +15,8 @@ val releaseSigningValues = listOf(
 )
 val hasReleaseSigning = releaseSigningValues.all { !it.isNullOrBlank() }
 val requireReleaseSigning = providers.gradleProperty("requireReleaseSigning").orNull == "true"
+val previewVersionCode = providers.gradleProperty("previewVersionCode").orNull?.toIntOrNull()
+val previewVersionNameSuffix = providers.gradleProperty("previewVersionNameSuffix").orNull.orEmpty()
 
 if (requireReleaseSigning && !hasReleaseSigning) {
     throw GradleException(
@@ -32,8 +34,8 @@ android {
         applicationId = "com.kienhoang.dualsubreplay"
         minSdk = 26
         targetSdk = 36
-        versionCode = 23
-        versionName = "0.9.2"
+        versionCode = previewVersionCode ?: 23
+        versionName = "0.9.2$previewVersionNameSuffix"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }


### PR DESCRIPTION
## Why

PR preview builds currently overwrite the exact same asset name, for example `DualSub-Replay-PR29-preview.apk`, while every preview also keeps the same Android `versionCode`/`versionName`. That makes it difficult to tell whether a downloaded or installed APK is actually the newest build and can interact badly with browser/CDN caching when the URL stays identical but the bytes change.

## Change

- Name each successful preview build `DualSub-Replay-PR<NUMBER>-build<RUN_NUMBER>-preview.apk`.
- Give each CI preview an increasing internal Android version code (`100000 + workflow run number`).
- Expose a readable version name such as `0.9.2-pr29-build97` in Android app info.
- Remove older preview assets for the same PR before publishing the newest one.
- Remove both legacy and versioned PR preview assets when the PR closes.
- Keep the existing automatic PR/push/manual triggers and test/lint/build checks.
- Leave normal local builds and official releases unchanged unless the preview-only Gradle properties are supplied.

## Example

A later rebuild of PR #29 may appear as `DualSub-Replay-PR29-build97-preview.apk` and install as `0.9.2-pr29-build97`, making it obvious that it is newer than an earlier build.

This also gives each preview a fresh download URL instead of repeatedly replacing one URL with different APK bytes.