### PR TITLE
Fix unresponsive YouTube controls in fullscreen

### DIFF
--- a/app/src/androidTest/java/com/kienhoang/dualsubreplay/ui/BrowseWebViewLifecycleTest.kt
+++ b/app/src/androidTest/java/com/kienhoang/dualsubreplay/ui/BrowseWebViewLifecycleTest.kt
@@ -192,6 +192,65 @@ class BrowseWebViewLifecycleTest {
         instrumentation.runOnMainSync { webView.destroySafely() }
     }
 
+    @Test
+    fun liveCaptionPollingDoesNotRepeatedlyClickMobileCaptionControl() {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val pageLoaded = CountDownLatch(1)
+        lateinit var webView: WebView
+
+        instrumentation.runOnMainSync {
+            webView = WebView(instrumentation.targetContext).apply {
+                settings.javaScriptEnabled = true
+                webViewClient = object : WebViewClient() {
+                    override fun onPageFinished(view: WebView, url: String?) {
+                        pageLoaded.countDown()
+                    }
+                }
+                loadDataWithBaseURL(
+                    "https://m.youtube.com/watch?v=controltest1",
+                    """
+                    <!doctype html>
+                    <html><body>
+                      <video id="native-video"></video>
+                      <button class="ytmClosedCaptioningButtonButton">CC</button>
+                      <button id="settings">Settings</button>
+                      <script>
+                        const video = document.getElementById('native-video');
+                        Object.defineProperty(video, 'currentTime', {
+                          configurable: true,
+                          get: function() { return 3.5; }
+                        });
+                        window.captionClicks = 0;
+                        window.settingsOpen = false;
+                        document.querySelector('.ytmClosedCaptioningButtonButton').onclick = function() {
+                          window.captionClicks += 1;
+                          window.settingsOpen = false;
+                        };
+                        document.getElementById('settings').onclick = function() {
+                          window.settingsOpen = true;
+                        };
+                      </script>
+                    </body></html>
+                    """.trimIndent(),
+                    "text/html",
+                    "UTF-8",
+                    null,
+                )
+            }
+        }
+
+        assertTrue("Live-caption control fixture did not load", pageLoaded.await(10, TimeUnit.SECONDS))
+        assertEquals("true", evaluateJavascript(webView, webLiveCaptionConfigurationScript(enabled = true)))
+        repeat(3) { evaluateJavascript(webView, WEB_PLAYBACK_SNAPSHOT_SCRIPT) }
+        evaluateJavascript(webView, "document.getElementById('settings').click()")
+        repeat(3) { evaluateJavascript(webView, WEB_PLAYBACK_SNAPSHOT_SCRIPT) }
+
+        assertEquals("1", evaluateJavascript(webView, "window.captionClicks"))
+        assertEquals("true", evaluateJavascript(webView, "window.settingsOpen"))
+
+        instrumentation.runOnMainSync { webView.destroySafely() }
+    }
+
     private fun evaluateJavascript(webView: WebView, script: String): String? {
         val instrumentation = InstrumentationRegistry.getInstrumentation()
         val result = AtomicReference<String?>()

--- a/app/src/main/java/com/kienhoang/dualsubreplay/ui/LearningPlayerRoot.kt
+++ b/app/src/main/java/com/kienhoang/dualsubreplay/ui/LearningPlayerRoot.kt
@@ -69,7 +69,7 @@ internal const val OVERLAY_VERTICAL_POSITION_PREFERENCE = "overlay_vertical_posi
 internal const val OVERLAY_HORIZONTAL_POSITION_PREFERENCE = "overlay_horizontal_position"
 internal const val MOVABLE_OVERLAY_PREFERENCE = "movable_subtitle_box"
 internal const val DEFAULT_OVERLAY_VERTICAL_POSITION = 0.86f
-internal const val FULLSCREEN_LANDSCAPE_DEFAULT_OVERLAY_VERTICAL_POSITION = 0.08f
+internal const val FULLSCREEN_LANDSCAPE_DEFAULT_OVERLAY_VERTICAL_POSITION = 0.72f
 internal const val DEFAULT_OVERLAY_HORIZONTAL_POSITION = 0.5f
 internal const val FULLSCREEN_OVERLAY_ESTIMATED_HEIGHT_DP = 88
 internal const val PLAYER_CONTROLS_AVOIDANCE_LIFT_DP = 88
@@ -87,8 +87,8 @@ internal fun normalizeOverlayVerticalPosition(value: Float): Float =
     if (value.isFinite()) value.coerceIn(0f, 1f) else DEFAULT_OVERLAY_VERTICAL_POSITION
 
 /**
- * The regular overlay keeps its lower default, while fullscreen landscape starts
- * near the top unless the user has moved it away from that default.
+ * The regular overlay keeps its lower default. Fullscreen landscape stays somewhat higher
+ * to leave room for YouTube's bottom controls, but it no longer starts in the top control band.
  */
 internal fun fullscreenOverlayVerticalPosition(
     position: Float,
@@ -439,7 +439,7 @@ fun LearningPlayerRoot(viewModel: AppViewModel) {
         position = overlayVerticalPosition,
         orientation = configuration.orientation,
     )
-    // Fullscreen landscape defaults close to the top and still keeps the whole box on-screen.
+    // Keep the default fullscreen overlay below YouTube's top control strip.
     val fullscreenBottomPadding = fullscreenOverlayBottomPaddingWithControlsDp(
         position = fullscreenVerticalPosition,
         screenHeightDp = configuration.screenHeightDp,

--- a/app/src/main/java/com/kienhoang/dualsubreplay/ui/MovableSubtitleFab.kt
+++ b/app/src/main/java/com/kienhoang/dualsubreplay/ui/MovableSubtitleFab.kt
@@ -39,7 +39,8 @@ internal const val COLLAPSED_CC_HORIZONTAL_POSITION_PREFERENCE = "collapsed_cc_h
 internal const val COLLAPSED_CC_VERTICAL_POSITION_PREFERENCE = "collapsed_cc_vertical_position"
 internal const val DEFAULT_COLLAPSED_CC_HORIZONTAL_POSITION = 1f
 internal const val DEFAULT_COLLAPSED_CC_VERTICAL_POSITION = 0.72f
-internal const val FULLSCREEN_LANDSCAPE_DEFAULT_COLLAPSED_CC_VERTICAL_POSITION = 0.08f
+// Keep the fullscreen FAB higher than normal without covering YouTube's top-right controls.
+internal const val FULLSCREEN_LANDSCAPE_DEFAULT_COLLAPSED_CC_VERTICAL_POSITION = 0.50f
 private const val COLLAPSED_CC_MARGIN_DP = 16
 
 internal fun normalizeControlPosition(value: Float, fallback: Float = 1f): Float =

--- a/app/src/main/java/com/kienhoang/dualsubreplay/ui/YouTubeBrowserScreen.kt
+++ b/app/src/main/java/com/kienhoang/dualsubreplay/ui/YouTubeBrowserScreen.kt
@@ -287,6 +287,7 @@ internal fun webLiveCaptionConfigurationScript(enabled: Boolean): String {
             captionMediaSecond: null,
             captionWasEnabled: null,
             enabledByApp: false,
+            captionEnableAttemptUrl: null,
             observer: null
           };
           state.trustedOrigin = function() {
@@ -344,17 +345,28 @@ internal fun webLiveCaptionConfigurationScript(enabled: Boolean): String {
               state.captionWasEnabled = pressed || !!activeTrack;
             }
             if (pressed || activeTrack) return;
-            if (button) {
-              try {
-                button.click();
-                state.enabledByApp = true;
-              } catch (_) {}
-            }
+
+            // Some mobile YouTube controls do not expose aria-pressed. Clicking their CC button on
+            // every 100 ms playback poll toggles captions repeatedly and closes native popups such
+            // as Settings. Attempt activation only once for each SPA page/video instead.
+            const pageUrl = window.location.href;
+            if (state.captionEnableAttemptUrl === pageUrl) return;
             const track = state.availableCaptionTrack(player);
             if (player && track) {
+              state.captionEnableAttemptUrl = pageUrl;
               try {
                 if (typeof player.loadModule === 'function') player.loadModule('captions');
                 player.setOption('captions', 'track', track);
+                state.enabledByApp = true;
+                return;
+              } catch (_) {
+                // Fall through to the mobile caption button when the player API is unavailable.
+              }
+            }
+            if (button) {
+              state.captionEnableAttemptUrl = pageUrl;
+              try {
+                button.click();
                 state.enabledByApp = true;
               } catch (_) {}
             }

--- a/app/src/test/java/com/kienhoang/dualsubreplay/ui/LearningPlayerRootTest.kt
+++ b/app/src/test/java/com/kienhoang/dualsubreplay/ui/LearningPlayerRootTest.kt
@@ -173,7 +173,7 @@ class LearningPlayerRootTest {
     }
 
     @Test
-    fun fullscreenLandscapeStartsNearTheTopButKeepsDraggedPositions() {
+    fun fullscreenLandscapeDefaultStaysBelowTopControlsAndKeepsDraggedPositions() {
         assertEquals(
             FULLSCREEN_LANDSCAPE_DEFAULT_OVERLAY_VERTICAL_POSITION,
             fullscreenOverlayVerticalPosition(
@@ -198,6 +198,10 @@ class LearningPlayerRootTest {
         assertTrue(
             FULLSCREEN_LANDSCAPE_DEFAULT_OVERLAY_VERTICAL_POSITION <
                 DEFAULT_OVERLAY_VERTICAL_POSITION,
+        )
+        assertTrue(
+            "fullscreen default must stay out of YouTube's top control band",
+            FULLSCREEN_LANDSCAPE_DEFAULT_OVERLAY_VERTICAL_POSITION >= 0.60f,
         )
     }
 

--- a/app/src/test/java/com/kienhoang/dualsubreplay/ui/MovableSubtitleFabTest.kt
+++ b/app/src/test/java/com/kienhoang/dualsubreplay/ui/MovableSubtitleFabTest.kt
@@ -13,7 +13,7 @@ class MovableSubtitleFabTest {
         assertEquals(1f, normalizeControlPosition(Float.NaN), 0f)
     }
 
-    @Test fun defaultCcIsHigherAndFullscreenLandscapeStartsNearTheTop() {
+    @Test fun defaultCcStaysHigherWithoutOccupyingFullscreenTopControls() {
         assertEquals(0.72f, DEFAULT_COLLAPSED_CC_VERTICAL_POSITION, 0f)
         assertEquals(
             FULLSCREEN_LANDSCAPE_DEFAULT_COLLAPSED_CC_VERTICAL_POSITION,
@@ -45,6 +45,10 @@ class MovableSubtitleFabTest {
         assertTrue(
             FULLSCREEN_LANDSCAPE_DEFAULT_COLLAPSED_CC_VERTICAL_POSITION <
                 DEFAULT_COLLAPSED_CC_VERTICAL_POSITION,
+        )
+        assertTrue(
+            "fullscreen CC default must stay below YouTube's top-right controls",
+            FULLSCREEN_LANDSCAPE_DEFAULT_COLLAPSED_CC_VERTICAL_POSITION >= 0.40f,
         )
     }
 

--- a/app/src/test/java/com/kienhoang/dualsubreplay/ui/PlaybackArchitectureTest.kt
+++ b/app/src/test/java/com/kienhoang/dualsubreplay/ui/PlaybackArchitectureTest.kt
@@ -193,6 +193,8 @@ class PlaybackArchitectureTest {
         assertTrue(enabled.contains("ytInitialPlayerResponse"))
         assertTrue(enabled.contains("player.loadModule('captions')"))
         assertTrue(enabled.contains("player.setOption('captions', 'track', track)"))
+        assertTrue(enabled.contains("captionEnableAttemptUrl"))
+        assertTrue(enabled.contains("state.captionEnableAttemptUrl === pageUrl"))
         assertTrue(disabled.contains("existing.restoreCaptions()"))
         assertTrue(enabled.contains("requestVideoFrameCallback"))
         assertTrue(enabled.contains("state.ensureCaptions()"))


### PR DESCRIPTION
## Summary

- stop the live-caption poller from synthetically clicking YouTube's mobile CC control every 100 ms when `aria-pressed` is unavailable
- attempt caption activation only once per YouTube SPA page/video, preferring the player API before the mobile-button fallback
- keep the fullscreen dual-subtitle overlay out of YouTube's top control strip by default
- move the collapsed fullscreen CC button away from YouTube's top-right Settings/overflow controls while keeping it higher than its normal position
- add regression coverage for both caption polling and the fullscreen overlay/FAB safe positions

## Root cause

The original PR addressed one real issue: the v0.9.5 live-caption observer could repeatedly click YouTube's CC control. Real-device testing showed that was not the only cause.

The fullscreen UI introduced another direct touch conflict: the expanded dual-subtitle overlay defaulted to vertical position `0.08` (near the top) while occupying roughly 90% of the screen width, and the collapsed CC FAB defaulted to the far right at vertical position `0.08`. Both are interactive Compose surfaces layered above the YouTube WebView, so they could intercept taps intended for YouTube's fullscreen Settings and nearby top-right controls.

The fullscreen defaults now avoid that top control area (`0.72` for the expanded overlay and `0.50` for the collapsed CC FAB). Users can still drag both controls manually.

## Verification

- WebView regression fixture verifies repeated playback polls no longer repeatedly click the mobile caption control
- unit regressions require the fullscreen subtitle overlay and collapsed CC default positions to stay below the top control band
- repository CI runs unit tests, lint, debug build, and API 36 managed-device WebView tests

## Manual verification requested

Install the latest PR preview on a real phone, enter YouTube fullscreen, and confirm Settings plus the neighboring top-right YouTube controls can be opened with both the dual subtitles visible and collapsed.