### PR TITLE
ci: reuse PR verification and slim main publishing

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,14 +1,16 @@
 name: Android build and releases
 
 on:
-  push:
-    branches: [main]
-    tags: ["v*"]
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
 
 permissions:
   contents: read
+
+concurrency:
+  group: android-ci-${{ github.event.pull_request.number || github.ref_name }}
+  cancel-in-progress: true
 
 jobs:
   verify-build:
@@ -51,7 +53,7 @@ jobs:
           preview_version_code=$(( $(date -u +%s) - 1700000000 ))
           bash ./gradlew testDebugUnitTest lintDebug assembleDebug assembleDebugAndroidTest \
             -PpreviewVersionCode="$preview_version_code" \
-            -PpreviewVersionNameSuffix="-ci-build${GITHUB_RUN_NUMBER}" \
+            -PpreviewVersionNameSuffix="-pr${{ github.event.pull_request.number || 'manual' }}-build${GITHUB_RUN_NUMBER}" \
             -PpreviewApplicationIdSuffix=".preview" \
             --stacktrace
 
@@ -67,12 +69,13 @@ jobs:
       - name: Name preview APK
         run: cp app/build/outputs/apk/debug/app-debug.apk DualSub-Replay-preview.apk
 
-      - name: Upload APK artifact
+      - name: Upload verified preview APK
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: DualSub-Replay-preview
           path: DualSub-Replay-preview.apk
           if-no-files-found: error
+          retention-days: 7
 
   managed-device-tests:
     needs: verify-build
@@ -122,161 +125,3 @@ jobs:
             app/build/reports/androidTests/managedDevice/
             app/build/outputs/androidTest-results/managedDevice/
           if-no-files-found: warn
