### PR TITLE
Improve karaoke word timing and underline active word

### DIFF
--- a/app/src/main/java/com/kienhoang/dualsubreplay/data/CaptionDocumentParser.kt
+++ b/app/src/main/java/com/kienhoang/dualsubreplay/data/CaptionDocumentParser.kt
@@ -5,6 +5,8 @@ import org.json.JSONObject
 
 /** Parses each caption format currently returned by YouTube timed-text URLs. */
 internal object CaptionDocumentParser {
+    private data class TimedChunk(val text: String, val offsetMs: Long?)
+
     fun parse(text: String): List<RawCaptionCue> {
         val trimmed = text.trimStart()
         if (trimmed.isBlank()) return emptyList()
@@ -30,33 +32,23 @@ internal object CaptionDocumentParser {
     }
 
     /**
-     * json3 splits captions into chunks with per-chunk [tOffsetMs] offsets that
-     * enable the real-time spoken-word highlight. Newline-only chunks separate
-     * lines and carry no spoken text.
+     * json3 carries per-chunk [tOffsetMs] offsets. A chunk is not guaranteed to
+     * be exactly one word, so split multi-word chunks while keeping YouTube's
+     * real timing anchors. This avoids highlighting a whole phrase at once on
+     * noisy/auto-generated transcripts.
      */
     private fun json3Words(segments: JSONArray, cueStartMs: Long, cueEndMs: Long): List<SubtitleWord> {
-        data class Chunk(val text: String, val offsetMs: Long)
-
         val chunks = (0 until segments.length())
             .mapNotNull(segments::optJSONObject)
-            .map { it.optString("utf8") to it.optLong("tOffsetMs", -1L) }
-            .filter { (raw, _) -> raw.isNotBlank() && raw != "\n" }
-            .map { (raw, offset) -> Chunk(raw.normalizeCaptionText(), offset) }
-            .filter { it.text.isNotBlank() }
-        if (chunks.none { it.offsetMs >= 0 }) return emptyList()
-
-        var cursorMs = cueStartMs
-        return chunks.mapIndexed { index, chunk ->
-            val wordStart = if (chunk.offsetMs >= 0) cueStartMs + chunk.offsetMs else cursorMs
-            val nextOffset = chunks.getOrNull(index + 1)?.offsetMs?.takeIf { it >= 0 }
-            val wordEnd = when {
-                nextOffset != null -> cueStartMs + nextOffset
-                index == chunks.lastIndex -> cueEndMs
-                else -> wordStart + DEFAULT_WORD_DURATION_MS
-            }.coerceAtLeast(wordStart + MIN_WORD_DURATION_MS).coerceAtMost(cueEndMs)
-            cursorMs = wordEnd
-            SubtitleWord(text = chunk.text, startMs = wordStart, endMs = wordEnd)
-        }
+            .map { segment ->
+                TimedChunk(
+                    text = segment.optString("utf8").normalizeCaptionText(),
+                    offsetMs = segment.optLong("tOffsetMs", -1L).takeIf { it >= 0L },
+                )
+            }
+            .filter { chunk -> chunk.text.isNotBlank() && chunk.text != "\n" }
+        if (chunks.none { it.offsetMs != null }) return emptyList()
+        return expandTimedChunks(chunks, cueStartMs, cueEndMs)
     }
 
     private fun parseXml(text: String): List<RawCaptionCue> {
@@ -85,29 +77,72 @@ internal object CaptionDocumentParser {
     }
 
     /**
-     * srv3 auto captions mark each spoken chunk with an `<s t="…">` offset in
-     * milliseconds relative to the paragraph start. Chunks without offsets
-     * inherit the previous chunk's timing.
+     * srv3 auto captions mark spoken chunks with an `<s t="…">` offset in
+     * milliseconds relative to the paragraph start. Like json3, one `<s>` can
+     * contain several words, so preserve the anchor and estimate only inside
+     * that anchored chunk.
      */
     private fun srv3Words(paragraphInnerXml: String, cueStartMs: Long, cueEndMs: Long): List<SubtitleWord> {
-        val matches = SRV3_WORD_REGEX.findAll(paragraphInnerXml).toList()
-        if (matches.isEmpty()) return emptyList()
-        var cursorMs = cueStartMs
+        val chunks = SRV3_WORD_REGEX.findAll(paragraphInnerXml)
+            .map { match ->
+                TimedChunk(
+                    text = cleanXmlText(match.groupValues[2]),
+                    offsetMs = attribute(match.groupValues[1], "t")?.toLongOrNull()?.takeIf { it >= 0L },
+                )
+            }
+            .filter { chunk -> chunk.text.isNotBlank() }
+            .toList()
+        if (chunks.isEmpty()) return emptyList()
+        if (chunks.none { it.offsetMs != null }) {
+            return estimateWordTimings(cleanXmlText(paragraphInnerXml), cueStartMs, cueEndMs)
+        }
+        return expandTimedChunks(chunks, cueStartMs, cueEndMs)
+    }
+
+    /**
+     * Expands timed caption chunks into individual words. YouTube's offset is
+     * kept as the chunk anchor; when a chunk contains multiple words, only the
+     * time inside that chunk is estimated. The next real offset remains the
+     * boundary, so accurate ASR anchors are never replaced by whole-line timing.
+     */
+    private fun expandTimedChunks(
+        chunks: List<TimedChunk>,
+        cueStartMs: Long,
+        cueEndMs: Long,
+    ): List<SubtitleWord> {
+        if (chunks.isEmpty() || cueEndMs <= cueStartMs) return emptyList()
         val words = mutableListOf<SubtitleWord>()
-        matches.forEachIndexed { index, match ->
-            val offset = attribute(match.groupValues[1], "t")?.toLongOrNull()
-            val text = cleanXmlText(match.groupValues[2])
-            if (text.isBlank()) return@forEachIndexed
-            val wordStart = offset?.let(cueStartMs::plus) ?: cursorMs
-            val nextOffset = matches.getOrNull(index + 1)?.groupValues?.get(1)
-                ?.let { attribute(it, "t")?.toLongOrNull() }
-            val wordEnd = when {
-                nextOffset != null -> cueStartMs + nextOffset
-                index == matches.lastIndex -> cueEndMs
-                else -> wordStart + DEFAULT_WORD_DURATION_MS
-            }.coerceAtLeast(wordStart + MIN_WORD_DURATION_MS).coerceAtMost(cueEndMs)
-            cursorMs = wordEnd
-            words += SubtitleWord(text = text, startMs = wordStart, endMs = wordEnd)
+        var cursorMs = cueStartMs
+
+        chunks.forEachIndexed { index, chunk ->
+            val anchoredStart = chunk.offsetMs?.let(cueStartMs::plus)
+            val chunkStart = maxOf(cursorMs, anchoredStart ?: cursorMs)
+                .coerceIn(cueStartMs, cueEndMs)
+            val nextAnchoredStart = chunks
+                .asSequence()
+                .drop(index + 1)
+                .mapNotNull { next -> next.offsetMs?.let(cueStartMs::plus) }
+                .firstOrNull()
+            val desiredEnd = when {
+                nextAnchoredStart != null -> nextAnchoredStart
+                index == chunks.lastIndex -> cueEndMs
+                else -> chunkStart + DEFAULT_WORD_DURATION_MS
+            }
+            val chunkEnd = desiredEnd
+                .coerceAtLeast(chunkStart)
+                .coerceAtMost(cueEndMs)
+            if (chunkEnd <= chunkStart) {
+                cursorMs = chunkStart
+                return@forEachIndexed
+            }
+
+            val expanded = estimateWordTimings(chunk.text, chunkStart, chunkEnd)
+            if (expanded.isNotEmpty()) {
+                words += expanded
+                cursorMs = expanded.last().endMs
+            } else {
+                cursorMs = chunkEnd
+            }
         }
         return words
     }

--- a/app/src/main/java/com/kienhoang/dualsubreplay/data/SubtitleMerger.kt
+++ b/app/src/main/java/com/kienhoang/dualsubreplay/data/SubtitleMerger.kt
@@ -4,7 +4,7 @@ object SubtitleMerger {
     private const val MAX_GAP_MS = 1_200L
     private const val MAX_DURATION_MS = 6_000L
     private const val MAX_CHARACTERS = 96
-    private const val MIN_TIMED_WORD_TEXT_COVERAGE = 0.60f
+    private const val MIN_TIMED_WORD_TEXT_COVERAGE = 0.85f
     private val sentenceEnding = Regex("[.!?。！？…][\\\"'’”)]*$")
 
     fun merge(cues: List<RawCaptionCue>): List<SubtitleSegment> {
@@ -17,8 +17,7 @@ object SubtitleMerger {
         var start = ordered.first().startMs
         var end = ordered.first().endMs
         var text = clean(ordered.first().text)
-        var pendingWords = ordered.first().words.filter { word -> word.text.isNotBlank() }
-        var pendingTimingsComplete = ordered.first().words.isNotEmpty()
+        var pendingWords = preparedCueWords(ordered.first())
 
         fun flush() {
             if (text.isNotBlank()) {
@@ -32,12 +31,10 @@ object SubtitleMerger {
                         startMs = start,
                         endMs = end,
                         collectedWords = pendingWords,
-                        timingsComplete = pendingTimingsComplete,
                     ),
                 )
             }
             pendingWords = emptyList()
-            pendingTimingsComplete = true
         }
 
         ordered.drop(1).forEach { cue ->
@@ -53,13 +50,11 @@ object SubtitleMerger {
                 start = cue.startMs
                 end = cue.endMs
                 text = nextText
-                pendingWords = cue.words.filter { word -> word.text.isNotBlank() }
-                pendingTimingsComplete = cue.words.isNotEmpty()
+                pendingWords = preparedCueWords(cue)
             } else {
                 text += separator(text.lastOrNull(), nextText.firstOrNull()) + nextText
                 end = maxOf(end, cue.endMs)
-                pendingWords += cue.words.filter { word -> word.text.isNotBlank() }
-                pendingTimingsComplete = pendingTimingsComplete && cue.words.isNotEmpty()
+                pendingWords += preparedCueWords(cue)
             }
         }
         flush()
@@ -67,21 +62,41 @@ object SubtitleMerger {
     }
 
     /**
-     * Keeps real caption word timings when every merged cue supplied them and
-     * all values are valid. Silent lead-ins and gaps are intentionally allowed.
-     * Auto-generated tracks occasionally contain stale/overlapping timing chunks
-     * whose text no longer matches the displayed caption; those now fall back to
-     * estimated word timings instead of disabling karaoke highlighting entirely.
+     * Keep YouTube's real word timing for each cue whenever it is coherent. If
+     * one noisy auto-caption cue is missing/stale, estimate only that cue instead
+     * of discarding accurate timing from every neighboring cue in the merged line.
+     */
+    private fun preparedCueWords(cue: RawCaptionCue): List<SubtitleWord> {
+        val cueText = clean(cue.text)
+        val sorted = cue.words
+            .filter { word -> word.text.isNotBlank() }
+            .sortedBy(SubtitleWord::startMs)
+        val hasUsableTimedWords = sorted.isNotEmpty() && sorted.all { word ->
+            word.startMs >= cue.startMs &&
+                word.startMs < cue.endMs &&
+                word.endMs > word.startMs &&
+                word.endMs <= cue.endMs
+        } && wordsAlignWithText(cueText, sorted)
+        return if (hasUsableTimedWords) {
+            sorted
+        } else {
+            estimateWordTimings(cueText, cue.startMs, cue.endMs)
+        }
+    }
+
+    /**
+     * Keeps the collected real/locally-estimated timings when they remain valid
+     * after merging. A final whole-line estimate is only a safety fallback for
+     * malformed overlapping data that cannot be aligned to the visible text.
      */
     private fun timedOrEstimatedWords(
         segmentText: String,
         startMs: Long,
         endMs: Long,
         collectedWords: List<SubtitleWord>,
-        timingsComplete: Boolean,
     ): List<SubtitleWord> {
         val sorted = collectedWords.sortedBy(SubtitleWord::startMs)
-        val hasValidTimedWords = timingsComplete && sorted.isNotEmpty() && sorted.all { word ->
+        val hasValidTimedWords = sorted.isNotEmpty() && sorted.all { word ->
             word.startMs >= startMs &&
                 word.startMs < endMs &&
                 word.endMs > word.startMs &&
@@ -97,8 +112,8 @@ object SubtitleMerger {
     /**
      * True when timed caption chunks can be found in display order and cover
      * enough of the visible text to provide useful karaoke highlighting.
-     * Partial timing payloads from broken auto-captions otherwise leave most of
-     * a line permanently unhighlighted even though the few supplied words match.
+     * Broken partial ASR payloads fall back to local estimates so visible words
+     * do not stay permanently unhighlighted.
      */
     private fun wordsAlignWithText(text: String, words: List<SubtitleWord>): Boolean {
         if (text.isBlank() || words.isEmpty()) return false

--- a/app/src/main/java/com/kienhoang/dualsubreplay/ui/SubtitleWordHighlight.kt
+++ b/app/src/main/java/com/kienhoang/dualsubreplay/ui/SubtitleWordHighlight.kt
@@ -4,7 +4,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
-import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextDecoration
 import com.kienhoang.dualsubreplay.data.SubtitleSegment
 import com.kienhoang.dualsubreplay.data.SubtitleWord
 
@@ -35,7 +35,7 @@ internal fun subtitleWordSpans(text: String, words: List<SubtitleWord>): List<Su
     return spans
 }
 
-/** Renders the original line with the currently spoken word tinted. */
+/** Renders the original line with the currently spoken word tinted and underlined. */
 internal fun annotatedSpokenText(
     segment: SubtitleSegment,
     activeWordIndex: Int,
@@ -50,7 +50,10 @@ internal fun annotatedSpokenText(
     return buildAnnotatedString {
         append(text)
         addStyle(
-            SpanStyle(color = highlightColor, fontWeight = FontWeight.ExtraBold),
+            SpanStyle(
+                color = highlightColor,
+                textDecoration = TextDecoration.Underline,
+            ),
             span.start,
             span.end,
         )

--- a/app/src/test/java/com/kienhoang/dualsubreplay/data/CaptionDocumentParserTest.kt
+++ b/app/src/test/java/com/kienhoang/dualsubreplay/data/CaptionDocumentParserTest.kt
@@ -57,6 +57,25 @@ class CaptionDocumentParserTest {
         assertEquals(3_000L, cue.words[1].endMs)
     }
 
+    @Test fun json3MultiWordChunksExpandToIndividualWords() {
+        val json = """
+            {"events":[
+              {"tStartMs":1000,"dDurationMs":2400,"segs":[
+                {"utf8":"limits is really ","tOffsetMs":0},
+                {"utf8":"the basis","tOffsetMs":1200}
+              ]}
+            ]}
+        """.trimIndent()
+
+        val words = CaptionDocumentParser.parse(json).single().words
+
+        assertEquals(listOf("limits", "is", "really", "the", "basis"), words.map { it.text })
+        assertEquals(1_000L, words.first().startMs)
+        assertEquals(2_200L, words[3].startMs)
+        assertEquals(3_400L, words.last().endMs)
+        assertTrue(words.zipWithNext().all { (left, right) -> left.startMs <= right.startMs })
+    }
+
     @Test fun srv3WordOffsetsProduceTimings() {
         val xml = """
             <timedtext><body>
@@ -70,6 +89,21 @@ class CaptionDocumentParserTest {
         assertEquals(2_200L, words[0].startMs)
         assertEquals(2_800L, words[1].startMs)
         assertEquals(4_000L, words[2].endMs)
+    }
+
+    @Test fun srv3MultiWordChunksExpandInsideRealAnchors() {
+        val xml = """
+            <timedtext><body>
+              <p t="1000" d="2000"><s t="0">we are really </s><s t="1000">ready now</s></p>
+            </body></timedtext>
+        """.trimIndent()
+
+        val words = CaptionDocumentParser.parse(xml).single().words
+
+        assertEquals(listOf("we", "are", "really", "ready", "now"), words.map { it.text })
+        assertEquals(1_000L, words.first().startMs)
+        assertEquals(2_000L, words[3].startMs)
+        assertEquals(3_000L, words.last().endMs)
     }
 
     @Test fun legacyXmlHasNoWordTimings() {

--- a/app/src/test/java/com/kienhoang/dualsubreplay/data/SubtitleMergerTest.kt
+++ b/app/src/test/java/com/kienhoang/dualsubreplay/data/SubtitleMergerTest.kt
@@ -98,7 +98,7 @@ class SubtitleMergerTest {
         assertEquals(2_000L, merged.words.last().endMs)
     }
 
-    @Test fun estimatesWholeMergedSegmentWhenAnyCueHasNoWordTimings() {
+    @Test fun keepsRealTimingWhenNeighborCueNeedsEstimatedWords() {
         val merged = SubtitleMerger.merge(
             listOf(
                 RawCaptionCue(
@@ -112,7 +112,8 @@ class SubtitleMergerTest {
         ).single()
 
         assertEquals(listOf("Hello", "world"), merged.words.map { it.text })
-        assertEquals(0L, merged.words.first().startMs)
+        assertEquals(250L, merged.words.first().startMs)
+        assertEquals(1_000L, merged.words[1].startMs)
         assertEquals(2_000L, merged.words.last().endMs)
     }
 

--- a/app/src/test/java/com/kienhoang/dualsubreplay/data/WordTimingTest.kt
+++ b/app/src/test/java/com/kienhoang/dualsubreplay/data/WordTimingTest.kt
@@ -82,6 +82,33 @@ class WordTimingTest {
         assertEquals(2_200L, segments.single().words[2].startMs)
     }
 
+    @Test fun mergerKeepsGoodAnchorsWhenNeighborCueHasNoTimings() {
+        val cues = listOf(
+            RawCaptionCue(
+                startMs = 1_000,
+                endMs = 2_000,
+                text = "Hello world",
+                words = listOf(
+                    SubtitleWord("Hello", 1_000, 1_350),
+                    SubtitleWord("world", 1_350, 2_000),
+                ),
+            ),
+            RawCaptionCue(
+                startMs = 2_200,
+                endMs = 3_200,
+                text = "missing timing",
+            ),
+        )
+
+        val words = SubtitleMerger.merge(cues).single().words
+
+        assertEquals(listOf("Hello", "world", "missing", "timing"), words.map { it.text })
+        assertEquals(1_000L, words[0].startMs)
+        assertEquals(1_350L, words[1].startMs)
+        assertEquals(2_200L, words[2].startMs)
+        assertEquals(3_200L, words.last().endMs)
+    }
+
     @Test fun mergerFallsBackToEstimatesWhenTimingsAreMissing() {
         val cues = listOf(
             RawCaptionCue(startMs = 0, endMs = 1_000, text = "No timings here"),

--- a/app/src/test/java/com/kienhoang/dualsubreplay/ui/SubtitleHighlightTest.kt
+++ b/app/src/test/java/com/kienhoang/dualsubreplay/ui/SubtitleHighlightTest.kt
@@ -1,5 +1,7 @@
 package com.kienhoang.dualsubreplay.ui
 
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextDecoration
 import com.kienhoang.dualsubreplay.data.SubtitleSegment
 import com.kienhoang.dualsubreplay.data.SubtitleWord
 import org.junit.Assert.assertEquals
@@ -50,6 +52,31 @@ class SubtitleWordHighlightTest {
 
         assertEquals(listOf(1, 2, 3), spans.map { it.wordIndex })
         assertEquals("changes", "changes being applied on web".substring(spans[0].start, spans[0].end))
+    }
+
+    @Test fun spokenWordUsesColorAndUnderlineWithoutBold() {
+        val segment = SubtitleSegment(
+            id = 1,
+            startMs = 0,
+            endMs = 1_000,
+            originalText = "really useful",
+            words = listOf(
+                SubtitleWord("really", 0, 500),
+                SubtitleWord("useful", 500, 1_000),
+            ),
+        )
+
+        val annotated = annotatedSpokenText(
+            segment = segment,
+            activeWordIndex = 0,
+            baseColor = Color.White,
+            highlightColor = Color.Yellow,
+        )
+        val style = annotated.spanStyles.single().item
+
+        assertEquals(Color.Yellow, style.color)
+        assertEquals(TextDecoration.Underline, style.textDecoration)
+        assertEquals(null, style.fontWeight)
     }
 
     @Test fun returnsEmptyWithoutWordsOrText() {


### PR DESCRIPTION
## Summary
- preserve YouTube json3/srv3 timing anchors while expanding multi-word ASR chunks into individual words
- keep good real word timings when a neighboring auto-caption cue is missing or malformed, estimating only the bad cue instead of the whole merged subtitle
- change the active-word style to highlight color + underline only (no bold), avoiding text reflow/jitter
- add unit coverage for multi-word auto-caption chunks, mixed real/estimated timing, and non-bold underline styling

## Why
Auto-generated YouTube captions are not always clean one-word-per-segment data. Some timed chunks contain multiple words, and one malformed/missing cue previously caused accurate timing from surrounding cues to be discarded. This PR keeps as much real ASR timing as possible while retaining safe local fallbacks.

## Testing
CI should run the existing Android/unit test workflow for this PR.