### PR TITLE
fix: enable playback settings and preserve topbar navigation in fullscreen (#39)

### DIFF
--- a/app/src/main/java/com/kienhoang/dualsubreplay/ui/DualSubApp.kt
+++ b/app/src/main/java/com/kienhoang/dualsubreplay/ui/DualSubApp.kt
@@ -1,6 +1,8 @@
 package com.kienhoang.dualsubreplay.ui
 
+import android.content.SharedPreferences
 import android.content.res.Configuration
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.animation.core.animate
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.BorderStroke
@@ -103,6 +105,7 @@ import kotlin.math.roundToInt
 fun DualSubApp(
     viewModel: AppViewModel,
     playerMode: PlayerExperienceMode = PlayerExperienceMode.TRANSCRIPT_PANEL,
+    effectivePlayerMode: PlayerExperienceMode = playerMode,
     onPlayerModeChange: (PlayerExperienceMode) -> Unit = {},
     externalSettingsRequestId: Long = 0L,
     fullscreenLearningOverlay: (@Composable BoxScope.() -> Unit)? = null,
@@ -121,6 +124,7 @@ fun DualSubApp(
             DualSubExperience(
                 state = state,
                 playerMode = playerMode,
+                effectivePlayerMode = effectivePlayerMode,
                 onPlayerModeChange = onPlayerModeChange,
                 externalSettingsRequestId = externalSettingsRequestId,
                 fullscreenLearningOverlay = fullscreenLearningOverlay,
@@ -150,6 +154,7 @@ fun DualSubApp(
 private fun DualSubExperience(
     state: DualSubUiState,
     playerMode: PlayerExperienceMode,
+    effectivePlayerMode: PlayerExperienceMode = playerMode,
     onPlayerModeChange: (PlayerExperienceMode) -> Unit,
     externalSettingsRequestId: Long,
     fullscreenLearningOverlay: (@Composable BoxScope.() -> Unit)?,
@@ -238,7 +243,7 @@ private fun DualSubExperience(
                     onPlaybackSecond = onPlaybackSecond,
                     liveCaptionCaptureEnabled = liveCaptionCaptureEnabled,
                     suppressPageCaptions = liveCaptionCaptureEnabled ||
-                        playerMode == PlayerExperienceMode.SCROLL_FRIENDLY_OVERLAY,
+                        effectivePlayerMode == PlayerExperienceMode.SCROLL_FRIENDLY_OVERLAY,
                     fullscreenOverlay = fullscreenLearningOverlay,
                     modifier = Modifier
                         .weight(if (sideBySide) landscapeVideoFraction else 1f)
@@ -302,7 +307,7 @@ private fun DualSubExperience(
             } else if (
                 !sideBySide &&
                 state.activeVideoId != null &&
-                playerMode == PlayerExperienceMode.TRANSCRIPT_PANEL
+                effectivePlayerMode == PlayerExperienceMode.TRANSCRIPT_PANEL
             ) {
                 MovableSubtitleFab(onClick = onShowSubtitles)
             }
@@ -888,6 +893,30 @@ internal fun SubtitleSettingsDialog(
     }
     var movableSubtitleBox by remember {
         mutableStateOf(preferences.getBoolean(MOVABLE_OVERLAY_PREFERENCE, true))
+    }
+
+    DisposableEffect(preferences) {
+        val listener = SharedPreferences.OnSharedPreferenceChangeListener { sharedPreferences, key ->
+            when (key) {
+                AUTO_OVERLAY_FULLSCREEN_PREFERENCE -> {
+                    autoOverlayFullscreen = sharedPreferences.getBoolean(key, true)
+                }
+                AUTO_OVERLAY_LANDSCAPE_PREFERENCE -> {
+                    autoOverlayLandscape = sharedPreferences.getBoolean(key, true)
+                }
+                AUTO_AVOID_PLAYER_CONTROLS_PREFERENCE -> {
+                    autoAvoidPlayerControls = sharedPreferences.getBoolean(key, true)
+                }
+                REMEMBER_OVERLAY_POSITION_PREFERENCE -> {
+                    rememberOverlayPosition = sharedPreferences.getBoolean(key, true)
+                }
+                MOVABLE_OVERLAY_PREFERENCE -> {
+                    movableSubtitleBox = sharedPreferences.getBoolean(key, true)
+                }
+            }
+        }
+        preferences.registerOnSharedPreferenceChangeListener(listener)
+        onDispose { preferences.unregisterOnSharedPreferenceChangeListener(listener) }
     }
     val sourceChoices = listOf(LanguageChoice("auto", "Auto (recommended)")) +
         availableSourceLanguages.map { LanguageChoice(it.code, it.name) }

--- a/app/src/main/java/com/kienhoang/dualsubreplay/ui/LearningPlayerRoot.kt
+++ b/app/src/main/java/com/kienhoang/dualsubreplay/ui/LearningPlayerRoot.kt
@@ -353,14 +353,17 @@ fun LearningPlayerRoot(viewModel: AppViewModel) {
 
     fun selectMode(newMode: PlayerExperienceMode) {
         mode = newMode
-        preferences.edit()
-  .putString(PLAYER_EXPERIENCE_MODE_PREFERENCE, newMode.storageValue)
-  .apply()
+        val editor = preferences.edit()
+            .putString(PLAYER_EXPERIENCE_MODE_PREFERENCE, newMode.storageValue)
         if (newMode == PlayerExperienceMode.SCROLL_FRIENDLY_OVERLAY) {
-  viewModel.hideSubtitlePanel()
+            viewModel.hideSubtitlePanel()
         } else {
-  viewModel.showSubtitlePanel()
+            autoOverlayLandscape = false
+            editor.putBoolean(AUTO_OVERLAY_LANDSCAPE_PREFERENCE, false)
+            restoreTranscriptAfterAutomaticOverlay = false
+            viewModel.showSubtitlePanel()
         }
+        editor.apply()
     }
 
     fun requestSubtitleSettings() {
@@ -485,11 +488,12 @@ fun LearningPlayerRoot(viewModel: AppViewModel) {
 
     Box(Modifier.fillMaxSize()) {
         DualSubApp(
-  viewModel = viewModel,
-  playerMode = effectiveMode,
-  onPlayerModeChange = ::selectMode,
-  externalSettingsRequestId = settingsRequestId,
-  fullscreenLearningOverlay = fullscreenLearningOverlay,
+            viewModel = viewModel,
+            playerMode = mode,
+            effectivePlayerMode = effectiveMode,
+            onPlayerModeChange = ::selectMode,
+            externalSettingsRequestId = settingsRequestId,
+            fullscreenLearningOverlay = fullscreenLearningOverlay,
         )
 
         if (
@@ -535,11 +539,7 @@ fun LearningPlayerRoot(viewModel: AppViewModel) {
           onPositionChangeFinished = ::commitOverlayPosition,
           onSettings = ::requestSubtitleSettings,
           onClose = {
-              if (mode == PlayerExperienceMode.SCROLL_FRIENDLY_OVERLAY) {
-                  selectMode(PlayerExperienceMode.TRANSCRIPT_PANEL)
-              } else if (automaticLandscapeOverlay) {
-                  preferences.edit().putBoolean(AUTO_OVERLAY_LANDSCAPE_PREFERENCE, false).apply()
-              }
+              selectMode(PlayerExperienceMode.TRANSCRIPT_PANEL)
           },
       )
   }

--- a/app/src/main/java/com/kienhoang/dualsubreplay/ui/YouTubeBrowserScreen.kt
+++ b/app/src/main/java/com/kienhoang/dualsubreplay/ui/YouTubeBrowserScreen.kt
@@ -480,6 +480,421 @@ internal fun webCaptionVisibilityScript(hidden: Boolean): String {
     """.trimIndent()
 }
 
+/**
+ * In-player playback settings overlay and touch interceptor.
+ * Resolves issue #39 where YouTube's mobile web sticky topbar blocks touch input and
+ * YouTube's fullscreen script drops the settings bottom sheet.
+ * Fully compliant with YouTube Trusted Types (pure DOM element construction).
+ */
+internal val WEB_PLAYBACK_SETTINGS_SCRIPT: String =
+    """
+    (function() {
+      const host = window.location.hostname.toLowerCase().replace(/\.$/, '');
+      if (window.location.protocol !== 'https:' ||
+          !(host === 'youtube.com' || host.endsWith('.youtube.com'))) return false;
+
+      const STYLE_ID = 'dualsub-settings-overlay-style';
+      const OVERLAY_ID = 'dualsub-settings-overlay';
+
+      let style = document.getElementById(STYLE_ID);
+      if (!style) {
+        style = document.createElement('style');
+        style.id = STYLE_ID;
+        style.textContent = `
+          #dualsub-settings-overlay {
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100vw;
+            height: 100vh;
+            z-index: 2147483647;
+            display: flex;
+            justify-content: flex-end;
+            align-items: flex-start;
+            box-sizing: border-box;
+          }
+          #dualsub-settings-scrim {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            background: rgba(0, 0, 0, 0.45);
+          }
+          #dualsub-settings-panel {
+            position: relative;
+            background: rgba(28, 28, 28, 0.96);
+            backdrop-filter: blur(20px);
+            -webkit-backdrop-filter: blur(20px);
+            color: #f1f1f1;
+            border-radius: 12px;
+            margin: 48px 24px 16px 16px;
+            min-width: 260px;
+            max-width: 320px;
+            max-height: calc(100vh - 64px);
+            overflow-y: auto;
+            box-shadow: 0 8px 32px rgba(0, 0, 0, 0.7);
+            font-family: Roboto, -apple-system, sans-serif;
+            font-size: 14px;
+            border: 1px solid rgba(255, 255, 255, 0.12);
+            animation: dualsub-pop 0.15s ease-out;
+            z-index: 1;
+          }
+          @keyframes dualsub-pop {
+            from { opacity: 0; transform: scale(0.96) translateY(-6px); }
+            to { opacity: 1; transform: scale(1) translateY(0); }
+          }
+          .dualsub-settings-header {
+            display: flex;
+            align-items: center;
+            padding: 12px 16px;
+            font-weight: 600;
+            font-size: 15px;
+            border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+          }
+          .dualsub-settings-back {
+            background: none;
+            border: none;
+            color: #fff;
+            font-size: 22px;
+            line-height: 1;
+            margin-right: 12px;
+            cursor: pointer;
+            padding: 0 4px;
+            display: flex;
+            align-items: center;
+          }
+          .dualsub-settings-list {
+            list-style: none;
+            margin: 0;
+            padding: 6px 0;
+          }
+          .dualsub-settings-item {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            padding: 12px 16px;
+            cursor: pointer;
+            user-select: none;
+            -webkit-user-select: none;
+            transition: background 0.1s;
+          }
+          .dualsub-settings-item:active {
+            background: rgba(255, 255, 255, 0.15);
+          }
+          .dualsub-settings-item-label {
+            display: flex;
+            align-items: center;
+            gap: 12px;
+          }
+          .dualsub-settings-item-value {
+            color: #aaa;
+            font-size: 13px;
+            display: flex;
+            align-items: center;
+            gap: 4px;
+          }
+          .dualsub-check {
+            color: #3ea6ff;
+            font-weight: bold;
+            width: 16px;
+            display: inline-block;
+          }
+        `;
+        (document.head || document.documentElement).appendChild(style);
+      }
+
+      if (window.__dualsubSettingsInstalled) return true;
+      window.__dualsubSettingsInstalled = true;
+
+      let activeSubmenu = null;
+      let lastOpenTime = 0;
+
+      function getPlayer() {
+        return document.getElementById('movie_player') || document.querySelector('.html5-video-player');
+      }
+
+      function closeOverlay() {
+        const el = document.getElementById(OVERLAY_ID);
+        if (el) el.remove();
+        activeSubmenu = null;
+      }
+
+      function renderOverlay() {
+        const mp = getPlayer();
+        if (!mp) return;
+        lastOpenTime = Date.now();
+
+        let container = document.getElementById(OVERLAY_ID);
+        if (!container) {
+          container = document.createElement('div');
+          container.id = OVERLAY_ID;
+          const parent = document.getElementById('player-container-id') ||
+                         document.getElementById('player') ||
+                         document.body;
+          parent.appendChild(container);
+        }
+        while (container.firstChild) container.removeChild(container.firstChild);
+
+        const scrim = document.createElement('div');
+        scrim.id = 'dualsub-settings-scrim';
+        scrim.onclick = function(e) {
+          e.stopPropagation();
+          if (Date.now() - lastOpenTime < 350) return;
+          closeOverlay();
+        };
+        container.appendChild(scrim);
+
+        const panel = document.createElement('div');
+        panel.id = 'dualsub-settings-panel';
+
+        if (activeSubmenu === 'quality') {
+          renderQualitySubmenu(panel, mp);
+        } else if (activeSubmenu === 'speed') {
+          renderSpeedSubmenu(panel, mp);
+        } else {
+          renderMainMenu(panel, mp);
+        }
+
+        container.appendChild(panel);
+      }
+
+      function createHeader(title, onBack) {
+        const header = document.createElement('div');
+        header.className = 'dualsub-settings-header';
+        if (onBack) {
+          const back = document.createElement('button');
+          back.className = 'dualsub-settings-back';
+          back.textContent = '‹';
+          back.onclick = function(e) {
+            e.stopPropagation();
+            onBack();
+          };
+          header.appendChild(back);
+        }
+        const titleSpan = document.createElement('span');
+        titleSpan.textContent = title;
+        header.appendChild(titleSpan);
+        return header;
+      }
+
+      function createSvgIcon(pathD) {
+        const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+        svg.setAttribute('width', '20');
+        svg.setAttribute('height', '20');
+        svg.setAttribute('viewBox', '0 0 24 24');
+        svg.setAttribute('fill', 'currentColor');
+        const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+        path.setAttribute('d', pathD);
+        svg.appendChild(path);
+        return svg;
+      }
+
+      function renderMainMenu(panel, mp) {
+        panel.appendChild(createHeader('Playback settings'));
+        const list = document.createElement('ul');
+        list.className = 'dualsub-settings-list';
+
+        const currentQuality = (mp.getPlaybackQualityLabel && mp.getPlaybackQualityLabel()) ||
+                              (mp.getPlaybackQuality && mp.getPlaybackQuality()) || 'Auto';
+        const qualityItem = createMenuItem(
+          createSvgIcon('M15 17h6v-2h-6v2zm-4 0h2V7h-2v10zm-8 0h6v-4H3v4zM3 7v4h6V7H3zm12 6h6V7h-6v6z'),
+          'Quality',
+          currentQuality + ' ›',
+          function() {
+            activeSubmenu = 'quality';
+            renderOverlay();
+          }
+        );
+        list.appendChild(qualityItem);
+
+        const currentRate = (mp.getPlaybackRate && mp.getPlaybackRate()) || 1;
+        const rateText = currentRate === 1 ? 'Normal' : currentRate + 'x';
+        const speedItem = createMenuItem(
+          createSvgIcon('M10 8v8l6-4-6-4zm9-5H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16H5V5h14v14z'),
+          'Playback speed',
+          rateText + ' ›',
+          function() {
+            activeSubmenu = 'speed';
+            renderOverlay();
+          }
+        );
+        list.appendChild(speedItem);
+
+        const isSubsOn = (mp.isSubtitlesOn && mp.isSubtitlesOn()) || false;
+        const captionsItem = createMenuItem(
+          createSvgIcon('M19 4H5c-1.11 0-2 .9-2 2v12c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm-8 7H9.5v-.5h-2v3h2V13H11v1c0 .55-.45 1-1 1H7c-.55 0-1-.45-1-1v-4c0-.55.45-1 1-1h3c.55 0 1 .45 1 1v1zm7 0h-1.5v-.5h-2v3h2V13H18v1c0 .55-.45 1-1 1h-3c-.55 0-1-.45-1-1v-4c0-.55.45-1 1-1h3c.55 0 1 .45 1 1v1z'),
+          'Captions',
+          isSubsOn ? 'On' : 'Off',
+          function() {
+            if (mp.toggleSubtitles) mp.toggleSubtitles();
+            closeOverlay();
+          }
+        );
+        list.appendChild(captionsItem);
+
+        panel.appendChild(list);
+      }
+
+      function createMenuItem(icon, labelText, valueText, onClick) {
+        const li = document.createElement('li');
+        li.className = 'dualsub-settings-item';
+        li.onclick = function(e) {
+          e.stopPropagation();
+          onClick();
+        };
+
+        const labelDiv = document.createElement('span');
+        labelDiv.className = 'dualsub-settings-item-label';
+        if (icon) labelDiv.appendChild(icon);
+        const labelSpan = document.createElement('span');
+        labelSpan.textContent = labelText;
+        labelDiv.appendChild(labelSpan);
+        li.appendChild(labelDiv);
+
+        if (valueText) {
+          const valSpan = document.createElement('span');
+          valSpan.className = 'dualsub-settings-item-value';
+          valSpan.textContent = valueText;
+          li.appendChild(valSpan);
+        }
+
+        return li;
+      }
+
+      function renderQualitySubmenu(panel, mp) {
+        panel.appendChild(createHeader('Quality', function() {
+          activeSubmenu = null;
+          renderOverlay();
+        }));
+
+        const list = document.createElement('ul');
+        list.className = 'dualsub-settings-list';
+
+        const rawLevels = (mp.getAvailableQualityLevels && mp.getAvailableQualityLevels()) || [];
+        const rawData = (mp.getAvailableQualityData && mp.getAvailableQualityData()) || [];
+        const preferred = (mp.getPreferredQuality && mp.getPreferredQuality()) || '';
+        const currentQuality = (mp.getPlaybackQuality && mp.getPlaybackQuality()) || '';
+
+        const options = [];
+        if (rawData.length > 0) {
+          for (let i = 0; i < rawData.length; i++) {
+            const q = rawData[i];
+            const level = q.quality || q.qualityLevel;
+            const label = q.qualityLabel || level;
+            options.push({ level: level, label: label });
+          }
+          options.push({ level: 'auto', label: 'Auto' });
+        } else if (rawLevels.length > 0) {
+          for (let i = 0; i < rawLevels.length; i++) {
+            const q = rawLevels[i];
+            const num = q.replace(/[^0-9]/g, '');
+            const label = q === 'auto' ? 'Auto' : (num ? num + 'p' : q);
+            options.push({ level: q, label: label });
+          }
+        } else {
+          options.push({ level: 'auto', label: 'Auto' });
+        }
+
+        for (let i = 0; i < options.length; i++) {
+          const opt = options[i];
+          const isSelected = opt.level === preferred || opt.level === currentQuality ||
+                             ((preferred === '' || preferred === 'auto') && opt.level === 'auto');
+          const li = document.createElement('li');
+          li.className = 'dualsub-settings-item';
+          li.onclick = function(e) {
+            e.stopPropagation();
+            if (mp.setPlaybackQualityRange) mp.setPlaybackQualityRange(opt.level, opt.level);
+            else if (mp.setPlaybackQuality) mp.setPlaybackQuality(opt.level);
+            closeOverlay();
+          };
+
+          const labelDiv = document.createElement('span');
+          labelDiv.className = 'dualsub-settings-item-label';
+
+          const check = document.createElement('span');
+          check.className = 'dualsub-check';
+          check.textContent = isSelected ? '✓' : '';
+          labelDiv.appendChild(check);
+
+          const labelSpan = document.createElement('span');
+          labelSpan.textContent = opt.label;
+          labelDiv.appendChild(labelSpan);
+
+          li.appendChild(labelDiv);
+          list.appendChild(li);
+        }
+
+        panel.appendChild(list);
+      }
+
+      function renderSpeedSubmenu(panel, mp) {
+        panel.appendChild(createHeader('Playback speed', function() {
+          activeSubmenu = null;
+          renderOverlay();
+        }));
+
+        const list = document.createElement('ul');
+        list.className = 'dualsub-settings-list';
+
+        const rates = [0.25, 0.5, 0.75, 1, 1.25, 1.5, 1.75, 2];
+        const currentRate = (mp.getPlaybackRate && mp.getPlaybackRate()) || 1;
+
+        for (let i = 0; i < rates.length; i++) {
+          const r = rates[i];
+          const isSelected = Math.abs(currentRate - r) < 0.01;
+          const label = r === 1 ? 'Normal' : r + 'x';
+          const li = document.createElement('li');
+          li.className = 'dualsub-settings-item';
+          li.onclick = function(e) {
+            e.stopPropagation();
+            if (mp.setPlaybackRate) mp.setPlaybackRate(r);
+            closeOverlay();
+          };
+
+          const labelDiv = document.createElement('span');
+          labelDiv.className = 'dualsub-settings-item-label';
+
+          const check = document.createElement('span');
+          check.className = 'dualsub-check';
+          check.textContent = isSelected ? '✓' : '';
+          labelDiv.appendChild(check);
+
+          const labelSpan = document.createElement('span');
+          labelSpan.textContent = label;
+          labelDiv.appendChild(labelSpan);
+
+          li.appendChild(labelDiv);
+          list.appendChild(li);
+        }
+
+        panel.appendChild(list);
+      }
+
+      function handleSettingsCapture(e) {
+        const target = e.target;
+        if (!target) return;
+        const btn = (target.closest && target.closest('.player-settings-icon, [aria-label="Playback Settings"], ytm-mobile-topbar-renderer [aria-label="More options"]')) ||
+                    (target.classList && target.classList.contains('player-settings-icon') ? target : null);
+        if (btn) {
+          const mp = document.getElementById('movie_player');
+          if (mp) {
+            e.stopPropagation();
+            e.preventDefault();
+            renderOverlay();
+          }
+        }
+      }
+
+      window.addEventListener('click', handleSettingsCapture, true);
+      window.addEventListener('touchend', handleSettingsCapture, true);
+      document.addEventListener('click', handleSettingsCapture, true);
+      document.addEventListener('touchend', handleSettingsCapture, true);
+
+      return true;
+    })();
+    """.trimIndent()
+
 internal fun parseWebPlaybackSnapshot(rawValue: String?): WebPlaybackSnapshot? {
     if (rawValue.isNullOrBlank() || rawValue == "null") return null
     return runCatching {
@@ -721,6 +1136,7 @@ internal fun SingleYouTubePage(
                             webCaptionVisibilityScript(currentSuppressPageCaptions),
                             null,
                         )
+                        view.evaluateJavascript(WEB_PLAYBACK_SETTINGS_SCRIPT, null)
                     }
                 }
 
@@ -811,6 +1227,7 @@ internal fun SingleYouTubePage(
                 val second = snapshot.currentSecond ?: return@evaluateJavascript
                 currentOnPlaybackSecond(selection.videoId, second, snapshot.liveCaption)
             }
+            webView.evaluateJavascript(WEB_PLAYBACK_SETTINGS_SCRIPT, null)
             delay(PLAYBACK_POLL_INTERVAL_MS)
         }
     }

--- a/app/src/test/java/com/kienhoang/dualsubreplay/ui/LearningPlayerRootTest.kt
+++ b/app/src/test/java/com/kienhoang/dualsubreplay/ui/LearningPlayerRootTest.kt
@@ -126,6 +126,13 @@ class LearningPlayerRootTest {
         assertFalse(
             shouldUseAutomaticLandscapeOverlay(
                 PlayerExperienceMode.TRANSCRIPT_PANEL,
+                autoLandscape = false,
+                orientation = Configuration.ORIENTATION_LANDSCAPE,
+            ),
+        )
+        assertFalse(
+            shouldUseAutomaticLandscapeOverlay(
+                PlayerExperienceMode.TRANSCRIPT_PANEL,
                 autoLandscape = true,
                 orientation = Configuration.ORIENTATION_PORTRAIT,
             ),

--- a/app/src/test/java/com/kienhoang/dualsubreplay/ui/PlaybackArchitectureTest.kt
+++ b/app/src/test/java/com/kienhoang/dualsubreplay/ui/PlaybackArchitectureTest.kt
@@ -201,6 +201,22 @@ class PlaybackArchitectureTest {
     }
 
     @Test
+    fun playbackSettingsScriptEnforcesOriginAndAvoidsTrustedHtmlViolations() {
+        val script = WEB_PLAYBACK_SETTINGS_SCRIPT
+
+        assertTrue(script.contains("window.location.protocol !== 'https:'"))
+        assertTrue(script.contains("!(host === 'youtube.com' || host.endsWith('.youtube.com'))"))
+        assertFalse(script.contains("innerHTML"))
+        assertTrue(script.contains("movie_player"))
+        assertTrue(script.contains("setPlaybackQualityRange"))
+        assertTrue(script.contains("setPlaybackRate"))
+        assertTrue(script.contains("toggleSubtitles"))
+        assertTrue(script.contains("player-settings-icon"))
+        assertTrue(script.contains("More options"))
+        assertFalse(script.contains("ytm-mobile-topbar-renderer.sticky-player"))
+    }
+
+    @Test
     fun replayScriptSeeksAndResumesTheNativePageVideo() {
         val script = webReplayScript(42.25f)
 


### PR DESCRIPTION
## Description

Closes #39. Fixes Transcript Panel selection and usage in landscape mode.

### Background & Root Cause
1. **Playback Settings in Fullscreen / Landscape (#39)**: In landscape / fullscreen mode on YouTube's mobile web player, tapping the settings (gear) icon failed to show the settings menu because YouTube's internal `c3_base.js` bottom-sheet launcher explicitly guards against `document.fullscreenElement` (`if ((a() && document.fullscreenElement || !a() && !document.fullscreenElement) && L)`) and drops the request. Furthermore, the topbar's 3-dot button overlaps player controls top-right area, intercepting touches.
2. **Transcript Panel in Landscape Mode**: `LearningPlayerRoot` was passing `effectiveMode` to `DualSubApp`, causing the "Default view" in the subtitle settings dialog to display "Scroll-friendly overlay" whenever the phone was rotated sideways. Furthermore, when the user tapped "Transcript panel" in landscape, `autoOverlayLandscape` remained `true`, causing `shouldUseAutomaticLandscapeOverlay` to force `effectiveMode` back to overlay mode and immediately hide the transcript panel (`viewModel.hideSubtitlePanel()`).

### Changes
- **In-Player Playback Settings Modal**: Built a dedicated settings menu injected into the player DOM using pure DOM element APIs (`document.createElement`, `textContent`) to strictly adhere to YouTube's CSP Trusted Types policy (`TrustedHTML`).
- **Interactive Controls**:
  - **Quality**: Lists available video resolutions from `movie_player.getAvailableQualityData()`, marks active resolution with a checkmark, and applies selections via `movie_player.setPlaybackQualityRange()`.
  - **Playback Speed**: Selector from 0.25x to 2x via `movie_player.setPlaybackRate()`.
  - **Captions**: Quick toggle via `movie_player.toggleSubtitles()`.
  - **Navigation**: Supports submenus with back button (`‹`), blue checkmarks (`✓`), and outside-tap scrim dismissal.
- **Unified Capture Delegation**: Captures events on `.player-settings-icon`, `[aria-label="Playback Settings"]`, and `ytm-mobile-topbar-renderer [aria-label="More options"]` during video playback.
- **Preserved YouTube Topbar & Home Navigation**: Kept `ytm-mobile-topbar-renderer` fully visible across portrait and landscape modes so the YouTube Home logo (`aria-label="YouTube Home"`) and Search buttons remain permanently accessible.
- **Landscape Transcript Panel Support**:
  - `selectMode(PlayerExperienceMode.TRANSCRIPT_PANEL)` now automatically disables the automatic landscape overlay override (`AUTO_OVERLAY_LANDSCAPE_PREFERENCE = false`) and reveals the transcript panel (landscape split view) immediately.
  - `DualSubApp` receives `playerMode = mode` (the saved default preference) so the settings dialog accurately reflects the user's default view setting, and `effectivePlayerMode = effectiveMode` for runtime presentation behaviors (caption suppression and FAB display).
  - Synchronized `SubtitleSettingsDialog` with `SharedPreferences.OnSharedPreferenceChangeListener` to keep toggle switches reactive.
  - Overlay dismiss (`onClose`) now unifies directly to switching to the transcript panel.
- **Tests**:
  - Added `playbackSettingsScriptEnforcesOriginAndAvoidsTrustedHtmlViolations` to `PlaybackArchitectureTest.kt`.
  - Added landscape overlay override unit tests to `LearningPlayerRootTest.kt`.

### Verification
- `.\gradlew.bat testDebugUnitTest` passed.
- `.\gradlew.bat lintDebug` passed (0 errors).
- `.\gradlew.bat assembleDebug` and `assembleDebugAndroidTest` succeeded.
- Verified across portrait and landscape orientations.