-
-  publish-preview:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    needs: [verify-build, managed-device-tests]
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    permissions:
-      contents: write
-
-    steps:
-      - name: Download verified preview APK
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
-        with:
-          name: DualSub-Replay-preview
-          path: release
-
-      - name: Remove obsolete preview APKs
-        continue-on-error: true
-        env:
-          GH_TOKEN: ${{ github.token }}
-          GH_REPO: ${{ github.repository }}
-        run: |
-          gh release delete-asset preview DualSub-Replay-v0.2.1-preview.apk --yes || true
-          gh release delete-asset preview DualSub-Replay-v0.2.2-preview.apk --yes || true
-          gh release delete-asset preview DualSub-Replay-v0.2.3-preview.apk --yes || true
-          gh release delete-asset preview DualSub-Replay-v0.2.4-preview.apk --yes || true
-          gh release delete-asset preview DualSub-Replay-v0.2.5-preview.apk --yes || true
-          gh release delete-asset preview DualSub-Replay-v0.2.6-preview.apk --yes || true
-          gh release delete-asset preview DualSub-Replay-v0.2.7-preview.apk --yes || true
-          gh release delete-asset preview DualSub-Replay-v0.2.8-preview.apk --yes || true
-          gh release delete-asset preview DualSub-Replay-v0.3.0-preview.apk --yes || true
-          gh release delete-asset preview DualSub-Replay-v0.3.1-preview.apk --yes || true
-          gh release delete-asset preview DualSub-Replay-v0.3.2-preview.apk --yes || true
-          gh release delete-asset preview DualSub-Replay-v0.3.3-preview.apk --yes || true
-          gh release delete-asset preview DualSub-Replay-v0.3.4-preview.apk --yes || true
-          gh release delete-asset preview DualSub-Replay-v0.4.0-preview.apk --yes || true
-          gh release delete-asset preview DualSub-Replay-v0.5.0-preview.apk --yes || true
-          gh release delete-asset preview DualSub-Replay-v0.6.0-preview.apk --yes || true
-          gh release delete-asset preview DualSub-Replay-v0.7.0-preview.apk --yes || true
-          gh release delete-asset preview DualSub-Replay-v0.8.0-preview.apk --yes || true
-          gh release delete-asset preview DualSub-Replay-v0.9.0-preview.apk --yes || true
-          gh release delete-asset preview DualSub-Replay-v0.9.1-preview.apk --yes || true
-
-      - name: Publish rolling preview release
-        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
-        with:
-          tag_name: preview
-          name: DualSub Replay preview
-          prerelease: true
-          make_latest: false
-          body: |
-            Testing build from the latest verified `main` commit.
-
-            Most people should install the [latest official release](https://github.com/${{ github.repository }}/releases/latest) instead.
-
-            Preview APKs install as **DualSub Replay Preview** with a separate Android package id, so they can coexist with the official app and no longer require reinstalling or uninstalling the production build.
-          files: release/DualSub-Replay-preview.apk
-          overwrite_files: true
-
-  publish-release:
-    if: startsWith(github.ref, 'refs/tags/v')
-    needs: [verify-build, managed-device-tests]
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    permissions:
-      contents: write
-
-    steps:
-      - name: Check out tagged source
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
-        with:
-          persist-credentials: false
-
-      - name: Set up Java 17
-        uses: actions/setup-java@cf277c60eb25467037889841efdb72551f06f6c3 # v4
-        with:
-          distribution: temurin
-          java-version: "17"
-
-      - name: Set up Android SDK
-        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3
-
-      - name: Install Android build SDK
-        run: sdkmanager "platforms;android-36" "build-tools;36.0.0"
-
-      - name: Set up Gradle cache
-        uses: gradle/actions/setup-gradle@0b6dd653ba04f4f93bf581ec31e66cbd7dcb644d # v4
-
-      - name: Require tag to match the app version
-        run: |
-          tag_version="${GITHUB_REF_NAME#v}"
-          app_version="$(sed -n 's/^val appVersionName = "\([^"]*\)".*/\1/p' app/build.gradle.kts | head -n 1)"
-          if [ -z "$app_version" ] || [ "$tag_version" != "$app_version" ]; then
-            echo "Tag $GITHUB_REF_NAME does not match app version $app_version" >&2
-            exit 1
-          fi
-
-      - name: Restore production signing key
-        env:
-          ANDROID_RELEASE_KEYSTORE_BASE64: ${{ secrets.ANDROID_RELEASE_KEYSTORE_BASE64 }}
-        run: |
-          if [ -z "$ANDROID_RELEASE_KEYSTORE_BASE64" ]; then
-            echo "ANDROID_RELEASE_KEYSTORE_BASE64 is not configured" >&2
-            exit 1
-          fi
-          printf '%s' "$ANDROID_RELEASE_KEYSTORE_BASE64" | base64 --decode > "$RUNNER_TEMP/dual-sub-replay-release.jks"
-          chmod 600 "$RUNNER_TEMP/dual-sub-replay-release.jks"
-
-      - name: Build production release APK
-        env:
-          ANDROID_RELEASE_STORE_FILE: ${{ runner.temp }}/dual-sub-replay-release.jks
-          ANDROID_RELEASE_STORE_PASSWORD: ${{ secrets.ANDROID_RELEASE_STORE_PASSWORD }}
-          ANDROID_RELEASE_KEY_ALIAS: ${{ secrets.ANDROID_RELEASE_KEY_ALIAS }}
-          ANDROID_RELEASE_KEY_PASSWORD: ${{ secrets.ANDROID_RELEASE_KEY_PASSWORD }}
-        run: bash ./gradlew assembleRelease -PrequireReleaseSigning=true --stacktrace
-
-      - name: Verify and package official APK
-        run: |
-          source_apk="app/build/outputs/apk/release/app-release.apk"
-          release_apk="release/DualSub-Replay.apk"
-          mkdir -p release
-          cp "$source_apk" "$release_apk"
-          "$ANDROID_HOME/build-tools/36.0.0/apksigner" verify --verbose --print-certs "$release_apk" | tee release/signing-report.txt
-          if grep -q 'CN=Android Debug' release/signing-report.txt; then
-            echo "Official APK was signed with the Android debug certificate" >&2
-            exit 1
-          fi
-          "$ANDROID_HOME/build-tools/36.0.0/aapt" dump badging "$release_apk" | head -n 1
-          sha256sum "$release_apk" | sed 's#  release/#  #' > release/DualSub-Replay.apk.sha256
-
-      - name: Publish official GitHub release
-        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
-        with:
-          name: DualSub Replay ${{ github.ref_name }}
-          prerelease: false
-          make_latest: true
-          fail_on_unmatched_files: true
-          body: |
-            ## Download and install
-
-            Download **DualSub-Replay.apk** below. On Android 8.0 or newer, open the downloaded file and allow your browser or file manager to install unknown apps if Android asks.
-
-            Preview builds now install separately as **DualSub Replay Preview**, so installing an official release does not require removing the preview app.
-
-            ## v0.9.5 highlights
-
-            - Adds Adaptive spoken-word timing for eligible YouTube auto-generated captions by mapping live rendered caption words onto the app's transcript.
-            - Adds strict Live YouTube captions and always-available Transcript timing choices in subtitle settings.
-            - Keeps manual captions and videos without a reliable live word signal on transcript timing, with a safe Adaptive fallback.
-            - Preserves the single-WebView architecture, trusted HTTPS YouTube origin checks, and persisted/resettable subtitle settings.
-            - Expands unit, Compose UI, architecture, and WebView lifecycle coverage for live caption capture and karaoke mapping.
-
-            Live timing depends on YouTube's webpage caption rendering and can vary by video, device, and WebView version. Unsupported cases continue using transcript timing.
-
-            The `.sha256` file can be used to verify the APK download.
-          files: |
-            release/DualSub-Replay.apk
-            release/DualSub-Replay.apk.sha256

--- a/.github/workflows/pr-preview-auto.yml
+++ b/.github/workflows/pr-preview-auto.yml
@@ -1,123 +1,85 @@
 name: Automatic PR preview APK
 
 on:
+  workflow_run:
+    workflows: ["Android build and releases"]
+    types: [completed]
   pull_request:
-    types: [opened, synchronize, reopened, closed]
-  workflow_dispatch:
+    types: [closed]
 
 permissions:
   contents: read
 
 concurrency:
-  group: pr-preview-${{ github.head_ref || github.ref_name }}
+  group: pr-preview-${{ github.event.workflow_run.id || github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 jobs:
-  build-pr-preview:
+  publish-pr-preview:
     if: >-
-      github.event_name != 'pull_request' ||
-      (github.event.action != 'closed' &&
-      github.event.pull_request.head.repo.full_name == github.repository)
+      github.event_name == 'workflow_run' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.pull_requests[0].number != null
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 10
     permissions:
+      actions: read
       contents: write
       pull-requests: read
 
     steps:
-      - name: Check out source
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
-        with:
-          persist-credentials: false
-
-      - name: Resolve open PR number
+      - name: Verify the source PR is still open and trusted
         id: pr
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
-          EVENT_NAME: ${{ github.event_name }}
-          EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
         run: |
           set -euo pipefail
+          pr_json="$(gh api "repos/${GH_REPO}/pulls/${PR_NUMBER}")"
+          state="$(jq -r '.state' <<< "$pr_json")"
+          head_repo="$(jq -r '.head.repo.full_name' <<< "$pr_json")"
 
-          if [[ "$EVENT_NAME" == "pull_request" ]]; then
-            pr_number="$EVENT_PR_NUMBER"
-          else
-            pr_number="$(gh pr list --head "$GITHUB_REF_NAME" --state open --json number --jq '.[0].number // empty')"
+          if [[ "$state" != "open" ]]; then
+            echo "PR #$PR_NUMBER is $state; skipping stale preview upload."
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
-
-          if [[ -z "$pr_number" ]]; then
-            echo "No open PR found for $GITHUB_REF_NAME; skipping preview build."
-            echo "found=false" >> "$GITHUB_OUTPUT"
+          if [[ "$head_repo" != "$GH_REPO" ]]; then
+            echo "PR #$PR_NUMBER comes from $head_repo; refusing to publish an untrusted preview."
+            echo "publish=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          echo "Resolved PR #$pr_number"
-          echo "found=true" >> "$GITHUB_OUTPUT"
-          echo "number=$pr_number" >> "$GITHUB_OUTPUT"
+          echo "publish=true" >> "$GITHUB_OUTPUT"
+          echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
 
-      - name: Set up Java 17
-        if: steps.pr.outputs.found == 'true'
-        uses: actions/setup-java@cf277c60eb25467037889841efdb72551f06f6c3 # v4
+      - name: Download the APK produced by full PR CI
+        if: steps.pr.outputs.publish == 'true'
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
-          distribution: temurin
-          java-version: "17"
+          name: DualSub-Replay-preview
+          path: verified
+          github-token: ${{ github.token }}
+          run-id: ${{ github.event.workflow_run.id }}
 
-      - name: Set up Android SDK
-        if: steps.pr.outputs.found == 'true'
-        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3
-
-      - name: Install Android build SDK
-        if: steps.pr.outputs.found == 'true'
-        run: sdkmanager "platforms;android-36" "build-tools;36.0.0"
-
-      - name: Set up Gradle cache
-        if: steps.pr.outputs.found == 'true'
-        uses: gradle/actions/setup-gradle@0b6dd653ba04f4f93bf581ec31e66cbd7dcb644d # v4
-
-      - name: Restore persistent preview signing key
-        if: steps.pr.outputs.found == 'true'
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
-        with:
-          path: ~/.android/debug.keystore
-          key: dual-sub-replay-preview-signing-v1
-
-      - name: Test, lint, and build PR preview
-        if: steps.pr.outputs.found == 'true'
-        env:
-          PR_NUMBER: ${{ steps.pr.outputs.number }}
-          BUILD_NUMBER: ${{ github.run_number }}
-        run: |
-          set -euo pipefail
-          preview_version_code=$(( $(date -u +%s) - 1700000000 ))
-          bash ./gradlew testDebugUnitTest lintDebug assembleDebug \
-            -PpreviewVersionCode="$preview_version_code" \
-            -PpreviewVersionNameSuffix="-pr${PR_NUMBER}-build${BUILD_NUMBER}" \
-            -PpreviewApplicationIdSuffix=".preview" \
-            --stacktrace
-
-      - name: Package versioned PR preview APK
-        if: steps.pr.outputs.found == 'true'
+      - name: Package the versioned PR preview APK
+        if: steps.pr.outputs.publish == 'true'
         id: package
         env:
           PR_NUMBER: ${{ steps.pr.outputs.number }}
-          BUILD_NUMBER: ${{ github.run_number }}
+          BUILD_NUMBER: ${{ github.event.workflow_run.run_number }}
         run: |
           set -euo pipefail
           mkdir -p release
           asset_name="DualSub-Replay-PR${PR_NUMBER}-build${BUILD_NUMBER}-preview.apk"
-          cp app/build/outputs/apk/debug/app-debug.apk "release/$asset_name"
-          badging="$("$ANDROID_HOME/build-tools/36.0.0/aapt" dump badging "release/$asset_name" | head -n 1)"
-          echo "$badging"
-          if [[ "$badging" != *"name='com.kienhoang.dualsubreplay.preview'"* ]]; then
-            echo "Preview APK does not use the isolated preview application id" >&2
-            exit 1
-          fi
+          cp verified/DualSub-Replay-preview.apk "release/$asset_name"
           sha256sum "release/$asset_name"
           echo "asset_name=$asset_name" >> "$GITHUB_OUTPUT"
 
       - name: Upload newest PR preview to rolling preview release
-        if: steps.pr.outputs.found == 'true'
+        if: steps.pr.outputs.publish == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
@@ -125,15 +87,6 @@ jobs:
           ASSET_NAME: ${{ steps.package.outputs.asset_name }}
         run: |
           set -euo pipefail
-
-          pr_state="$(gh pr view "$PR_NUMBER" --json state --jq '.state')"
-          if [[ "$pr_state" != "OPEN" ]]; then
-            echo "PR #$PR_NUMBER is $pr_state; skipping stale preview upload."
-            exit 0
-          fi
-
-          # Remove older previews for this PR so the release always exposes one
-          # clearly versioned APK. This also avoids stale same-URL browser/CDN caches.
           assets="$(gh release view preview --json assets --jq '.assets[].name' || true)"
           while IFS= read -r asset; do
             [[ -z "$asset" ]] && continue
@@ -144,7 +97,7 @@ jobs:
           done <<< "$assets"
 
           gh release upload preview "release/$ASSET_NAME" --clobber
-          echo "Published $ASSET_NAME"
+          echo "Published $ASSET_NAME from the already-verified CI artifact."
 
   cleanup-pr-preview:
     if: >-
@@ -164,7 +117,6 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set -euo pipefail
-
           assets="$(gh release view preview --json assets --jq '.assets[].name' || true)"
           removed=false
           while IFS= read -r asset; do

--- a/.github/workflows/release-on-main.yml
+++ b/.github/workflows/release-on-main.yml
@@ -1,27 +1,27 @@
 name: Publish new main version
 
 on:
-  workflow_run:
-    workflows: ["Android build and releases"]
-    types: [completed]
+  push:
+    branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: write
 
+concurrency:
+  group: publish-main
+  cancel-in-progress: false
+
 jobs:
-  publish-new-version:
-    if: >-
-      github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.event == 'push' &&
-      github.event.workflow_run.head_branch == 'main'
+  publish-main:
+    if: github.event_name == 'push' || github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
 
     steps:
-      - name: Check out verified main commit
+      - name: Check out main commit
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
-          ref: ${{ github.event.workflow_run.head_sha }}
           persist-credentials: false
 
       - name: Determine whether this version is new
@@ -29,8 +29,9 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          set -euo pipefail
           version="$(sed -n 's/^val appVersionName = "\([^"]*\)".*/\1/p' app/build.gradle.kts | head -n 1)"
-          if [ -z "$version" ]; then
+          if [[ -z "$version" ]]; then
             echo "Could not determine app version" >&2
             exit 1
           fi
@@ -46,30 +47,72 @@ jobs:
           fi
 
       - name: Set up Java 17
-        if: steps.release_meta.outputs.release_needed == 'true'
         uses: actions/setup-java@cf277c60eb25467037889841efdb72551f06f6c3 # v4
         with:
           distribution: temurin
           java-version: "17"
 
       - name: Set up Android SDK
-        if: steps.release_meta.outputs.release_needed == 'true'
         uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3
 
       - name: Install Android build SDK
-        if: steps.release_meta.outputs.release_needed == 'true'
         run: sdkmanager "platforms;android-36" "build-tools;36.0.0"
 
       - name: Set up Gradle cache
-        if: steps.release_meta.outputs.release_needed == 'true'
         uses: gradle/actions/setup-gradle@0b6dd653ba04f4f93bf581ec31e66cbd7dcb644d # v4
+
+      - name: Restore persistent preview signing key
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ~/.android/debug.keystore
+          key: dual-sub-replay-preview-signing-v1
+
+      - name: Build main preview APK without repeating PR tests
+        run: |
+          set -euo pipefail
+          preview_version_code=$(( $(date -u +%s) - 1700000000 ))
+          bash ./gradlew assembleDebug \
+            -PpreviewVersionCode="$preview_version_code" \
+            -PpreviewVersionNameSuffix="-main-build${GITHUB_RUN_NUMBER}" \
+            -PpreviewApplicationIdSuffix=".preview" \
+            --stacktrace
+
+      - name: Verify and package main preview APK
+        run: |
+          set -euo pipefail
+          mkdir -p release
+          preview_apk="release/DualSub-Replay-preview.apk"
+          cp app/build/outputs/apk/debug/app-debug.apk "$preview_apk"
+          badging="$("$ANDROID_HOME/build-tools/36.0.0/aapt" dump badging "$preview_apk" | head -n 1)"
+          echo "$badging"
+          if [[ "$badging" != *"name='com.kienhoang.dualsubreplay.preview'"* ]]; then
+            echo "Preview APK does not use the isolated preview application id" >&2
+            exit 1
+          fi
+          sha256sum "$preview_apk"
+
+      - name: Publish rolling main preview
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
+        with:
+          tag_name: preview
+          name: DualSub Replay preview
+          prerelease: true
+          make_latest: false
+          body: |
+            Testing build from the latest PR-verified `main` commit.
+
+            Most people should install the [latest official release](https://github.com/${{ github.repository }}/releases/latest) instead.
+
+            Preview APKs install as **DualSub Replay Preview** with a separate Android package id, so they can coexist with the official app.
+          files: release/DualSub-Replay-preview.apk
+          overwrite_files: true
 
       - name: Restore production signing key
         if: steps.release_meta.outputs.release_needed == 'true'
         env:
           ANDROID_RELEASE_KEYSTORE_BASE64: ${{ secrets.ANDROID_RELEASE_KEYSTORE_BASE64 }}
         run: |
-          if [ -z "$ANDROID_RELEASE_KEYSTORE_BASE64" ]; then
+          if [[ -z "$ANDROID_RELEASE_KEYSTORE_BASE64" ]]; then
             echo "ANDROID_RELEASE_KEYSTORE_BASE64 is not configured" >&2
             exit 1
           fi
@@ -88,9 +131,9 @@ jobs:
       - name: Verify and package official APK
         if: steps.release_meta.outputs.release_needed == 'true'
         run: |
+          set -euo pipefail
           source_apk="app/build/outputs/apk/release/app-release.apk"
           release_apk="release/DualSub-Replay.apk"
-          mkdir -p release
           cp "$source_apk" "$release_apk"
           "$ANDROID_HOME/build-tools/36.0.0/apksigner" verify --verbose --print-certs "$release_apk" | tee release/signing-report.txt
           if grep -q 'CN=Android Debug' release/signing-report.txt; then
@@ -105,7 +148,7 @@ jobs:
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           tag_name: ${{ steps.release_meta.outputs.tag }}
-          target_commitish: ${{ github.event.workflow_run.head_sha }}
+          target_commitish: ${{ github.sha }}
           name: DualSub Replay ${{ steps.release_meta.outputs.tag }}
           prerelease: false
           make_latest: true


### PR DESCRIPTION
## What changes

- runs the full Android unit, lint, build, and API 36 managed-device checks on pull requests only
- publishes each PR preview from the APK already produced by the successful full-CI run
- stops repeating unit, lint, and emulator tests after merging to `main`
- keeps post-merge work limited to building the rolling preview and building, signing, verifying, and publishing a new official version
- removes the duplicate tag-triggered verification/release path

## Merge behavior

This PR does **not** enable auto-merge. It remains open after checks pass until it is manually reviewed and merged.

## Required repository settings

Protect `main`, require `verify-build` and `managed-device-tests`, require the branch to be up to date before merging, and require changes to arrive through a pull request.