### PR TITLE
Add Practice, navigation drawer, and resilient dual subtitles

### DIFF
--- a/.github/workflows/release-on-main.yml
+++ b/.github/workflows/release-on-main.yml
@@ -160,16 +160,15 @@ jobs:
 
             Preview builds install separately as **DualSub Replay Preview**, so installing an official release does not require removing the preview app.
 
-            ## v0.9.6 highlights
+            ## v0.9.7 highlights
 
-            - **Word Learning Mode (POS Colors & Tap-to-Learn)**: Color-coded grammatical parts of speech (nouns, verbs, adjectives, adverbs, pronouns, conjunctions, prepositions, particles) and instant tap-to-learn dictionary popups (#42).
-            - **Cross-Language Subtitle Alignment**: Harmonized POS coloring across both original and translated subtitle lines, with unaligned/filler words rendered in dark slate gray (#42 V4 & V5).
-            - **Active-Sentence-Only Focus**: Keeps the transcript list calm, legible, and clutter-free by lighting up only the currently spoken sentence, with a toggle in More Settings (#42).
-            - **Preload Translation Models**: Automatic background preloading of ML Kit translation models for instant translations on video open (#47).
-            - **Video Overlay Aspect Ratio Lock**: Lock the minimized subtitle overlay to the video player bounds (#46).
-            - **Japanese & CJK Morphological Timing**: High-precision morpheme segmentation for non-spaced languages during karaoke playback (#44).
-            - **Natural Subtitle Flow**: Cleaner subtitle presentation without artificial boundary punctuation (#43).
-            - **Clean Playback UI**: Suppressed YouTube player overlays and cluttering web elements during video playback (#37).
+            - **Practice mode with spaced repetition**: Save vocabulary and review it with Again, Hard, Good, and Easy ratings (#52).
+            - **Pronunciation and examples**: Saved words keep their language and subtitle context, with automatic pronunciation plus optional online examples and downloadable offline clips (#52).
+            - **Cleaner navigation**: Practice and Settings now live in a left navigation drawer with a larger, easier-to-tap menu target (#52).
+            - **More resilient dual subtitles**: When full transcript retrieval fails, the app can fall back to live YouTube captions, translate them, reconcile rolling text, and recover back to the full transcript when available (#52).
+            - **Native YouTube playback settings restored**: The app no longer injects a replacement settings menu or intercepts YouTube's original playback controls (#52).
+            - **Better dialog behavior**: App subtitle panels temporarily hide while YouTube's native dialog is open and return when it closes (#52).
+            - **Updated open-source notices**: Licensing and third-party notices now cover the optional downloader and bundled FFmpeg components (#52).
 
             The `.sha256` file can be used to verify the APK download.
           files: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,7 @@ Single-module Android app (`:app`, package `com.kienhoang.dualsubreplay`): Kotli
 
 ## Architecture invariants (enforced by tests)
 
-- Exactly one WebView exists (`SingleYouTubePage` in `ui/YouTubeBrowserScreen.kt`). Replay seeks the native YouTube page video via a JS polling bridge — never add a second player/WebView.
+- Exactly one WebView exists (`SingleYouTubePage` in `ui/YouTubeBrowserScreen.kt`). Online replay seeks the native YouTube page video via a JS polling bridge. Saved offline clips may use a lifecycle-managed Media3 player for app-private local files; pause the YouTube player before local playback and never add a second online player/WebView.
 - Main-frame navigation goes through `classifyMainFrameUrl` → `YOUTUBE_WEB` (embed) / `GOOGLE_SIGN_IN` (embed during sign-in flow) / `OPEN_EXTERNAL` (browser) / `BLOCK`. JS snapshot/replay scripts must keep re-verifying the executing origin (`https:` + `*.youtube.com`); `PlaybackArchitectureTest` asserts the literal script text.
 - Captions use YouTube's undocumented Innertube transcript endpoint, deliberately isolated in `data/YouTubeCaptionProvider.kt` (host allowlist, 8 MiB response cap) so it can be replaced without touching the rest of the app.
 - Translation is on-device via ML Kit (`translation/OnDeviceTranslator.kt`); the app has no API keys.

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -8,13 +8,16 @@ DualSub Replay is designed without an application account, analytics SDK, advert
 - The app requests public caption data from YouTube to build the replayable subtitle timeline.
 - Google ML Kit may download the language models you select. Translation then runs on the device.
 - The app stores the last Browse URL, target language, subtitle text size, and landscape split ratio in local Android preferences.
+- Saved words, meanings, subtitle context, video IDs, timestamp ranges, and review schedules are stored in a local SQLite database. They are not sent to an application server. Android's normal app backup may include this database and preferences.
+- Optional offline clip downloads send video requests to YouTube and its media hosts using the bundled yt-dlp downloader. Downloads do not copy cookies from the browsing WebView. Clip files are stored privately and excluded from Android backups. Restored cards may require their clips to be downloaded again.
+- Pronunciation sends the selected word and language to the device's configured Android text-to-speech engine. That engine may use an online voice according to its own settings and privacy policy.
 - If you use the experimental Google/YouTube sign-in flow, authentication occurs inside YouTube's embedded web experience and WebView cookies persist locally. Google may reject embedded-WebView sign-in.
 
 ## What the project does not do
 
 - It does not require an API key or DualSub Replay account.
 - It does not send subtitle text or translation requests to a server operated by this project.
-- It does not download YouTube video or audio.
+- It does not download media automatically during browsing; users explicitly request offline vocabulary clips.
 - It does not intentionally collect analytics, advertising identifiers, or crash telemetry.
 
 Deleting the app clears its local app data under Android's normal uninstall behavior. You can also clear the app's storage from Android Settings.

--- a/README.md
+++ b/README.md
@@ -97,7 +97,21 @@ Starting with v0.3.3, the app experimentally keeps the Google/YouTube sign-in fl
 
 YouTube's official Data API does not allow ordinary viewers to download captions from arbitrary public videos. To provide automatic captions, this prototype uses YouTube's undocumented Innertube transcript endpoint. It can stop working when YouTube changes its internal API, and its use may be restricted by YouTube's terms. The extraction code is isolated in `YouTubeCaptionProvider` so it can be replaced without rewriting the app.
 
-Video playback uses the native player in YouTube's mobile webpage. The app does not download video or audio, remove ads, or enable background playback. The subtitle layer can be hidden at any time to restore the unobstructed YouTube page.
+Online video playback uses the native player in YouTube's mobile webpage. Saved vocabulary can optionally download a short example clip for offline practice. Downloads use yt-dlp and FFmpeg, may be unavailable for some videos, and can stop working when YouTube changes. Normal browsing does not download media. The subtitle layer can be hidden at any time to restore the unobstructed YouTube page.
+
+## Saved words and practice
+
+Tap a word in either subtitle line to hear it, inspect its meaning, and choose **Save word**. Pronunciation uses the tapped word's language and the device's installed speech engine; Android voice availability varies. Automatic pronunciation can be disabled in Settings, and the Pronounce button remains available.
+
+Each card stores an editable meaning and its original subtitle context. The two clip options are independent: online only, offline only, both, or neither. Online examples replay the saved sentence in the existing YouTube page and stop at its end. A translated word's example contains the original spoken sentence, which may not literally contain the translated word. Offline files play without an internet connection and never silently fall back to online playback.
+
+Open **Saved words** beside Settings to search, edit, delete, or practice cards. Practice reveals the meaning on request and schedules reviews with Again (10 minutes), Hard (initially 1 day), Good (3 days), or Easy (7 days). Later successful reviews expand the previous interval by 1.2, 2, or 3 respectively; Again restarts progression. This is an independent local review system, without Anki sync. Cards are due immediately when first saved; duplicate saves of the same word/languages/video/segment retain review progress.
+
+Offline clips download only on request, at up to 480p, one at a time. The app shows progress and offers cancellation, retry, and removal. A job is limited to 10 minutes and 100 MiB of temporary/output storage. Clips live in app-private storage excluded from backups. Removing a clip keeps the card; deleting a word also removes its clip and review history. Resetting Settings preserves vocabulary. A restored card whose clip is missing can download it again.
+
+## Distribution licenses
+
+Source contributed to this repository retains its [MIT notice](LICENSE). APKs combining it with the GPL-3.0 Android downloader are distributed as a whole under GPL-3.0. See [third-party notices and build/source information](THIRD_PARTY_NOTICES.md). Settings includes an offline copy of the GPL terms. Native download dependencies increase APK size.
 
 Live spoken-word timing reads caption text rendered by YouTube's webpage and is available only for eligible auto-generated caption tracks. Adaptive mode falls back to transcript timing when a reliable live word cannot be mapped; manual captions always use transcript timing. YouTube's page structure and WebView behavior can vary by video and device, so live word timing may be unavailable or less precise on some phones.
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ Watch YouTube with two subtitle languages at once, then tap any sentence to repl
 [![Latest release](https://img.shields.io/github/v/release/hoangkien1703/dual-sub-replay?label=latest)](https://github.com/hoangkien1703/dual-sub-replay/releases/latest)
 [![Android 8+](https://img.shields.io/badge/Android-8.0%2B-3ddc84?logo=android&logoColor=white)](https://github.com/hoangkien1703/dual-sub-replay/releases/latest/download/DualSub-Replay.apk)
 [![CI](https://github.com/hoangkien1703/dual-sub-replay/actions/workflows/android.yml/badge.svg)](https://github.com/hoangkien1703/dual-sub-replay/actions/workflows/android.yml)
-[![License: MIT](https://img.shields.io/badge/License-MIT-26c6da.svg)](LICENSE)
+[![Source: MIT](https://img.shields.io/badge/Source-MIT-26c6da.svg)](LICENSE)
+[![App distribution: GPL-3.0](https://img.shields.io/badge/App-GPL--3.0-blue.svg)](THIRD_PARTY_NOTICES.md)
 
 <p align="center">
   <a href="docs/media/dualsub-replay-promo.mp4">

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,19 @@
+# Distribution and source notices
+
+DualSub Replay copyright (c) 2026 Hoang Trung Kien. Original repository source retains the MIT permissions and notice in LICENSE. The application combining that source with the GPL-3.0 downloader is distributed as a whole under GNU GPL version 3, without warranty. You may copy, modify, and redistribute the combined application under those terms. The full GPL text is packaged at `app/src/main/assets/licenses/GPL-3.0.txt` and accessible in Settings.
+
+The vocabulary/downloader integration was added in September 2026. The upstream download libraries are used without source modifications.
+
+## Download components
+
+- `io.github.junkfood02.youtubedl-android:library:0.18.1` and `:ffmpeg:0.18.1`: GPL-3.0 Android wrapper, by yausername, JunkFood02, xibr, and contributors. [Versioned source](https://github.com/yausername/youtubedl-android/tree/0.18.1), [source archive](https://github.com/yausername/youtubedl-android/archive/refs/tags/0.18.1.tar.gz), [license](https://github.com/yausername/youtubedl-android/blob/0.18.1/LICENSE).
+- The wrapper bundles yt-dlp, CPython, QuickJS, FFmpeg, and their native dependencies. Their upstream terms continue to apply. The wrapper's [Python build instructions](https://github.com/yausername/youtubedl-android/blob/0.18.1/BUILD_PYTHON.md) and [FFmpeg build instructions](https://github.com/yausername/youtubedl-android/blob/0.18.1/BUILD_FFMPEG.md) describe the native package build process. Native package recipes and patches are maintained in [Termux packages](https://github.com/termux/termux-packages). The bundled yt-dlp build is maintained in [ytdlp-lazy](https://github.com/xibr/ytdlp-lazy); upstream [yt-dlp source and third-party licenses](https://github.com/yt-dlp/yt-dlp) remain available.
+- Media3 ExoPlayer/UI 1.5.1 and WorkManager 2.10.1: Android Open Source Project contributors, Apache-2.0. Sources and source JARs are available from Google's Maven repository and [AndroidX](https://android.googlesource.com/platform/frameworks/support/).
+
+## Obtain and build this application's source
+
+The complete application source and build scripts are available without charge at https://github.com/hoangkien1703/dual-sub-replay. For a PR preview, select the PR's exact commit; for a tagged release, select that tag. GitHub provides downloadable source archives for both commits and tags. Keep these source links beside redistributed APKs and retain upstream notices and access to the corresponding dependency sources.
+
+Use JDK 17, Android SDK 36, and the committed Gradle wrapper. Run `bash ./gradlew testDebugUnitTest lintDebug assembleDebug assembleDebugAndroidTest`. Dependencies are pinned in `app/build.gradle.kts` and resolved from Maven Central/Google Maven. Building a modified debug APK requires no production signing key. Install with Android's normal APK installation flow or `adb install`; uninstall a differently signed build first if Android reports a signature mismatch (uninstalling erases local data).
+
+The release signing keys are not necessary to build or install modified versions. This application does not restrict installation of user-built variants.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -141,3 +141,14 @@ dependencies {
     androidTestImplementation("androidx.compose.ui:ui-test-junit4")
     debugImplementation("androidx.compose.ui:ui-test-manifest")
 }
+
+// Put screenshot evidence alongside the reports already uploaded by CI.
+val collectUiEvidence by tasks.registering(Copy::class) {
+    from(layout.buildDirectory.dir("outputs/managed_device_android_test_additional_output"))
+    from(layout.buildDirectory.dir("intermediates/managed_device_android_test_additional_output"))
+    include("**/*.png")
+    into(layout.buildDirectory.dir("reports/androidTests/managedDevice/ui-evidence"))
+}
+tasks.matching { it.name == "pixel2Api36DebugAndroidTest" }.configureEach {
+    finalizedBy(collectUiEvidence)
+}

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -85,6 +85,7 @@ android {
 
     packaging {
         jniLibs.useLegacyPackaging = true
+        jniLibs.keepDebugSymbols += setOf("**/libffmpeg.zip.so", "**/libpython.zip.so")
         resources.excludes += setOf(
             "/META-INF/{AL2.0,LGPL2.1}",
             "META-INF/DEPENDENCIES",

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -84,6 +84,7 @@ android {
     }
 
     packaging {
+        jniLibs.useLegacyPackaging = true
         resources.excludes += setOf(
             "/META-INF/{AL2.0,LGPL2.1}",
             "META-INF/DEPENDENCIES",
@@ -125,6 +126,11 @@ dependencies {
     implementation("com.google.mlkit:translate:17.0.3")
     implementation("com.squareup.okhttp3:okhttp:4.12.0")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.10.2")
+    implementation("androidx.work:work-runtime-ktx:2.10.1")
+    implementation("androidx.media3:media3-exoplayer:1.5.1")
+    implementation("androidx.media3:media3-ui:1.5.1")
+    implementation("io.github.junkfood02.youtubedl-android:library:0.18.1")
+    implementation("io.github.junkfood02.youtubedl-android:ffmpeg:0.18.1")
 
     debugImplementation("androidx.compose.ui:ui-tooling")
     testImplementation("junit:junit:4.13.2")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -3,8 +3,8 @@ plugins {
     id("org.jetbrains.kotlin.plugin.compose")
 }
 
-val appVersionCode = 27
-val appVersionName = "0.9.6"
+val appVersionCode = 28
+val appVersionName = "0.9.7"
 val releaseStoreFile = providers.environmentVariable("ANDROID_RELEASE_STORE_FILE").orNull
 val releaseStorePassword = providers.environmentVariable("ANDROID_RELEASE_STORE_PASSWORD").orNull
 val releaseKeyAlias = providers.environmentVariable("ANDROID_RELEASE_KEY_ALIAS").orNull

--- a/app/src/androidTest/java/com/kienhoang/dualsubreplay/data/ClipNativeToolsTest.kt
+++ b/app/src/androidTest/java/com/kienhoang/dualsubreplay/data/ClipNativeToolsTest.kt
@@ -1,0 +1,52 @@
+package com.kienhoang.dualsubreplay.data
+
+import android.media.MediaMetadataRetriever
+import androidx.test.platform.app.InstrumentationRegistry
+import com.yausername.ffmpeg.FFmpeg
+import com.yausername.youtubedl_android.YoutubeDL
+import com.yausername.youtubedl_android.YoutubeDLRequest
+import java.io.File
+import java.util.UUID
+import java.util.concurrent.TimeUnit
+import org.junit.Assert.*
+import org.junit.Test
+
+/** No live sites: exercise the actual packaged binaries and a generated audio/video fixture. */
+class ClipNativeToolsTest {
+    @Test(timeout = 120_000) fun bundledDownloaderAndFfmpegRunAndProducePlayableTrimmedMedia() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        YoutubeDL.getInstance().init(context)
+        FFmpeg.getInstance().init(context)
+        val version = YoutubeDL.getInstance().execute(YoutubeDLRequest(emptyList()).addOption("--version"))
+        assertTrue(version.out.trim().isNotEmpty())
+        val directory = File(context.cacheDir, "native-clip-test-${UUID.randomUUID()}").apply { mkdirs() }
+        val nativeDirectory = context.applicationInfo.nativeLibraryDir
+        val packages = File(context.noBackupFilesDir, "youtubedl-android/packages")
+        fun ffmpeg(vararg arguments: String) {
+            val process = ProcessBuilder(listOf("$nativeDirectory/libffmpeg.so", "-nostdin", "-hide_banner", "-loglevel", "error", "-y") + arguments)
+                .redirectErrorStream(true).apply {
+                    environment()["LD_LIBRARY_PATH"] = "$packages/ffmpeg/usr/lib:$packages/python/usr/lib:$nativeDirectory"
+                }.start()
+            try {
+                assertTrue("FFmpeg timed out", process.waitFor(30, TimeUnit.SECONDS))
+                val output = process.inputStream.bufferedReader().readText()
+                assertEquals(output, 0, process.exitValue())
+            } finally { process.destroy() }
+        }
+        try {
+            val source = File(directory, "source.mp4")
+            val clip = File(directory, "clip.mp4")
+            ffmpeg("-f", "lavfi", "-i", "color=c=blue:s=160x90:r=10", "-f", "lavfi", "-i", "sine=frequency=440:sample_rate=44100",
+                "-t", "2", "-c:v", "libx264", "-pix_fmt", "yuv420p", "-c:a", "aac", source.absolutePath)
+            ffmpeg("-ss", "0.5", "-i", source.absolutePath, "-t", "1", "-c:v", "libx264", "-c:a", "aac", clip.absolutePath)
+            val media = MediaMetadataRetriever()
+            try {
+                media.setDataSource(clip.absolutePath)
+                assertEquals("yes", media.extractMetadata(MediaMetadataRetriever.METADATA_KEY_HAS_AUDIO))
+                assertEquals("yes", media.extractMetadata(MediaMetadataRetriever.METADATA_KEY_HAS_VIDEO))
+                val duration = media.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION)!!.toLong()
+                assertTrue("Unexpected duration: $duration", duration in 900..1200)
+            } finally { media.release() }
+        } finally { directory.deleteRecursively() }
+    }
+}

--- a/app/src/androidTest/java/com/kienhoang/dualsubreplay/data/VocabularyRepositoryTest.kt
+++ b/app/src/androidTest/java/com/kienhoang/dualsubreplay/data/VocabularyRepositoryTest.kt
@@ -1,0 +1,34 @@
+package com.kienhoang.dualsubreplay.data
+
+import androidx.test.platform.app.InstrumentationRegistry
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.*
+import org.junit.Test
+import java.util.UUID
+
+class VocabularyRepositoryTest {
+    @Test fun duplicateSaveAndReopenPreserveReviewsAndDeletionRejectsLateWorkerUpdates() = runBlocking {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val name = "vocabulary-test-${UUID.randomUUID()}.db"
+        var repository = VocabularyRepository(context, name)
+        val selection = LearningWordSelection(AnalyzedToken("word", 0, 4, PartOfSpeech.NOUN), "en", "vi",
+            "dQw4w9WgXcQ", SubtitleSegment(1, 1000, 3000, "a word", null), false)
+        val word = savedWordFrom(selection, "từ", true, false)
+        try {
+            repository.save(word)
+            repository.update(word.id) { reviewWord(it, ReviewRating.GOOD, 1000) }
+            repository.save(word.copy(meaning = "edited", online = false))
+            assertEquals(1, repository.words.value.size)
+            assertEquals(1000 + 3 * DAY_MS, repository.words.value.single().dueAt)
+            repository.close()
+            repository = VocabularyRepository(context, name)
+            repository.refresh()
+            assertEquals("edited", repository.words.value.single().meaning)
+            assertFalse(repository.words.value.single().online)
+            assertEquals(1000 + 3 * DAY_MS, repository.words.value.single().dueAt)
+            repository.remove(word.id)
+            assertNull(repository.update(word.id) { it.copy(clipStatus = "ready") })
+            assertTrue(repository.words.value.isEmpty())
+        } finally { repository.close(); context.deleteDatabase(name) }
+    }
+}

--- a/app/src/androidTest/java/com/kienhoang/dualsubreplay/data/VocabularyRepositoryTest.kt
+++ b/app/src/androidTest/java/com/kienhoang/dualsubreplay/data/VocabularyRepositoryTest.kt
@@ -26,6 +26,12 @@ class VocabularyRepositoryTest {
             assertEquals("edited", repository.words.value.single().meaning)
             assertFalse(repository.words.value.single().online)
             assertEquals(1000 + 3 * DAY_MS, repository.words.value.single().dueAt)
+            repository.update(word.id) { it.copy(offline = true, clipStatus = "downloading", clipGeneration = 1) }
+            val partial = java.io.File(repository.clipDirectory, "${word.id}-1-interrupted.part").apply { mkdirs() }
+            java.io.File(partial, "partial.mp4").writeText("unfinished download")
+            repository.reconcileDownloads(context)
+            assertEquals("failed", repository.words.value.single().clipStatus)
+            assertFalse(partial.exists())
             repository.remove(word.id)
             assertNull(repository.update(word.id) { it.copy(clipStatus = "ready") })
             assertTrue(repository.words.value.isEmpty())

--- a/app/src/androidTest/java/com/kienhoang/dualsubreplay/ui/BrowseWebViewLifecycleTest.kt
+++ b/app/src/androidTest/java/com/kienhoang/dualsubreplay/ui/BrowseWebViewLifecycleTest.kt
@@ -221,6 +221,58 @@ class BrowseWebViewLifecycleTest {
         } finally { instrumentation.runOnMainSync { view.destroySafely() } }
     }
 
+    @Test fun nativeSettingsReceiveClickAndTouchEventsWithCaptionScriptsInstalled() {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val loaded = CountDownLatch(1)
+        lateinit var view: WebView
+        instrumentation.runOnMainSync {
+            view = WebView(instrumentation.targetContext).apply {
+                settings.javaScriptEnabled = true
+                webViewClient = object : WebViewClient() {
+                    override fun onPageFinished(view: WebView, url: String?) { loaded.countDown() }
+                }
+                loadDataWithBaseURL("https://m.youtube.com/watch?v=abcdefghijk", """
+                    <html><body><div id="movie_player"><video></video>
+                    <button class="player-settings-icon" aria-label="Playback Settings">Settings</button>
+                    </div><ytm-mobile-topbar-renderer><button aria-label="More options">More</button></ytm-mobile-topbar-renderer>
+                    <bottom-sheet-container id="native-menu" role="dialog" aria-modal="true" style="display:none">
+                    <ytw-scrim style="display:block;position:fixed;left:0;top:0;width:300px;height:400px">YouTube settings fixture</ytw-scrim>
+                    </bottom-sheet-container>
+                    <script>
+                      window.clicks = 0; window.touches = 0; window.bubbled = 0;
+                      document.querySelectorAll('button').forEach(function(button) {
+                        button.addEventListener('click', function() {
+                          window.clicks++; document.getElementById('native-menu').style.display = 'contents';
+                        });
+                        button.addEventListener('touchend', function() { window.touches++; });
+                      });
+                      document.addEventListener('click', function() { window.bubbled++; });
+                    </script></body></html>
+                """.trimIndent(), "text/html", "UTF-8", null)
+            }
+        }
+        try {
+            assertTrue(loaded.await(10, TimeUnit.SECONDS))
+            evaluateJavascript(view, webLiveCaptionConfigurationScript(true))
+            evaluateJavascript(view, webCaptionVisibilityScript(true))
+            evaluateJavascript(view, WEB_PLAYBACK_SNAPSHOT_SCRIPT)
+            assertEquals("true", evaluateJavascript(view, """
+                (function() {
+                  let allowed = true;
+                  document.querySelectorAll('button').forEach(function(button) {
+                    allowed = button.dispatchEvent(new Event('touchend', {bubbles:true, cancelable:true})) && allowed;
+                    button.click();
+                  });
+                  return allowed && window.clicks === 2 && window.touches === 2 && window.bubbled === 2 &&
+                    !document.getElementById('dualsub-settings-overlay');
+                })();
+            """.trimIndent()))
+            assertTrue(parseWebPlaybackSnapshot(evaluateJavascript(view, WEB_PLAYBACK_SNAPSHOT_SCRIPT))!!.nativeDialogVisible)
+            evaluateJavascript(view, "document.getElementById('native-menu').style.display = 'none'")
+            assertFalse(parseWebPlaybackSnapshot(evaluateJavascript(view, WEB_PLAYBACK_SNAPSHOT_SCRIPT))!!.nativeDialogVisible)
+        } finally { instrumentation.runOnMainSync { view.destroySafely() } }
+    }
+
     private fun evaluateJavascript(webView: WebView, script: String): String? {
         val instrumentation = InstrumentationRegistry.getInstrumentation()
         val result = AtomicReference<String?>()

--- a/app/src/androidTest/java/com/kienhoang/dualsubreplay/ui/BrowseWebViewLifecycleTest.kt
+++ b/app/src/androidTest/java/com/kienhoang/dualsubreplay/ui/BrowseWebViewLifecycleTest.kt
@@ -131,12 +131,13 @@ class BrowseWebViewLifecycleTest {
                     }
                 }
                 loadDataWithBaseURL(
-                    "https://m.youtube.com/watch?v=captiontest1",
+                    "https://m.youtube.com/watch?v=abcdefghijk",
                     """
                     <!doctype html>
                     <html><body>
                       <video id="native-video"></video>
                       <button class="ytmClosedCaptioningButtonButton" aria-label="字幕がオフになりました" aria-pressed="false">CC</button>
+                      <div id="movie_player"></div>
                       <div class="ytp-caption-window-container">
                         <span class="ytp-caption-segment">Hello</span>
                       </div>
@@ -146,6 +147,12 @@ class BrowseWebViewLifecycleTest {
                           configurable: true,
                           get: function() { return 4.5; }
                         });
+                        const player = document.getElementById('movie_player');
+                        player.getOption = function() {
+                          return document.querySelector('button').getAttribute('aria-pressed') === 'true' ? {languageCode:'en'} : {};
+                        };
+                        player.setOption = function() {};
+                        player.getPlayerResponse = function() { return {videoDetails:{videoId:'abcdefghijk'}}; };
                         document.querySelector('.ytmClosedCaptioningButtonButton').onclick = function() {
                           this.setAttribute(
                             'aria-pressed',
@@ -178,6 +185,8 @@ class BrowseWebViewLifecycleTest {
         Thread.sleep(150)
         val snapshot = parseWebPlaybackSnapshot(evaluateJavascript(webView, WEB_PLAYBACK_SNAPSHOT_SCRIPT))
         assertEquals("Hello world", snapshot?.liveCaption?.text)
+        assertEquals("abcdefghijk", snapshot?.liveCaption?.videoId)
+        assertEquals("en", snapshot?.liveCaption?.languageCode)
         assertTrue((snapshot?.liveCaption?.revision ?: 0L) >= 2L)
         assertEquals(4_500L, snapshot?.liveCaption?.mediaTimeMs)
         assertEquals("true", evaluateJavascript(webView, webLiveCaptionConfigurationScript(enabled = false)))
@@ -190,6 +199,26 @@ class BrowseWebViewLifecycleTest {
         )
 
         instrumentation.runOnMainSync { webView.destroySafely() }
+    }
+
+    @Test fun liveObserverRejectsUntrustedOrigin() {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val loaded = CountDownLatch(1)
+        lateinit var view: WebView
+        instrumentation.runOnMainSync {
+            view = WebView(instrumentation.targetContext).apply {
+                settings.javaScriptEnabled = true
+                webViewClient = object : WebViewClient() {
+                    override fun onPageFinished(view: WebView, url: String?) { loaded.countDown() }
+                }
+                loadDataWithBaseURL("https://youtube.com.evil.test/", "<html><video></video></html>", "text/html", "UTF-8", null)
+            }
+        }
+        try {
+            assertTrue(loaded.await(10, TimeUnit.SECONDS))
+            assertEquals("false", evaluateJavascript(view, webLiveCaptionConfigurationScript(true)))
+            assertNull(parseWebPlaybackSnapshot(evaluateJavascript(view, WEB_PLAYBACK_SNAPSHOT_SCRIPT)))
+        } finally { instrumentation.runOnMainSync { view.destroySafely() } }
     }
 
     private fun evaluateJavascript(webView: WebView, script: String): String? {

--- a/app/src/androidTest/java/com/kienhoang/dualsubreplay/ui/CaptionRecoveryStateTest.kt
+++ b/app/src/androidTest/java/com/kienhoang/dualsubreplay/ui/CaptionRecoveryStateTest.kt
@@ -1,0 +1,60 @@
+package com.kienhoang.dualsubreplay.ui
+
+import android.app.Application
+import androidx.test.platform.app.InstrumentationRegistry
+import com.kienhoang.dualsubreplay.data.*
+import kotlinx.coroutines.*
+import kotlinx.coroutines.flow.first
+import org.junit.Assert.*
+import org.junit.Test
+
+class CaptionRecoveryStateTest {
+    @Test fun failedLookupUsesLiveCaptionsAndRetryPreservesThemUntilTranscriptReturns() = runBlocking {
+        val application = InstrumentationRegistry.getInstrumentation().targetContext.applicationContext as Application
+        val preferences = application.getSharedPreferences("dual_sub_preferences", 0)
+        val previousPreload = preferences.getBoolean(PRELOAD_MODELS_ENABLED_PREFERENCE, true)
+        preferences.edit().putBoolean(PRELOAD_MODELS_ENABLED_PREFERENCE, false).commit()
+        var attempts = 0
+        val retryResult = CompletableDeferred<CaptionTrackResult>()
+        val provider = object : CaptionProvider {
+            override suspend fun fetch(videoId: String, preferredLanguages: List<String>): CaptionTrackResult {
+                attempts++
+                if (attempts == 1) throw CaptionUnavailableException("Simulated HTTP 429")
+                return retryResult.await()
+            }
+        }
+        val vm = withContext(Dispatchers.Main) { AppViewModel(application, provider) }
+        val oldTarget = vm.state.value.targetLanguage
+        val oldHighlight = vm.state.value.wordHighlightEnabled
+        val oldTiming = vm.state.value.karaokeTimingMode
+        try {
+            withContext(Dispatchers.Main) {
+                vm.setTargetLanguage("en") // Exercises ML Kit's no-download same-language path.
+                vm.setWordHighlightEnabled(false)
+                vm.setKaraokeTimingMode(KaraokeTimingMode.TRANSCRIPT)
+                vm.onYouTubePageChanged("https://m.youtube.com/watch?v=abcdefghijk")
+            }
+            withTimeout(5000) { vm.state.first { it.liveFallback } }
+            withContext(Dispatchers.Main) {
+                vm.onWebPlaybackSecond("abcdefghijk", 1f, LiveCaptionSample("Hello", 1, 1000, true, "abcdefghijk", "en"))
+            }
+            withTimeout(5000) { vm.state.first { it.liveTranslated == "Hello" } }
+            withContext(Dispatchers.Main) { vm.retryCaptions() }
+            assertEquals("Hello", vm.state.value.liveOriginal)
+            assertEquals("Hello", vm.state.value.liveTranslated)
+            assertTrue(vm.state.value.retryingTranscript)
+            retryResult.complete(CaptionTrackResult("en", false, listOf(RawCaptionCue(0, 5000, "Full transcript"))))
+            withTimeout(5000) { vm.state.first { !it.liveFallback && it.segments.isNotEmpty() } }
+            assertNull(vm.state.value.liveOriginal)
+            assertFalse(vm.state.value.retryingTranscript)
+        } finally {
+            withContext(Dispatchers.Main) {
+                vm.onYouTubePageChanged(YOUTUBE_HOME_URL)
+                vm.setTargetLanguage(oldTarget)
+                vm.setWordHighlightEnabled(oldHighlight)
+                vm.setKaraokeTimingMode(oldTiming)
+            }
+            preferences.edit().putBoolean(PRELOAD_MODELS_ENABLED_PREFERENCE, previousPreload).commit()
+        }
+    }
+}

--- a/app/src/androidTest/java/com/kienhoang/dualsubreplay/ui/NavigationRecoveryUiTest.kt
+++ b/app/src/androidTest/java/com/kienhoang/dualsubreplay/ui/NavigationRecoveryUiTest.kt
@@ -1,0 +1,83 @@
+package com.kienhoang.dualsubreplay.ui
+
+import android.webkit.WebView
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.*
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.test.espresso.Espresso
+import org.junit.Assert.*
+import org.junit.Rule
+import org.junit.Test
+
+class NavigationRecoveryUiTest {
+    @get:Rule val compose = createComposeRule()
+
+    @Test fun drawerNavigatesDismissesAndKeepsWebViewAlive() {
+        var created = 0
+        var disposed = 0
+        var practice = 0
+        var settings = 0
+        compose.setContent {
+            MaterialTheme {
+                AppNavigation(onPractice = { practice++ }, onSettings = { settings++ }) { menu ->
+                    Column {
+                        menu()
+                        AndroidView(factory = { context ->
+                            created++
+                            WebView(context).apply { loadData("<html>Offline video fixture</html>", "text/html", "UTF-8") }
+                        }, modifier = Modifier.weight(1f))
+                        DisposableEffect(Unit) { onDispose { disposed++ } }
+                    }
+                }
+            }
+        }
+        compose.onNodeWithContentDescription("Open navigation menu").performClick()
+        compose.onNodeWithText("Practice").assertIsDisplayed()
+        compose.onNodeWithText("Open-source licenses").performScrollTo().assertIsDisplayed()
+        compose.onNodeWithTag("settings_github_link").assertIsDisplayed()
+        saveUiEvidence("navigation-drawer")
+        compose.onNodeWithText("Open-source licenses").performClick()
+        compose.onNodeWithText("Close").assertIsDisplayed().performClick()
+        compose.onNodeWithText("Practice").assertIsNotDisplayed()
+        compose.onNodeWithContentDescription("Open navigation menu").performClick()
+        Espresso.pressBack()
+        compose.waitForIdle()
+        compose.onNodeWithText("Practice").assertIsNotDisplayed()
+        compose.onNodeWithContentDescription("Open navigation menu").performClick()
+        compose.onNodeWithText("Practice").performScrollTo().performClick()
+        compose.waitForIdle()
+        compose.runOnIdle { assertEquals(1, practice); assertEquals(1, created); assertEquals(0, disposed) }
+        compose.onNodeWithContentDescription("Open navigation menu").performClick()
+        compose.onNodeWithText("Settings").performClick()
+        compose.waitForIdle()
+        compose.runOnIdle { assertEquals(1, settings); assertEquals(1, created); assertEquals(0, disposed) }
+        compose.onNodeWithContentDescription("Open navigation menu").performClick()
+        compose.onRoot().performTouchInput { click(androidx.compose.ui.geometry.Offset(width - 2f, height / 2f)) }
+        compose.waitForIdle()
+        compose.onNodeWithText("Practice").assertIsNotDisplayed()
+    }
+
+    @Test fun livePanelShowsBothLanguagesAndRetriesWithoutReplay() {
+        var retries = 0
+        compose.setContent {
+            MaterialTheme {
+                LiveSubtitlePanel(DualSubUiState(liveFallback = true, liveOriginal = "Hello world",
+                    liveTranslated = "Xin chào thế giới", resolvedSourceLanguage = "en",
+                    wordHighlightEnabled = false, karaokeTimingMode = KaraokeTimingMode.TRANSCRIPT,
+                    wordLearningEnabled = false), onRetry = { retries++ }, onWordClick = {})
+            }
+        }
+        compose.onNodeWithText("Live subtitles").assertIsDisplayed()
+        compose.onNodeWithText("Hello world").assertIsDisplayed()
+        compose.onNodeWithText("Xin chào thế giới").assertIsDisplayed()
+        compose.onNodeWithContentDescription("Replay this paragraph").assertDoesNotExist()
+        saveUiEvidence("live-subtitle-fallback")
+        compose.onNodeWithText("Retry full transcript").performClick()
+        compose.runOnIdle { assertEquals(1, retries) }
+        compose.onNodeWithText("Hello world").assertIsDisplayed()
+    }
+}

--- a/app/src/androidTest/java/com/kienhoang/dualsubreplay/ui/NavigationRecoveryUiTest.kt
+++ b/app/src/androidTest/java/com/kienhoang/dualsubreplay/ui/NavigationRecoveryUiTest.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.viewinterop.AndroidView
+import androidx.compose.ui.unit.dp
 import androidx.test.espresso.Espresso
 import org.junit.Assert.*
 import org.junit.Rule
@@ -35,7 +36,9 @@ class NavigationRecoveryUiTest {
                 }
             }
         }
-        compose.onNodeWithContentDescription("Open navigation menu").performClick()
+        compose.onNodeWithTag("navigation_menu_button")
+            .assertWidthIsEqualTo(72.dp).assertHeightIsEqualTo(48.dp)
+            .performTouchInput { click(androidx.compose.ui.geometry.Offset(width - 4f, height / 2f)) }
         compose.onNodeWithText("Practice").assertIsDisplayed()
         compose.onNodeWithText("Open-source licenses").performScrollTo().assertIsDisplayed()
         compose.onNodeWithTag("settings_github_link").assertIsDisplayed()

--- a/app/src/androidTest/java/com/kienhoang/dualsubreplay/ui/SavedWordsScreenTest.kt
+++ b/app/src/androidTest/java/com/kienhoang/dualsubreplay/ui/SavedWordsScreenTest.kt
@@ -1,0 +1,47 @@
+package com.kienhoang.dualsubreplay.ui
+
+import androidx.compose.ui.test.*
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.test.platform.app.InstrumentationRegistry
+import com.kienhoang.dualsubreplay.data.*
+import com.kienhoang.dualsubreplay.ui.theme.DualSubTheme
+import java.util.UUID
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.*
+import org.junit.Rule
+import org.junit.Test
+
+class SavedWordsScreenTest {
+    @get:Rule val compose = createComposeRule()
+
+    @Test fun practiceRevealsMeaningAndPersistsRatingWithoutAnyClips() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val name = "vocabulary-ui-${UUID.randomUUID()}.db"
+        val repository = VocabularyRepository(context, name)
+        val visible = androidx.compose.runtime.mutableStateOf(true)
+        val word = savedWordFrom(LearningWordSelection(AnalyzedToken("learn", 0, 5, PartOfSpeech.VERB), "en", "vi",
+            "dQw4w9WgXcQ", SubtitleSegment(1, 1000, 3000, "Learn a word", "Học một từ"), false), "học", false, false)
+        runBlocking { repository.save(word) }
+        try {
+            compose.setContent { DualSubTheme { if (visible.value) SavedWordsScreen(repository, {}, {}, {}) } }
+            compose.waitForIdle()
+            saveUiEvidence("saved-words")
+            compose.onNodeWithTag("practice_words").performClick()
+            compose.onNodeWithTag("review_meaning").assertDoesNotExist()
+            compose.onNodeWithTag("reveal_meaning").performClick()
+            compose.onNodeWithTag("review_meaning").assertTextEquals("học")
+            compose.onNodeWithTag("play_online_clip").assertDoesNotExist()
+            compose.onNodeWithTag("play_offline_clip").assertDoesNotExist()
+            saveUiEvidence("word-practice")
+            compose.onNodeWithTag("review_good").performScrollTo().performClick()
+            compose.waitUntil(5000) { repository.words.value.single().intervalMs == 3 * DAY_MS }
+            compose.onNodeWithTag("practice_complete").assertIsDisplayed()
+            assertTrue(repository.words.value.single().dueAt > System.currentTimeMillis())
+        } finally {
+            // Dispose the screen before closing the isolated test database.
+            compose.runOnIdle { visible.value = false }
+            compose.waitForIdle()
+            repository.close(); context.deleteDatabase(name)
+        }
+    }
+}

--- a/app/src/androidTest/java/com/kienhoang/dualsubreplay/ui/SubtitleUiTest.kt
+++ b/app/src/androidTest/java/com/kienhoang/dualsubreplay/ui/SubtitleUiTest.kt
@@ -49,6 +49,7 @@ class SubtitleUiTest {
         composeRule.onNodeWithText("Original language").assertIsDisplayed()
         composeRule.onNodeWithText("Translate to").assertIsDisplayed()
         composeRule.onNodeWithText("Vietnamese").assertIsDisplayed()
+        saveUiEvidence("settings")
         composeRule.onNodeWithText("Focus").assertDoesNotExist()
         composeRule.onNodeWithTag("source_language_picker").performClick()
         composeRule.onNodeWithTag("language_option_source_ja").performClick()

--- a/app/src/androidTest/java/com/kienhoang/dualsubreplay/ui/UiEvidence.kt
+++ b/app/src/androidTest/java/com/kienhoang/dualsubreplay/ui/UiEvidence.kt
@@ -1,0 +1,14 @@
+package com.kienhoang.dualsubreplay.ui
+
+import android.graphics.Bitmap
+import androidx.test.platform.app.InstrumentationRegistry
+import java.io.File
+
+internal fun saveUiEvidence(name: String) {
+    val instrumentation = InstrumentationRegistry.getInstrumentation()
+    val output = InstrumentationRegistry.getArguments().getString("additionalTestOutputDir") ?: return
+    val directory = File(output).apply { mkdirs() }
+    val screenshot = instrumentation.uiAutomation.takeScreenshot() ?: return
+    File(directory, "$name.png").outputStream().use { screenshot.compress(Bitmap.CompressFormat.PNG, 100, it) }
+    screenshot.recycle()
+}

--- a/app/src/androidTest/java/com/kienhoang/dualsubreplay/ui/WordLearningDialogTest.kt
+++ b/app/src/androidTest/java/com/kienhoang/dualsubreplay/ui/WordLearningDialogTest.kt
@@ -26,6 +26,7 @@ class WordLearningDialogTest {
         compose.runOnIdle { assertEquals(1, spoken); recompose.value = "Voice ready" }
         compose.waitForIdle()
         compose.runOnIdle { assertEquals(1, spoken) }
+        saveUiEvidence("word-definition")
         compose.onNodeWithTag("offline_clip_choice").performScrollTo().performClick()
         compose.onNodeWithTag("save_word").performClick()
         compose.waitForIdle()

--- a/app/src/androidTest/java/com/kienhoang/dualsubreplay/ui/WordLearningDialogTest.kt
+++ b/app/src/androidTest/java/com/kienhoang/dualsubreplay/ui/WordLearningDialogTest.kt
@@ -1,0 +1,45 @@
+package com.kienhoang.dualsubreplay.ui
+
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.test.*
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import com.kienhoang.dualsubreplay.data.*
+import com.kienhoang.dualsubreplay.ui.theme.DualSubTheme
+import org.junit.Assert.*
+import org.junit.Rule
+import org.junit.Test
+
+class WordLearningDialogTest {
+    @get:Rule val compose = createComposeRule()
+    private val selection = LearningWordSelection(AnalyzedToken("word", 0, 4, PartOfSpeech.NOUN), "en", "vi",
+        "dQw4w9WgXcQ", SubtitleSegment(1, 1000, 3000, "a word", null), false)
+
+    @Test fun pronouncesOnceAndSavesBothOptionalClipChoices() {
+        var spoken = 0
+        var saved: Triple<String, Boolean, Boolean>? = null
+        val recompose = mutableStateOf<String?>(null)
+        compose.setContent { DualSubTheme {
+            WordLearningDialog(selection, true, { "từ" }, { meaning, online, offline -> saved = Triple(meaning, online, offline) },
+                { spoken++ }, recompose.value, {})
+        } }
+        compose.waitForIdle()
+        compose.runOnIdle { assertEquals(1, spoken); recompose.value = "Voice ready" }
+        compose.waitForIdle()
+        compose.runOnIdle { assertEquals(1, spoken) }
+        compose.onNodeWithTag("offline_clip_choice").performScrollTo().performClick()
+        compose.onNodeWithTag("save_word").performClick()
+        compose.waitForIdle()
+        compose.runOnIdle { assertEquals(Triple("từ", true, true), saved) }
+        compose.onNodeWithTag("word_saved").performScrollTo().assertIsDisplayed()
+    }
+    @Test fun manualSpeechWorksWhenAutomaticSpeechIsDisabled() {
+        var spoken = 0
+        compose.setContent { DualSubTheme {
+            WordLearningDialog(selection, false, { "từ" }, { _, _, _ -> }, { spoken++ }, null, {})
+        } }
+        compose.waitForIdle()
+        compose.runOnIdle { assertEquals(0, spoken) }
+        compose.onNodeWithTag("pronounce_word").performClick()
+        compose.runOnIdle { assertEquals(1, spoken) }
+    }
+}

--- a/app/src/androidTest/java/com/kienhoang/dualsubreplay/ui/WordLearningDialogTest.kt
+++ b/app/src/androidTest/java/com/kienhoang/dualsubreplay/ui/WordLearningDialogTest.kt
@@ -43,4 +43,17 @@ class WordLearningDialogTest {
         compose.onNodeWithTag("pronounce_word").performClick()
         compose.runOnIdle { assertEquals(1, spoken) }
     }
+
+    @Test fun liveWordCanBeSavedWithoutOfferingUnreliableClipExamples() {
+        var saved: Triple<String, Boolean, Boolean>? = null
+        compose.setContent { DualSubTheme {
+            WordLearningDialog(selection.copy(videoId = null, segment = null), false, { "từ" },
+                { meaning, online, offline -> saved = Triple(meaning, online, offline) }, {}, null, {})
+        } }
+        compose.onNodeWithTag("offline_clip_choice").assertDoesNotExist()
+        compose.onNodeWithTag("online_clip_choice").assertDoesNotExist()
+        compose.onNodeWithTag("save_word").performClick()
+        compose.waitForIdle()
+        compose.runOnIdle { assertEquals(Triple("từ", false, false), saved) }
+    }
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,7 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <queries>
+        <intent><action android:name="android.intent.action.TTS_SERVICE" /></intent>
+    </queries>
 
     <application
         android:allowBackup="true"
@@ -11,6 +18,8 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.DualSubReplay"
         android:usesCleartextTraffic="false">
+        <service android:name="androidx.work.impl.foreground.SystemForegroundService"
+            android:foregroundServiceType="dataSync" tools:node="merge" />
 
         <meta-data
             android:name="android.webkit.WebView.EnableSafeBrowsing"

--- a/app/src/main/assets/licenses/GPL-3.0.txt
+++ b/app/src/main/assets/licenses/GPL-3.0.txt
@@ -1,0 +1,674 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<https://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<https://www.gnu.org/licenses/why-not-lgpl.html>.

--- a/app/src/main/assets/licenses/MIT.txt
+++ b/app/src/main/assets/licenses/MIT.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Hoang Trung Kien
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/app/src/main/java/com/kienhoang/dualsubreplay/data/ClipDownloadWorker.kt
+++ b/app/src/main/java/com/kienhoang/dualsubreplay/data/ClipDownloadWorker.kt
@@ -92,12 +92,19 @@ internal class ClipDownloadWorker(context: Context, params: WorkerParameters) : 
                         val transfer = async { backend.download(request, temporary) { percent ->
                             setProgressAsync(Data.Builder().putInt("percent", percent).build())
                         } }
-                        while (!transfer.isCompleted) {
-                            delay(500)
-                            val bytes = withContext(Dispatchers.IO) { temporary.walkTopDown().filter { it.isFile }.sumOf { it.length() } }
-                            check(bytes <= MAX_CLIP_BYTES) { "Clip exceeds the 100 MiB storage limit" }
+                        try {
+                            while (!transfer.isCompleted) {
+                                delay(500)
+                                val bytes = withContext(Dispatchers.IO) { temporary.walkTopDown().filter { it.isFile }.sumOf { it.length() } }
+                                check(bytes <= MAX_CLIP_BYTES) { "Clip exceeds the 100 MiB storage limit" }
+                            }
+                            transfer.await()
+                        } catch (error: Exception) {
+                            withContext(kotlinx.coroutines.NonCancellable + Dispatchers.IO) {
+                                runCatching { backend.cancel(request.processId) }
+                            }
+                            throw error
                         }
-                        transfer.await()
                     }
                 }
                 withContext(Dispatchers.IO) {

--- a/app/src/main/java/com/kienhoang/dualsubreplay/data/ClipDownloadWorker.kt
+++ b/app/src/main/java/com/kienhoang/dualsubreplay/data/ClipDownloadWorker.kt
@@ -1,0 +1,173 @@
+package com.kienhoang.dualsubreplay.data
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.content.Context
+import android.content.pm.ServiceInfo
+import android.media.MediaMetadataRetriever
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import androidx.work.CoroutineWorker
+import androidx.work.Data
+import androidx.work.ExistingWorkPolicy
+import androidx.work.ForegroundInfo
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.WorkerParameters
+import com.yausername.ffmpeg.FFmpeg
+import com.yausername.youtubedl_android.YoutubeDL
+import com.yausername.youtubedl_android.YoutubeDLRequest
+import java.io.File
+import java.util.Locale
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runInterruptible
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
+
+internal data class ClipRequest(val videoId: String, val startMs: Long, val endMs: Long, val processId: String)
+internal interface ClipDownloadBackend {
+    suspend fun download(request: ClipRequest, directory: File, progress: (Int) -> Unit): File
+    fun cancel(processId: String)
+}
+
+internal fun clipDownloadArguments(request: ClipRequest, output: File): List<Pair<String, String?>> {
+    require(validClipRange(request.videoId, request.startMs, request.endMs))
+    return listOf(
+        "--no-playlist" to null, "--no-cache-dir" to null,
+        "--socket-timeout" to "20", "--retries" to "2", "--fragment-retries" to "2",
+        "--download-sections" to String.format(Locale.ROOT, "*%.3f-%.3f", request.startMs / 1000.0, request.endMs / 1000.0),
+        "--force-keyframes-at-cuts" to null,
+        "-f" to "bv[height<=480][ext=mp4][vcodec^=avc1]+ba[ext=m4a]/b[height<=480][ext=mp4]",
+        "--merge-output-format" to "mp4", "--recode-video" to "mp4",
+        "-o" to output.absolutePath,
+    )
+}
+
+internal class YoutubeClipBackend(private val context: Context) : ClipDownloadBackend {
+    override suspend fun download(request: ClipRequest, directory: File, progress: (Int) -> Unit): File =
+        runInterruptible(Dispatchers.IO) {
+            YoutubeDL.getInstance().init(context)
+            FFmpeg.getInstance().init(context)
+            val command = YoutubeDLRequest("https://www.youtube.com/watch?v=${request.videoId}")
+            clipDownloadArguments(request, File(directory, "clip.%(ext)s")).forEach { (key, value) ->
+                if (value == null) command.addOption(key) else command.addOption(key, value)
+            }
+            YoutubeDL.getInstance().execute(command, request.processId, true) { percent, _, _ ->
+                progress(percent.toInt().coerceIn(0, 99))
+            }
+            File(directory, "clip.mp4").also { check(it.isFile && it.length() > 0) { "No playable clip was downloaded" } }
+        }
+
+    override fun cancel(processId: String) { YoutubeDL.getInstance().destroyProcessById(processId) }
+}
+
+internal const val MAX_CLIP_BYTES = 100L * 1024 * 1024
+internal const val CLIP_JOB_TIMEOUT_MS = 600_000L
+
+internal class ClipDownloadWorker(context: Context, params: WorkerParameters) : CoroutineWorker(context, params) {
+    override suspend fun doWork(): Result {
+        val wordId = inputData.getString("wordId") ?: return Result.failure()
+        val generation = inputData.getLong("generation", -1)
+        val repository = VocabularyRepository.get(applicationContext)
+        repository.refresh()
+        val word = repository.words.value.firstOrNull { it.id == wordId && it.clipGeneration == generation && it.offline }
+            ?: return Result.success()
+        if (word.clipStatus == "ready" && repository.clipFile(word).isFile) return Result.success()
+        val backend = YoutubeClipBackend(applicationContext)
+        val request = ClipRequest(word.videoId.orEmpty(), word.startMs, word.endMs, id.toString())
+        val temporary = File(repository.clipDirectory, "${word.id}-$generation-${id}.part")
+        try {
+            setForeground(foregroundInfo())
+            downloadLock.withLock {
+                repository.update(wordId) { if (it.clipGeneration == generation) it.copy(clipStatus = "downloading", clipError = null) else it }
+                withContext(Dispatchers.IO) { check(temporary.mkdirs() || temporary.isDirectory) }
+                val file = withTimeout(CLIP_JOB_TIMEOUT_MS) {
+                    coroutineScope {
+                        val transfer = async { backend.download(request, temporary) { percent ->
+                            setProgressAsync(Data.Builder().putInt("percent", percent).build())
+                        } }
+                        while (!transfer.isCompleted) {
+                            delay(500)
+                            val bytes = withContext(Dispatchers.IO) { temporary.walkTopDown().filter { it.isFile }.sumOf { it.length() } }
+                            check(bytes <= MAX_CLIP_BYTES) { "Clip exceeds the 100 MiB storage limit" }
+                        }
+                        transfer.await()
+                    }
+                }
+                withContext(Dispatchers.IO) {
+                    check(file.length() <= MAX_CLIP_BYTES) { "Clip exceeds the 100 MiB storage limit" }
+                    val media = MediaMetadataRetriever()
+                    try {
+                        media.setDataSource(file.absolutePath)
+                        val duration = media.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION)?.toLongOrNull() ?: 0
+                        check(duration > 0 && kotlin.math.abs(duration - (word.endMs - word.startMs)) <= 2000) { "Downloaded clip has an unexpected duration" }
+                        check(media.extractMetadata(MediaMetadataRetriever.METADATA_KEY_HAS_AUDIO) == "yes" &&
+                            media.extractMetadata(MediaMetadataRetriever.METADATA_KEY_HAS_VIDEO) == "yes") { "Clip must contain video and audio" }
+                    } finally { media.release() }
+                }
+                repository.update(wordId) { current ->
+                    if (current.clipGeneration != generation || !current.offline || current.clipStatus != "downloading") current
+                    else {
+                        check(file.renameTo(repository.clipFile(current))) { "Could not store the downloaded clip" }
+                        current.copy(clipStatus = "ready", clipError = null)
+                    }
+                }
+            }
+            return Result.success()
+        } catch (error: Exception) {
+            withContext(kotlinx.coroutines.NonCancellable) {
+                repository.update(wordId) {
+                    if (it.clipGeneration != generation) it else it.copy(clipStatus = "failed", clipError =
+                        if (error is CancellationException) "Download interrupted. Tap Retry to start again."
+                        else "Download unavailable. Check your connection and storage, then retry.")
+                }
+            }
+            if (error is CancellationException) throw error
+            return Result.failure()
+        } finally {
+            withContext(kotlinx.coroutines.NonCancellable + Dispatchers.IO) {
+                runCatching { backend.cancel(request.processId) }
+                temporary.deleteRecursively()
+            }
+        }
+    }
+
+    private fun foregroundInfo(): ForegroundInfo {
+        val manager = applicationContext.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        manager.createNotificationChannel(NotificationChannel("word_clips", "Word clip downloads", NotificationManager.IMPORTANCE_LOW))
+        val notification = NotificationCompat.Builder(applicationContext, "word_clips")
+            .setSmallIcon(android.R.drawable.stat_sys_download).setContentTitle("Saving a word clip")
+            .setContentText("Downloading and trimming your example video")
+            .setProgress(0, 0, true).setOngoing(true)
+            .addAction(android.R.drawable.ic_delete, "Cancel", WorkManager.getInstance(applicationContext).createCancelPendingIntent(id))
+            .build()
+        return if (Build.VERSION.SDK_INT >= 29) ForegroundInfo(id.hashCode(), notification, ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC)
+        else ForegroundInfo(id.hashCode(), notification)
+    }
+
+    companion object { private val downloadLock = Mutex() }
+}
+
+internal suspend fun enqueueClip(context: Context, wordId: String) {
+    val repository = VocabularyRepository.get(context)
+    val word = repository.update(wordId) {
+        it.copy(offline = true, clipGeneration = it.clipGeneration + 1, clipStatus = "queued", clipError = null)
+    } ?: return
+    val work = OneTimeWorkRequestBuilder<ClipDownloadWorker>()
+        .setInputData(Data.Builder().putString("wordId", word.id).putLong("generation", word.clipGeneration).build())
+        .addTag("word-clip").addTag("word:${word.id}").build()
+    WorkManager.getInstance(context).enqueueUniqueWork("word-clip-${word.id}", ExistingWorkPolicy.REPLACE, work)
+}
+
+internal suspend fun removeClip(context: Context, word: SavedWord) {
+    val repository = VocabularyRepository.get(context)
+    repository.update(word.id) { it.copy(offline = false, clipStatus = "none", clipError = null, clipGeneration = it.clipGeneration + 1) }
+    WorkManager.getInstance(context).cancelUniqueWork("word-clip-${word.id}")
+    withContext(Dispatchers.IO) { repository.clipFile(word).delete() }
+}

--- a/app/src/main/java/com/kienhoang/dualsubreplay/data/SavedWord.kt
+++ b/app/src/main/java/com/kienhoang/dualsubreplay/data/SavedWord.kt
@@ -1,0 +1,69 @@
+package com.kienhoang.dualsubreplay.data
+
+import java.security.MessageDigest
+import java.util.Locale
+
+data class WordTap(val token: AnalyzedToken, val segment: SubtitleSegment?, val translated: Boolean)
+
+data class LearningWordSelection(
+    val token: AnalyzedToken,
+    val wordLanguage: String,
+    val meaningLanguage: String,
+    val videoId: String?,
+    val segment: SubtitleSegment?,
+    val translated: Boolean,
+)
+
+data class SavedWord(
+    val id: String,
+    val word: String,
+    val reading: String?,
+    val wordLanguage: String,
+    val meaningLanguage: String,
+    val meaning: String,
+    val sentence: String,
+    val translatedSentence: String?,
+    val videoId: String?,
+    val startMs: Long,
+    val endMs: Long,
+    val translated: Boolean,
+    val online: Boolean = true,
+    val offline: Boolean = false,
+    val clipStatus: String = "none",
+    val clipError: String? = null,
+    val clipGeneration: Long = 0,
+    val dueAt: Long = 0,
+    val intervalMs: Long = 0,
+)
+
+enum class ReviewRating { AGAIN, HARD, GOOD, EASY }
+internal const val DAY_MS = 86_400_000L
+
+internal fun reviewInterval(previous: Long, rating: ReviewRating): Long = when (rating) {
+    ReviewRating.AGAIN -> 600_000L
+    ReviewRating.HARD -> if (previous < DAY_MS) DAY_MS else (previous * 1.2).toLong()
+    ReviewRating.GOOD -> if (previous < DAY_MS) 3 * DAY_MS else previous * 2
+    ReviewRating.EASY -> if (previous < DAY_MS) 7 * DAY_MS else previous * 3
+}.coerceIn(600_000L, 3650 * DAY_MS)
+
+internal fun reviewWord(word: SavedWord, rating: ReviewRating, now: Long): SavedWord {
+    val interval = reviewInterval(word.intervalMs, rating)
+    return word.copy(dueAt = now + interval, intervalMs = interval)
+}
+
+internal fun validClipRange(videoId: String?, start: Long, end: Long): Boolean =
+    videoId?.matches(Regex("[A-Za-z0-9_-]{11}")) == true && start >= 0 && end > start
+
+internal fun savedWordFrom(selection: LearningWordSelection, meaning: String, online: Boolean, offline: Boolean): SavedWord {
+    val segment = selection.segment
+    val word = selection.token.text.trim()
+    val key = listOf(word.lowercase(Locale.ROOT), selection.wordLanguage, selection.meaningLanguage,
+        selection.videoId.orEmpty(), segment?.startMs.toString(), segment?.endMs.toString()).joinToString("\u0000")
+    val id = MessageDigest.getInstance("SHA-256").digest(key.toByteArray(Charsets.UTF_8))
+        .joinToString("") { "%02x".format(it) }
+    val hasClip = validClipRange(selection.videoId, segment?.startMs ?: -1, segment?.endMs ?: -1)
+    return SavedWord(id, word, selection.token.reading, selection.wordLanguage, selection.meaningLanguage,
+        meaning.trim(), segment?.originalText.orEmpty(), segment?.translatedText, selection.videoId,
+        segment?.startMs ?: 0, segment?.endMs ?: 0, selection.translated,
+        online = online && hasClip, offline = offline && hasClip)
+}

--- a/app/src/main/java/com/kienhoang/dualsubreplay/data/SavedWord.kt
+++ b/app/src/main/java/com/kienhoang/dualsubreplay/data/SavedWord.kt
@@ -14,6 +14,10 @@ data class LearningWordSelection(
     val translated: Boolean,
 )
 
+internal fun learningSelection(tap: WordTap, source: String, target: String, videoId: String?): LearningWordSelection =
+    LearningWordSelection(tap.token, if (tap.translated) target else source,
+        if (tap.translated) source else target, videoId, tap.segment, tap.translated)
+
 data class SavedWord(
     val id: String,
     val word: String,

--- a/app/src/main/java/com/kienhoang/dualsubreplay/data/VocabularyRepository.kt
+++ b/app/src/main/java/com/kienhoang/dualsubreplay/data/VocabularyRepository.kt
@@ -1,0 +1,102 @@
+package com.kienhoang.dualsubreplay.data
+
+import android.content.ContentValues
+import android.content.Context
+import android.database.sqlite.SQLiteDatabase
+import android.database.sqlite.SQLiteOpenHelper
+import java.io.File
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import org.json.JSONObject
+
+/** Separate from preferences: resetting appearance/settings never erases learning history. */
+internal class VocabularyRepository private constructor(context: Context) {
+    private val database = object : SQLiteOpenHelper(context, "vocabulary.db", null, 1) {
+        override fun onCreate(db: SQLiteDatabase) {
+            db.execSQL("CREATE TABLE words (id TEXT PRIMARY KEY, payload TEXT NOT NULL)")
+        }
+        override fun onUpgrade(db: SQLiteDatabase, oldVersion: Int, newVersion: Int) = Unit
+    }
+    val clipDirectory = File(context.noBackupFilesDir, "word-clips")
+    private val mutex = Mutex()
+    private val _words = MutableStateFlow<List<SavedWord>>(emptyList())
+    val words = _words.asStateFlow()
+
+    fun clipFile(word: SavedWord): File = File(clipDirectory, "${word.id}-${word.clipGeneration}.mp4")
+
+    suspend fun refresh() = withContext(Dispatchers.IO) { mutex.withLock { publish() } }
+
+    private fun readAll(): List<SavedWord> = database.readableDatabase.query(
+        "words", arrayOf("payload"), null, null, null, null, "rowid DESC",
+    ).use { cursor -> buildList {
+        while (cursor.moveToNext()) add(decodeWord(JSONObject(cursor.getString(0))))
+    } }
+
+    private fun publish() { _words.value = readAll() }
+    private fun write(word: SavedWord) {
+        database.writableDatabase.insertWithOnConflict("words", null, ContentValues().apply {
+            put("id", word.id)
+            put("payload", encodeWord(word).toString())
+        }, SQLiteDatabase.CONFLICT_REPLACE).also { check(it != -1L) { "Could not save word" } }
+    }
+
+    suspend fun save(word: SavedWord): SavedWord = withContext(Dispatchers.IO) { mutex.withLock {
+        val old = readAll().firstOrNull { it.id == word.id }
+        val updated = if (old == null) word else word.copy(
+            dueAt = old.dueAt, intervalMs = old.intervalMs, clipGeneration = old.clipGeneration,
+            clipStatus = old.clipStatus, clipError = old.clipError,
+        )
+        write(updated)
+        publish()
+        updated
+    } }
+
+    suspend fun update(id: String, change: (SavedWord) -> SavedWord): SavedWord? = withContext(Dispatchers.IO) {
+        mutex.withLock {
+            val old = readAll().firstOrNull { it.id == id } ?: return@withLock null
+            val updated = change(old)
+            write(updated)
+            publish()
+            updated
+        }
+    }
+
+    suspend fun remove(id: String) = withContext(Dispatchers.IO) { mutex.withLock {
+        database.writableDatabase.delete("words", "id = ?", arrayOf(id))
+        // Filenames are generated SHA-256 IDs, never user-provided paths.
+        clipDirectory.listFiles()?.filter { it.name.startsWith("$id-") }?.forEach { it.delete() }
+        publish()
+    } }
+
+    companion object {
+        @Volatile private var instance: VocabularyRepository? = null
+        fun get(context: Context): VocabularyRepository = instance ?: synchronized(this) {
+            instance ?: VocabularyRepository(context.applicationContext).also { instance = it }
+        }
+    }
+}
+
+internal fun encodeWord(w: SavedWord): JSONObject = JSONObject().apply {
+    put("id", w.id); put("word", w.word); put("reading", w.reading)
+    put("wordLanguage", w.wordLanguage); put("meaningLanguage", w.meaningLanguage)
+    put("meaning", w.meaning); put("sentence", w.sentence); put("translatedSentence", w.translatedSentence)
+    put("videoId", w.videoId); put("startMs", w.startMs); put("endMs", w.endMs)
+    put("translated", w.translated); put("online", w.online); put("offline", w.offline)
+    put("clipStatus", w.clipStatus); put("clipError", w.clipError); put("clipGeneration", w.clipGeneration)
+    put("dueAt", w.dueAt); put("intervalMs", w.intervalMs)
+}
+
+internal fun decodeWord(j: JSONObject): SavedWord = SavedWord(
+    id = j.getString("id"), word = j.getString("word"), reading = j.optString("reading").takeIf { it.isNotBlank() },
+    wordLanguage = j.getString("wordLanguage"), meaningLanguage = j.getString("meaningLanguage"),
+    meaning = j.getString("meaning"), sentence = j.getString("sentence"),
+    translatedSentence = j.optString("translatedSentence").takeIf { it.isNotBlank() },
+    videoId = j.optString("videoId").takeIf { it.isNotBlank() }, startMs = j.getLong("startMs"), endMs = j.getLong("endMs"),
+    translated = j.getBoolean("translated"), online = j.getBoolean("online"), offline = j.getBoolean("offline"),
+    clipStatus = j.optString("clipStatus", "none"), clipError = j.optString("clipError").takeIf { it.isNotBlank() },
+    clipGeneration = j.optLong("clipGeneration"), dueAt = j.optLong("dueAt"), intervalMs = j.optLong("intervalMs"),
+)

--- a/app/src/main/java/com/kienhoang/dualsubreplay/data/VocabularyRepository.kt
+++ b/app/src/main/java/com/kienhoang/dualsubreplay/data/VocabularyRepository.kt
@@ -14,8 +14,8 @@ import kotlinx.coroutines.withContext
 import org.json.JSONObject
 
 /** Separate from preferences: resetting appearance/settings never erases learning history. */
-internal class VocabularyRepository private constructor(context: Context) {
-    private val database = object : SQLiteOpenHelper(context, "vocabulary.db", null, 1) {
+internal class VocabularyRepository internal constructor(context: Context, databaseName: String = "vocabulary.db") {
+    private val database = object : SQLiteOpenHelper(context, databaseName, null, 1) {
         override fun onCreate(db: SQLiteDatabase) {
             db.execSQL("CREATE TABLE words (id TEXT PRIMARY KEY, payload TEXT NOT NULL)")
         }
@@ -25,6 +25,7 @@ internal class VocabularyRepository private constructor(context: Context) {
     private val mutex = Mutex()
     private val _words = MutableStateFlow<List<SavedWord>>(emptyList())
     val words = _words.asStateFlow()
+    internal fun close() = database.close()
 
     fun clipFile(word: SavedWord): File = File(clipDirectory, "${word.id}-${word.clipGeneration}.mp4")
 

--- a/app/src/main/java/com/kienhoang/dualsubreplay/data/VocabularyRepository.kt
+++ b/app/src/main/java/com/kienhoang/dualsubreplay/data/VocabularyRepository.kt
@@ -21,7 +21,7 @@ internal class VocabularyRepository internal constructor(context: Context, datab
         }
         override fun onUpgrade(db: SQLiteDatabase, oldVersion: Int, newVersion: Int) = Unit
     }
-    val clipDirectory = File(context.noBackupFilesDir, "word-clips")
+    val clipDirectory = File(context.noBackupFilesDir, if (databaseName == "vocabulary.db") "word-clips" else "clips-$databaseName")
     private val mutex = Mutex()
     private val _words = MutableStateFlow<List<SavedWord>>(emptyList())
     val words = _words.asStateFlow()
@@ -30,6 +30,24 @@ internal class VocabularyRepository internal constructor(context: Context, datab
     fun clipFile(word: SavedWord): File = File(clipDirectory, "${word.id}-${word.clipGeneration}.mp4")
 
     suspend fun refresh() = withContext(Dispatchers.IO) { mutex.withLock { publish() } }
+
+    /** Recover after process death/cancellation, without touching files owned by active jobs. */
+    suspend fun reconcileDownloads(context: Context) = withContext(Dispatchers.IO) { mutex.withLock {
+        val activeWords = androidx.work.WorkManager.getInstance(context).getWorkInfosByTag("word-clip").get()
+            .filter { !it.state.isFinished }.flatMap { it.tags }
+            .filter { it.startsWith("word:") }.map { it.removePrefix("word:") }.toSet()
+        val wordsById = readAll().associateBy { it.id }
+        clipDirectory.listFiles()?.forEach { file ->
+            val owner = wordsById[file.name.substringBefore('-')]
+            if (owner?.id !in activeWords && (owner == null || owner.clipStatus != "ready" || file != clipFile(owner))) {
+                file.deleteRecursively()
+            }
+        }
+        wordsById.values.filter { it.id !in activeWords && it.clipStatus in listOf("queued", "downloading") }.forEach {
+            write(it.copy(clipStatus = "failed", clipError = "Download interrupted. Tap Retry to start again."))
+        }
+        publish()
+    } }
 
     private fun readAll(): List<SavedWord> = database.readableDatabase.query(
         "words", arrayOf("payload"), null, null, null, null, "rowid DESC",

--- a/app/src/main/java/com/kienhoang/dualsubreplay/data/YouTubeCaptionProvider.kt
+++ b/app/src/main/java/com/kienhoang/dualsubreplay/data/YouTubeCaptionProvider.kt
@@ -39,6 +39,7 @@ internal data class YouTubePlayerClient(
     val deviceModel: String? = null,
     val osName: String? = null,
     val osVersion: String? = null,
+    val embedUrl: String? = null,
 )
 
 private val INNERTUBE_CLIENT_VERSION_REGEX =
@@ -100,7 +101,49 @@ internal fun extractJsonObject(text: String, objectStart: Int): String? {
     return null
 }
 
+/**
+ * Keep the most reliable logged-out caption clients first. YouTube changed player access again in
+ * mid-2026: older Android/iOS/Web profiles can now return UNPLAYABLE even while the same video is
+ * playing normally in the embedded WebView. visionOS is the current no-JS player fallback and
+ * Android VR plus the embedded web player provide additional compatibility for videos that reject
+ * one client family.
+ */
 internal fun youtubePlayerClients(webClientVersion: String?): List<YouTubePlayerClient> = listOf(
+    YouTubePlayerClient(
+        label = "visionOS",
+        clientName = "VISIONOS",
+        clientNumber = "101",
+        clientVersion = "1.02",
+        userAgent =
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 15_7_3) AppleWebKit/605.1.15 " +
+                "(KHTML, like Gecko) Version/26.0 Safari/605.1.15",
+        deviceMake = "Apple",
+        deviceModel = "RealityDevice17,1",
+        osName = "visionOS",
+        osVersion = "26.5.23O471",
+    ),
+    YouTubePlayerClient(
+        label = "Android VR",
+        clientName = "ANDROID_VR",
+        clientNumber = "28",
+        clientVersion = "1.65.10",
+        userAgent =
+            "com.google.android.apps.youtube.vr.oculus/1.65.10 " +
+                "(Linux; U; Android 12L; eureka-user Build/SQ3A.220605.009.A1) gzip",
+        androidSdkVersion = 32,
+        deviceMake = "Oculus",
+        deviceModel = "Quest 3",
+        osName = "Android",
+        osVersion = "12L",
+    ),
+    YouTubePlayerClient(
+        label = "Web embedded",
+        clientName = "WEB_EMBEDDED_PLAYER",
+        clientNumber = "56",
+        clientVersion = webClientVersion?.takeIf(String::isNotBlank) ?: DEFAULT_WEB_CLIENT_VERSION,
+        userAgent = WEB_USER_AGENT,
+        embedUrl = "https://www.reddit.com/",
+    ),
     YouTubePlayerClient(
         label = "Android current",
         clientName = "ANDROID",
@@ -121,6 +164,13 @@ internal fun youtubePlayerClients(webClientVersion: String?): List<YouTubePlayer
         deviceModel = "iPhone16,2",
         osName = "iPhone",
         osVersion = "18.3.2.22D82",
+    ),
+    YouTubePlayerClient(
+        label = "TV downgraded",
+        clientName = "TVHTML5",
+        clientNumber = "7",
+        clientVersion = "5.20260707",
+        userAgent = "Mozilla/5.0 (ChromiumStylePlatform) Cobalt/Version",
     ),
     YouTubePlayerClient(
         label = "TV",
@@ -144,6 +194,30 @@ internal fun playerApiUrls(apiKey: String): List<String> = listOf(
     "https://youtubei.googleapis.com/youtubei/v1/player?key=$apiKey",
     "https://www.youtube.com/youtubei/v1/player?key=$apiKey",
 )
+
+internal fun playerRequestBody(videoId: String, profile: YouTubePlayerClient): JSONObject {
+    val clientContext = JSONObject()
+        .put("clientName", profile.clientName)
+        .put("clientVersion", profile.clientVersion)
+        .put("userAgent", profile.userAgent)
+        .put("hl", "en")
+        .put("gl", "US")
+    profile.androidSdkVersion?.let { clientContext.put("androidSdkVersion", it) }
+    profile.deviceMake?.let { clientContext.put("deviceMake", it) }
+    profile.deviceModel?.let { clientContext.put("deviceModel", it) }
+    profile.osName?.let { clientContext.put("osName", it) }
+    profile.osVersion?.let { clientContext.put("osVersion", it) }
+
+    val context = JSONObject().put("client", clientContext)
+    profile.embedUrl?.let { embedUrl ->
+        context.put("thirdParty", JSONObject().put("embedUrl", embedUrl))
+    }
+    return JSONObject()
+        .put("context", context)
+        .put("videoId", videoId)
+        .put("contentCheckOk", true)
+        .put("racyCheckOk", true)
+}
 
 internal fun trustedYouTubeCaptionUrl(url: String): HttpUrl? {
     val parsed = url.toHttpUrlOrNull() ?: return null
@@ -354,23 +428,7 @@ class YouTubeCaptionProvider(
         profile: YouTubePlayerClient,
         deadlineNanos: Long,
     ): CaptionTrackResult {
-        val clientContext = JSONObject()
-            .put("clientName", profile.clientName)
-            .put("clientVersion", profile.clientVersion)
-            .put("userAgent", profile.userAgent)
-            .put("hl", "en")
-            .put("gl", "US")
-        profile.androidSdkVersion?.let { clientContext.put("androidSdkVersion", it) }
-        profile.deviceMake?.let { clientContext.put("deviceMake", it) }
-        profile.deviceModel?.let { clientContext.put("deviceModel", it) }
-        profile.osName?.let { clientContext.put("osName", it) }
-        profile.osVersion?.let { clientContext.put("osVersion", it) }
-
-        val body = JSONObject()
-            .put("context", JSONObject().put("client", clientContext))
-            .put("videoId", videoId)
-            .put("contentCheckOk", true)
-            .put("racyCheckOk", true)
+        val body = playerRequestBody(videoId, profile)
 
         var lastError: Exception? = null
         for (playerUrl in playerApiUrls(apiKey)) {
@@ -381,6 +439,7 @@ class YouTubeCaptionProvider(
                     Request.Builder()
                         .url(playerUrl)
                         .header("User-Agent", profile.userAgent)
+                        .header("Origin", "https://www.youtube.com")
                         .header("X-YouTube-Client-Name", profile.clientNumber)
                         .header("X-YouTube-Client-Version", profile.clientVersion)
                         .post(body.toString().toRequestBody(JSON_MEDIA_TYPE))

--- a/app/src/main/java/com/kienhoang/dualsubreplay/data/YouTubeCaptionProvider.kt
+++ b/app/src/main/java/com/kienhoang/dualsubreplay/data/YouTubeCaptionProvider.kt
@@ -28,6 +28,21 @@ internal class ResponseLimitExceededException(message: String) : Exception(messa
 internal class CaptionLookupTimeoutException(message: String, cause: Throwable? = null) :
     Exception(message, cause)
 
+/** Fixed categories only: never put server text, signed URLs, or cookies in logcat. */
+internal fun captionFailureCategory(message: String?): String = when {
+    message == null -> "discovery"
+    message.contains("HTTP ") -> Regex("HTTP ([0-9]{3})").find(message)?.value ?: "http"
+    message.contains("timed out", true) || message.contains("seconds", true) -> "timeout"
+    message.contains("Player returned") -> "playability"
+    message.contains("empty", true) || message.contains("readable", true) -> "empty-response"
+    message.contains("track", true) -> "no-tracks"
+    else -> "discovery"
+}
+
+private fun reportCaptionFailure(stage: String, error: Throwable) {
+    android.util.Log.w("CaptionRecovery", "$stage: ${captionFailureCategory(error.message)}")
+}
+
 internal data class YouTubePlayerClient(
     val label: String,
     val clientName: String,
@@ -312,10 +327,12 @@ class YouTubeCaptionProvider(
             // ViewModel uses cancellation whenever the video or language changes.
             throw error
         } catch (error: CaptionUnavailableException) {
+            reportCaptionFailure("lookup", error)
             throw error
         } catch (error: ResponseLimitExceededException) {
             throw CaptionUnavailableException(error.message.orEmpty(), error)
         } catch (error: CaptionLookupTimeoutException) {
+            reportCaptionFailure("lookup", error)
             throw CaptionUnavailableException(error.message.orEmpty(), error)
         } catch (error: Exception) {
             throw CaptionUnavailableException(
@@ -342,6 +359,7 @@ class YouTubeCaptionProvider(
             )
         }
         watchResult.exceptionOrNull()?.let { error ->
+            reportCaptionFailure("watch-page", error)
             if (error is CaptionLookupTimeoutException) throw error
         }
         val watchHtml = watchResult.getOrNull().orEmpty()
@@ -372,11 +390,13 @@ class YouTubeCaptionProvider(
             } catch (error: NoCaptionTracksException) {
                 lastError = error
                 failures += "Watch page: ${error.message}"
+                reportCaptionFailure("watch-page", error)
             } catch (error: Exception) {
                 lastError = error
                 sawNonTrackFailure = true
                 val failure = "Watch page: ${error.message ?: error.javaClass.simpleName}"
                 failures += failure
+                reportCaptionFailure("watch-page", error)
                 lastServiceFailure = failure
             }
         }
@@ -398,10 +418,12 @@ class YouTubeCaptionProvider(
             } catch (error: NoCaptionTracksException) {
                 lastError = error
                 failures += "${profile.label}: ${error.message}"
+                reportCaptionFailure(profile.clientName, error)
             } catch (error: Exception) {
                 lastError = error
                 sawNonTrackFailure = true
                 val failure = "${profile.label}: ${error.message ?: error.javaClass.simpleName}"
+                reportCaptionFailure(profile.clientName, error)
                 failures += failure
                 lastServiceFailure = failure
             }

--- a/app/src/main/java/com/kienhoang/dualsubreplay/ui/AppNavigation.kt
+++ b/app/src/main/java/com/kienhoang/dualsubreplay/ui/AppNavigation.kt
@@ -2,6 +2,7 @@ package com.kienhoang.dualsubreplay.ui
 
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
@@ -9,6 +10,8 @@ import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
@@ -59,8 +62,17 @@ internal fun AppNavigation(
         },
     ) {
         content {
-            IconButton(onClick = { scope.launch { drawer.open() } }) {
-                Icon(Icons.Default.Menu, contentDescription = "Open navigation menu")
+            Box(
+                modifier = Modifier.size(width = 72.dp, height = 48.dp)
+                    .testTag("navigation_menu_button")
+                    .clickable(role = Role.Button) { scope.launch { drawer.open() } },
+                contentAlignment = Alignment.CenterStart,
+            ) {
+                Icon(
+                    Icons.Default.Menu,
+                    contentDescription = "Open navigation menu",
+                    modifier = Modifier.padding(start = 12.dp).size(24.dp),
+                )
             }
         }
     }

--- a/app/src/main/java/com/kienhoang/dualsubreplay/ui/AppNavigation.kt
+++ b/app/src/main/java/com/kienhoang/dualsubreplay/ui/AppNavigation.kt
@@ -1,0 +1,67 @@
+package com.kienhoang.dualsubreplay.ui
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Menu
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.launch
+
+@Composable
+internal fun AppNavigation(
+    onPractice: () -> Unit,
+    onSettings: () -> Unit,
+    onVisibilityChange: (Boolean) -> Unit = {},
+    content: @Composable (menuButton: @Composable () -> Unit) -> Unit,
+) {
+    val drawer = rememberDrawerState(DrawerValue.Closed)
+    val scope = rememberCoroutineScope()
+    LaunchedEffect(drawer.currentValue, drawer.targetValue) {
+        onVisibilityChange(drawer.currentValue == DrawerValue.Open || drawer.targetValue == DrawerValue.Open)
+    }
+    DisposableEffect(Unit) { onDispose { onVisibilityChange(false) } }
+    BackHandler(drawer.isOpen) { scope.launch { drawer.close() } }
+    ModalNavigationDrawer(
+        drawerState = drawer,
+        gesturesEnabled = drawer.isOpen,
+        drawerContent = {
+            ModalDrawerSheet {
+                BoxWithConstraints(Modifier.fillMaxHeight()) {
+                    Column(
+                        Modifier.verticalScroll(rememberScrollState()).heightIn(min = maxHeight).padding(12.dp),
+                        verticalArrangement = Arrangement.SpaceBetween,
+                    ) {
+                        Column {
+                            Text("DualSub Replay", style = MaterialTheme.typography.titleLarge, modifier = Modifier.padding(16.dp))
+                            NavigationDrawerItem(
+                                label = { Text("Practice") }, selected = false,
+                                modifier = Modifier.testTag("open_saved_words"),
+                                onClick = { scope.launch { drawer.close(); onPractice() } },
+                            )
+                            NavigationDrawerItem(
+                                label = { Text("Settings") }, selected = false,
+                                onClick = { scope.launch { drawer.close(); onSettings() } },
+                            )
+                        }
+                        Column {
+                            HorizontalDivider(Modifier.padding(vertical = 16.dp))
+                            SettingsRepositoryLink(beforeOpen = { drawer.close() })
+                        }
+                    }
+                }
+            }
+        },
+    ) {
+        content {
+            IconButton(onClick = { scope.launch { drawer.open() } }) {
+                Icon(Icons.Default.Menu, contentDescription = "Open navigation menu")
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/kienhoang/dualsubreplay/ui/AppViewModel.kt
+++ b/app/src/main/java/com/kienhoang/dualsubreplay/ui/AppViewModel.kt
@@ -579,7 +579,8 @@ class AppViewModel(application: Application) : AndroidViewModel(application) {
 
     internal suspend fun saveWord(selection: LearningWordSelection, meaning: String, online: Boolean, offline: Boolean): SavedWord {
         val word = vocabulary.save(savedWordFrom(selection, meaning, online, offline))
-        if (offline && (word.clipStatus != "ready" || !vocabulary.clipFile(word).isFile)) enqueueClip(getApplication(), word.id)
+        if (offline && word.clipStatus !in listOf("queued", "downloading") &&
+            (word.clipStatus != "ready" || !vocabulary.clipFile(word).isFile)) enqueueClip(getApplication(), word.id)
         else if (!offline && word.clipStatus != "none") removeClip(getApplication(), word)
         return word
     }

--- a/app/src/main/java/com/kienhoang/dualsubreplay/ui/AppViewModel.kt
+++ b/app/src/main/java/com/kienhoang/dualsubreplay/ui/AppViewModel.kt
@@ -4,6 +4,13 @@ import android.app.Application
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.kienhoang.dualsubreplay.data.AnalyzedToken
+import com.kienhoang.dualsubreplay.data.LearningWordSelection
+import com.kienhoang.dualsubreplay.data.WordTap
+import com.kienhoang.dualsubreplay.data.VocabularyRepository
+import com.kienhoang.dualsubreplay.data.SavedWord
+import com.kienhoang.dualsubreplay.data.savedWordFrom
+import com.kienhoang.dualsubreplay.data.enqueueClip
+import com.kienhoang.dualsubreplay.data.removeClip
 import com.kienhoang.dualsubreplay.data.CaptionLanguage
 import com.kienhoang.dualsubreplay.data.CaptionProvider
 import com.kienhoang.dualsubreplay.data.CaptionUnavailableException
@@ -59,7 +66,8 @@ data class DualSubUiState(
     val wordLearningTarget: String = "both",
     val wordLearningActiveOnly: Boolean = true,
     val tapToLearnEnabled: Boolean = true,
-    val selectedLearningToken: AnalyzedToken? = null,
+    val selectedLearningWord: LearningWordSelection? = null,
+    val autoPronounce: Boolean = true,
     val stage: LoadStage = LoadStage.IDLE,
     val statusMessage: String? = null,
     val errorMessage: String? = null,
@@ -217,6 +225,7 @@ class AppViewModel(application: Application) : AndroidViewModel(application) {
     private val preferences = application.getSharedPreferences("dual_sub_preferences", 0)
     private val captionProvider: CaptionProvider = YouTubeCaptionProvider()
     private val translator = OnDeviceTranslator()
+    internal val vocabulary = VocabularyRepository.get(application)
     private var loadingJob: Job? = null
     private var translationWarmupJob: Job? = null
     private var loadGeneration = 0L
@@ -283,6 +292,7 @@ class AppViewModel(application: Application) : AndroidViewModel(application) {
             wordLearningActiveOnly = storedFeatureEnabled(
                 preferences.getBoolean(WORD_LEARNING_ACTIVE_ONLY_PREFERENCE, true),
             ),
+            autoPronounce = preferences.getBoolean("auto_pronounce", true),
             tapToLearnEnabled = storedFeatureEnabled(
                 preferences.getBoolean(TAP_TO_LEARN_PREFERENCE, true),
             ),
@@ -291,6 +301,7 @@ class AppViewModel(application: Application) : AndroidViewModel(application) {
     val state: StateFlow<DualSubUiState> = _state.asStateFlow()
 
     init {
+        viewModelScope.launch { vocabulary.refresh() }
         if (_state.value.preloadModelsEnabled) {
             val source = _state.value.sourcePreference.takeUnless { it == "auto" } ?: "en"
             warmTranslationModel(sourceLanguage = source, targetLanguage = _state.value.targetLanguage)
@@ -547,8 +558,30 @@ class AppViewModel(application: Application) : AndroidViewModel(application) {
         _state.update { it.copy(wordLearningActiveOnly = enabled) }
     }
 
-    fun selectLearningToken(token: AnalyzedToken?) {
-        _state.update { it.copy(selectedLearningToken = token) }
+    fun selectLearningWord(tap: WordTap?) {
+        val current = _state.value
+        val source = current.resolvedSourceLanguage ?: current.sourcePreference.takeUnless { it == "auto" } ?: "en"
+        _state.update { it.copy(selectedLearningWord = tap?.let { selected ->
+            LearningWordSelection(selected.token,
+                if (selected.translated) current.targetLanguage else source,
+                if (selected.translated) source else current.targetLanguage,
+                current.activeVideoId, selected.segment, selected.translated)
+        }) }
+    }
+
+    fun setAutoPronounce(enabled: Boolean) {
+        preferences.edit().putBoolean("auto_pronounce", enabled).apply()
+        _state.update { it.copy(autoPronounce = enabled) }
+    }
+
+    internal suspend fun translateSelection(selection: LearningWordSelection): String =
+        translator.translateSingle(selection.wordLanguage, selection.meaningLanguage, selection.token.text)
+
+    internal suspend fun saveWord(selection: LearningWordSelection, meaning: String, online: Boolean, offline: Boolean): SavedWord {
+        val word = vocabulary.save(savedWordFrom(selection, meaning, online, offline))
+        if (offline && (word.clipStatus != "ready" || !vocabulary.clipFile(word).isFile)) enqueueClip(getApplication(), word.id)
+        else if (!offline && word.clipStatus != "none") removeClip(getApplication(), word)
+        return word
     }
 
     suspend fun translateWord(word: String): String {
@@ -583,6 +616,7 @@ class AppViewModel(application: Application) : AndroidViewModel(application) {
         val editor = preferences.edit()
         RESETTABLE_SETTING_KEYS.forEach(editor::remove)
         editor.apply()
+        _state.update { it.copy(autoPronounce = true) }
         latestPlaybackSecondMs = 0L
         liveCaptionTracker.reset()
         _state.update { current ->
@@ -605,7 +639,7 @@ class AppViewModel(application: Application) : AndroidViewModel(application) {
                 wordLearningTarget = "both",
                 wordLearningActiveOnly = true,
                 tapToLearnEnabled = true,
-                selectedLearningToken = null,
+                selectedLearningWord = null,
             )
         }
         // "Reset all settings" re-enables sentence splitting, so the currently

--- a/app/src/main/java/com/kienhoang/dualsubreplay/ui/AppViewModel.kt
+++ b/app/src/main/java/com/kienhoang/dualsubreplay/ui/AppViewModel.kt
@@ -301,7 +301,13 @@ class AppViewModel(application: Application) : AndroidViewModel(application) {
     val state: StateFlow<DualSubUiState> = _state.asStateFlow()
 
     init {
-        viewModelScope.launch { vocabulary.refresh() }
+        viewModelScope.launch {
+            try {
+                vocabulary.refresh()
+                vocabulary.reconcileDownloads(application)
+            } catch (cancel: CancellationException) { throw cancel }
+            catch (_: Exception) { /* The saved-words screen reports storage failures with a retry on reopen. */ }
+        }
         if (_state.value.preloadModelsEnabled) {
             val source = _state.value.sourcePreference.takeUnless { it == "auto" } ?: "en"
             warmTranslationModel(sourceLanguage = source, targetLanguage = _state.value.targetLanguage)
@@ -562,10 +568,7 @@ class AppViewModel(application: Application) : AndroidViewModel(application) {
         val current = _state.value
         val source = current.resolvedSourceLanguage ?: current.sourcePreference.takeUnless { it == "auto" } ?: "en"
         _state.update { it.copy(selectedLearningWord = tap?.let { selected ->
-            LearningWordSelection(selected.token,
-                if (selected.translated) current.targetLanguage else source,
-                if (selected.translated) source else current.targetLanguage,
-                current.activeVideoId, selected.segment, selected.translated)
+            com.kienhoang.dualsubreplay.data.learningSelection(selected, source, current.targetLanguage, current.activeVideoId)
         }) }
     }
 

--- a/app/src/main/java/com/kienhoang/dualsubreplay/ui/AppViewModel.kt
+++ b/app/src/main/java/com/kienhoang/dualsubreplay/ui/AppViewModel.kt
@@ -35,6 +35,10 @@ import kotlinx.coroutines.launch
 enum class LoadStage { IDLE, LOADING_CAPTIONS, TRANSLATING, READY, ERROR }
 
 data class DualSubUiState(
+    val liveFallback: Boolean = false,
+    val liveOriginal: String? = null,
+    val liveTranslated: String? = null,
+    val retryingTranscript: Boolean = false,
     val browserUrl: String = YOUTUBE_HOME_URL,
     val browserNavigationRequestId: Long = 0L,
     val activeVideoId: String? = null,
@@ -221,9 +225,9 @@ internal fun initialGuideCompleted(
     onboardingCompleted: Boolean,
 ): Boolean = if (preferenceExists) preferenceValue else onboardingCompleted
 
-class AppViewModel(application: Application) : AndroidViewModel(application) {
+class AppViewModel internal constructor(application: Application, private val captionProvider: CaptionProvider) : AndroidViewModel(application) {
+    constructor(application: Application) : this(application, YouTubeCaptionProvider())
     private val preferences = application.getSharedPreferences("dual_sub_preferences", 0)
-    private val captionProvider: CaptionProvider = YouTubeCaptionProvider()
     private val translator = OnDeviceTranslator()
     internal val vocabulary = VocabularyRepository.get(application)
     private var loadingJob: Job? = null
@@ -232,6 +236,9 @@ class AppViewModel(application: Application) : AndroidViewModel(application) {
     private var latestPlaybackSecondMs = 0L
     private var rawMergedSegments: List<SubtitleSegment> = emptyList()
     private val liveCaptionTracker = LiveCaptionTracker()
+    private val liveTranslationGate = LiveTranslationGate()
+    private var liveTranslationJob: Job? = null
+    private var rejectedLiveRevision: Long? = null
 
     private val _state = MutableStateFlow(
         DualSubUiState(
@@ -350,6 +357,13 @@ class AppViewModel(application: Application) : AndroidViewModel(application) {
         val current = _state.value
         if (current.activeVideoId != videoId || !second.isFinite()) return
         val timeMs = (second.coerceAtLeast(0f) * 1_000).toLong()
+        val seek = timeMs + LIVE_CAPTION_BACKWARD_SEEK_RESET_MS < latestPlaybackSecondMs ||
+            timeMs > latestPlaybackSecondMs + 2_000L
+        if (current.liveFallback) {
+            latestPlaybackSecondMs = timeMs
+            updateLiveSubtitle(videoId, liveCaption, seek)
+            return
+        }
         if (timeMs + LIVE_CAPTION_BACKWARD_SEEK_RESET_MS < latestPlaybackSecondMs) {
             liveCaptionTracker.reset()
         }
@@ -394,12 +408,49 @@ class AppViewModel(application: Application) : AndroidViewModel(application) {
         }
     }
 
+    private fun updateLiveSubtitle(videoId: String, sample: LiveCaptionSample?, seek: Boolean) {
+        if (seek) rejectedLiveRevision = sample?.revision
+        val key = liveTranslationKey(sample?.takeUnless { it.revision == rejectedLiveRevision }, videoId, _state.value.targetLanguage)
+        if (!liveTranslationGate.update(key, seek)) return
+        liveTranslationJob?.cancel()
+        val ticket = liveTranslationGate.generation
+        _state.update { it.copy(
+            liveOriginal = key?.text, liveTranslated = null,
+            resolvedSourceLanguage = key?.language,
+            statusMessage = if (key == null) "Waiting for YouTube captions and their language. Play the video with captions enabled." else "Translating live captions…",
+        ) }
+        if (key == null) return
+        if (!TranslationLanguages.isSupported(key.language)) {
+            _state.update { it.copy(statusMessage = "Live translation is not supported for ${TranslationLanguages.displayName(key.language)}.") }
+            return
+        }
+        liveTranslationJob = viewModelScope.launch {
+            try {
+                val translated = debouncedLiveTranslation(key,
+                    isCurrent = { liveTranslationGate.accepts(ticket, key) && _state.value.liveFallback && _state.value.activeVideoId == videoId },
+                    translate = translator::translateSingle,
+                ) ?: return@launch
+                if (liveTranslationGate.accepts(ticket, key) && _state.value.liveFallback && _state.value.activeVideoId == videoId) {
+                    _state.update { it.copy(liveTranslated = translated, statusMessage = "Current captions only; paragraph replay is unavailable.") }
+                }
+            } catch (error: CancellationException) {
+                throw error
+            } catch (_: Exception) {
+                if (liveTranslationGate.accepts(ticket, key)) {
+                    _state.update { it.copy(statusMessage = "Live translation unavailable. Check the connection for the language model download.") }
+                }
+            }
+        }
+    }
+
     fun setSourcePreference(language: String) {
         val normalized = language.takeIf { it == "auto" } ?: TranslationLanguages.normalize(language)
         val current = _state.value
         if (!shouldAcceptSourcePreference(normalized, current.availableSourceLanguages)) return
         if (current.sourcePreference == normalized) return
         preferences.edit().putString("preferred_caption_language", normalized).apply()
+        liveTranslationJob?.cancel()
+        liveTranslationGate.reset()
         _state.update { it.copy(sourcePreference = normalized) }
         val videoId = _state.value.activeVideoId ?: return
         loadVideo(videoId, showPanel = true)
@@ -409,7 +460,9 @@ class AppViewModel(application: Application) : AndroidViewModel(application) {
         val normalized = TranslationLanguages.normalize(language)
         if (!TranslationLanguages.isSupported(normalized) || _state.value.targetLanguage == normalized) return
         preferences.edit().putString("target_language", normalized).apply()
-        _state.update { it.copy(targetLanguage = normalized) }
+        liveTranslationJob?.cancel()
+        liveTranslationGate.reset()
+        _state.update { it.copy(targetLanguage = normalized, liveTranslated = null) }
         if (_state.value.activeVideoId != null && _state.value.segments.isNotEmpty()) {
             retranslateCurrentSegments()
         }
@@ -568,7 +621,10 @@ class AppViewModel(application: Application) : AndroidViewModel(application) {
         val current = _state.value
         val source = current.resolvedSourceLanguage ?: current.sourcePreference.takeUnless { it == "auto" } ?: "en"
         _state.update { it.copy(selectedLearningWord = tap?.let { selected ->
-            com.kienhoang.dualsubreplay.data.learningSelection(selected, source, current.targetLanguage, current.activeVideoId)
+            com.kienhoang.dualsubreplay.data.learningSelection(
+                if (current.liveFallback) selected.copy(segment = null) else selected,
+                source, current.targetLanguage, current.activeVideoId.takeUnless { current.liveFallback },
+            )
         }) }
     }
 
@@ -669,12 +725,15 @@ class AppViewModel(application: Application) : AndroidViewModel(application) {
         if (_state.value.activeVideoId == null) return
         loadGeneration += 1
         loadingJob?.cancel()
+        liveTranslationJob?.cancel()
+        liveTranslationGate.reset()
         latestPlaybackSecondMs = 0L
         liveCaptionTracker.reset()
         rawMergedSegments = emptyList()
         _state.update {
             it.copy(
                 activeVideoId = null,
+                liveFallback = false, liveOriginal = null, liveTranslated = null, retryingTranscript = false,
                 subtitlePanelVisible = true,
                 availableSourceLanguages = emptyList(),
                 resolvedSourceLanguage = null,
@@ -693,6 +752,12 @@ class AppViewModel(application: Application) : AndroidViewModel(application) {
         val generation = ++loadGeneration
         loadingJob?.cancel()
         liveCaptionTracker.reset()
+        val preserveLive = _state.value.liveFallback && _state.value.activeVideoId == videoId
+        if (!preserveLive) {
+            rejectedLiveRevision = null
+            liveTranslationGate.reset()
+            liveTranslationJob?.cancel()
+        }
         // Reloading the same video (language change, retry) keeps tracking the
         // current position so subtitles resume exactly where playback is.
         if (shouldResetPlaybackClock(_state.value.activeVideoId, videoId)) {
@@ -700,16 +765,20 @@ class AppViewModel(application: Application) : AndroidViewModel(application) {
         }
         _state.update {
             it.copy(
+                liveFallback = preserveLive,
+                liveOriginal = if (preserveLive) it.liveOriginal else null,
+                liveTranslated = if (preserveLive) it.liveTranslated else null,
+                retryingTranscript = preserveLive,
                 activeVideoId = videoId,
                 subtitlePanelVisible = showPanel,
                 availableSourceLanguages = emptyList(),
-                resolvedSourceLanguage = null,
+                resolvedSourceLanguage = if (preserveLive) it.resolvedSourceLanguage else null,
                 generatedCaptions = false,
                 segments = emptyList(),
                 currentIndex = -1,
                 activeWordIndex = -1,
                 stage = LoadStage.LOADING_CAPTIONS,
-                statusMessage = "Finding the best caption track…",
+                statusMessage = if (preserveLive) it.statusMessage else "Finding the best caption track…",
                 errorMessage = null,
             )
         }
@@ -731,10 +800,13 @@ class AppViewModel(application: Application) : AndroidViewModel(application) {
                     merged
                 }
                 rawMergedSegments = merged
+                liveTranslationGate.reset()
+                liveTranslationJob?.cancel()
 
                 _state.update { current ->
                     if (!isCurrentLoad(current, videoId, generation)) return@update current
                     current.copy(
+                        liveFallback = false, liveOriginal = null, liveTranslated = null, retryingTranscript = false,
                         resolvedSourceLanguage = track.languageCode,
                         sourcePreference = resolvedSourcePreference(
                             current.sourcePreference,
@@ -760,9 +832,10 @@ class AppViewModel(application: Application) : AndroidViewModel(application) {
                 _state.update { current ->
                     if (!isCurrentLoad(current, videoId, generation)) return@update current
                     current.copy(
-                        stage = LoadStage.ERROR,
-                        statusMessage = null,
-                        errorMessage = error.message ?: "The captions could not be loaded.",
+                        stage = LoadStage.READY,
+                        liveFallback = true, retryingTranscript = false,
+                        statusMessage = if (current.liveOriginal != null) current.statusMessage else "Waiting for YouTube captions and their language. Play the video with captions enabled.",
+                        errorMessage = null,
                     )
                 }
             }

--- a/app/src/main/java/com/kienhoang/dualsubreplay/ui/DualSubApp.kt
+++ b/app/src/main/java/com/kienhoang/dualsubreplay/ui/DualSubApp.kt
@@ -1195,9 +1195,6 @@ internal fun SubtitleSettingsDialog(
                         .verticalScroll(rememberScrollState()),
                 ) {
                     SettingsRepositoryLink()
-                    TextButton(onClick = onVocabulary) { Text("Saved words and practice") }
-                    SettingsSwitchRow("Pronounce tapped words", "Automatically speak a word when you open its definition.",
-                        autoPronounce, onAutoPronounceChange, "auto_pronounce_switch")
                     Text("Captions", style = MaterialTheme.typography.titleSmall)
                     Spacer(Modifier.height(8.dp))
                     Text("Original language")
@@ -1232,6 +1229,7 @@ internal fun SubtitleSettingsDialog(
                     Spacer(Modifier.height(12.dp))
                     Text("Text size: ${(fontScale * 100).toInt()}%")
                     Slider(value = fontScale, onValueChange = onFontScaleChange, valueRange = 0.8f..1.5f)
+                    TextButton(onClick = onVocabulary) { Text("Saved words and practice") }
 
                     Spacer(Modifier.height(14.dp))
                     HorizontalDivider()
@@ -1278,6 +1276,8 @@ internal fun SubtitleSettingsDialog(
                         HorizontalDivider()
                         Spacer(Modifier.height(14.dp))
                         Text("Word Learning Mode", style = MaterialTheme.typography.titleSmall)
+                        SettingsSwitchRow("Pronounce tapped words", "Automatically speak a word when you open its definition.",
+                            autoPronounce, onAutoPronounceChange, "auto_pronounce_switch")
                         SettingsSwitchRow(
                             title = "Word learning mode (POS colors)",
                             description = "Color words by their grammatical role (nouns, verbs, adjectives, particles) to quickly understand sentence structure.",

--- a/app/src/main/java/com/kienhoang/dualsubreplay/ui/DualSubApp.kt
+++ b/app/src/main/java/com/kienhoang/dualsubreplay/ui/DualSubApp.kt
@@ -28,6 +28,7 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
@@ -53,6 +54,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import com.kienhoang.dualsubreplay.data.AnalyzedToken
+import com.kienhoang.dualsubreplay.data.WordTap
 import com.kienhoang.dualsubreplay.data.LanguageAwareTokenizer
 import androidx.compose.material3.OutlinedCard
 import androidx.compose.material3.OutlinedButton
@@ -117,6 +119,9 @@ fun DualSubApp(
     fullscreenLearningOverlay: (@Composable BoxScope.() -> Unit)? = null,
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
+    val webController = rememberYouTubeWebController()
+    val pronouncer = rememberWordPronouncer()
+    var showVocabulary by remember { mutableStateOf(false) }
 
     DualSubTheme {
         if (!state.onboardingCompleted) {
@@ -129,6 +134,9 @@ fun DualSubApp(
         } else {
             DualSubExperience(
                 state = state,
+                webController = webController,
+                onVocabulary = { viewModel.selectLearningWord(null); webController.pause(); showVocabulary = true },
+                onAutoPronounceChange = viewModel::setAutoPronounce,
                 playerMode = playerMode,
                 effectivePlayerMode = effectivePlayerMode,
                 onPlayerModeChange = onPlayerModeChange,
@@ -164,26 +172,45 @@ fun DualSubApp(
                 onWordLearningActiveOnlyChange = viewModel::setWordLearningActiveOnly,
                 tapToLearnEnabled = state.tapToLearnEnabled,
                 onTapToLearnChange = viewModel::setTapToLearnEnabled,
-                onWordClick = viewModel::selectLearningToken,
+                onWordClick = viewModel::selectLearningWord,
                 onResetSettings = viewModel::resetAllSettings,
             )
         }
-
-        state.selectedLearningToken?.let { token ->
-            WordLearningDialog(
-                token = token,
-                sourceLanguage = state.resolvedSourceLanguage ?: state.sourcePreference,
-                targetLanguage = state.targetLanguage,
-                onTranslateWord = viewModel::translateWord,
-                onDismiss = { viewModel.selectLearningToken(null) },
-            )
+        state.selectedLearningWord?.let { selection ->
+            androidx.compose.runtime.key(selection) {
+                androidx.compose.runtime.DisposableEffect(selection) {
+                    onDispose { pronouncer.stop() }
+                }
+                WordLearningDialog(
+                    selection = selection,
+                    autoPronounce = state.autoPronounce,
+                    onTranslateWord = { viewModel.translateSelection(selection) },
+                    onSave = { meaning, online, offline -> viewModel.saveWord(selection, meaning, online, offline); Unit },
+                    onSpeak = { webController.pause(); pronouncer.speak(selection.token.text, selection.wordLanguage) },
+                    speechMessage = pronouncer.message,
+                    onDismiss = { viewModel.selectLearningWord(null) },
+                )
+            }
         }
+        if (showVocabulary) SavedWordsScreen(
+            repository = viewModel.vocabulary,
+            onOnline = { word ->
+                pronouncer.stop()
+                viewModel.acceptSharedText("https://www.youtube.com/watch?v=${word.videoId}")
+                webController.replayClip(word)
+            },
+            onPause = { webController.pause() },
+            onDismiss = { showVocabulary = false },
+        )
     }
 }
 
 @Composable
 private fun DualSubExperience(
     state: DualSubUiState,
+    webController: YouTubeWebController,
+    onVocabulary: () -> Unit,
+    onAutoPronounceChange: (Boolean) -> Unit,
     playerMode: PlayerExperienceMode,
     effectivePlayerMode: PlayerExperienceMode = playerMode,
     onPlayerModeChange: (PlayerExperienceMode) -> Unit,
@@ -219,11 +246,10 @@ private fun DualSubExperience(
     onWordLearningActiveOnlyChange: (Boolean) -> Unit = {},
     tapToLearnEnabled: Boolean = true,
     onTapToLearnChange: (Boolean) -> Unit = {},
-    onWordClick: (AnalyzedToken) -> Unit = {},
+    onWordClick: (WordTap) -> Unit = {},
     onResetSettings: () -> Unit,
 ) {
     var showSettings by remember { mutableStateOf(false) }
-    val webController = rememberYouTubeWebController()
     val configuration = LocalConfiguration.current
     val context = LocalContext.current
     val layoutPreferences = remember(context) {
@@ -267,7 +293,14 @@ private fun DualSubExperience(
         if (externalSettingsRequestId > 0L) showSettings = true
     }
 
-    Scaffold(contentWindowInsets = contentInsets) { innerPadding ->
+    Scaffold(contentWindowInsets = contentInsets, topBar = {
+        Surface {
+            Row(Modifier.fillMaxWidth().statusBarsPadding(), horizontalArrangement = Arrangement.End) {
+                TextButton(onClick = onVocabulary, modifier = Modifier.testTag("open_saved_words")) { Text("Saved words") }
+                TextButton(onClick = { showSettings = true }) { Text("Settings") }
+            }
+        }
+    }) { innerPadding ->
         Box(
             Modifier
                 .fillMaxSize()
@@ -363,6 +396,9 @@ private fun DualSubExperience(
     }
     if (showSettings) {
         SubtitleSettingsDialog(
+            autoPronounce = state.autoPronounce,
+            onAutoPronounceChange = onAutoPronounceChange,
+            onVocabulary = { showSettings = false; onVocabulary() },
             sourcePreference = state.sourcePreference,
             targetLanguage = state.targetLanguage,
             availableSourceLanguages = state.availableSourceLanguages,
@@ -428,7 +464,7 @@ private fun SubtitlePanel(
     onHide: () -> Unit,
     onSettings: () -> Unit,
     onRetry: () -> Unit,
-    onWordClick: (AnalyzedToken) -> Unit = {},
+    onWordClick: (WordTap) -> Unit = {},
     onReplay: (SubtitleSegment) -> Unit,
 ) {
     var panelOffsetY by remember { mutableFloatStateOf(0f) }
@@ -625,7 +661,7 @@ private fun SideSubtitlePanel(
     onHide: () -> Unit,
     onSettings: () -> Unit,
     onRetry: () -> Unit,
-    onWordClick: (AnalyzedToken) -> Unit = {},
+    onWordClick: (WordTap) -> Unit = {},
     onReplay: (SubtitleSegment) -> Unit,
 ) {
     var panelOffsetX by remember { mutableFloatStateOf(0f) }
@@ -728,7 +764,7 @@ private fun SideSubtitlePanel(
 @Composable
 private fun SubtitleTimeline(
     state: DualSubUiState,
-    onWordClick: (AnalyzedToken) -> Unit = {},
+    onWordClick: (WordTap) -> Unit = {},
     onReplay: (SubtitleSegment) -> Unit,
 ) {
     // When the panel is recreated after being closed, start the lazy list at the
@@ -843,7 +879,7 @@ internal fun CompactSubtitleCard(
     resolvedSourceLanguage: String? = null,
     targetLanguage: String = "vi",
     isDownloadingTranslationModel: Boolean = false,
-    onWordClick: (AnalyzedToken) -> Unit = {},
+    onWordClick: (WordTap) -> Unit = {},
 ) {
     OutlinedCard(
         modifier = Modifier
@@ -905,7 +941,7 @@ internal fun CompactSubtitleCard(
                         onClick = { offset ->
                             val token = findWordAtOffset(segment.originalText, offset, resolvedSourceLanguage)
                             if (token != null) {
-                                onWordClick(token)
+                                onWordClick(WordTap(token, segment, false))
                             } else {
                                 onReplay()
                             }
@@ -961,7 +997,7 @@ internal fun CompactSubtitleCard(
                                 alignedOriginalTokens = originalTokens,
                             )
                             if (token != null) {
-                                onWordClick(token)
+                                onWordClick(WordTap(token, segment, true))
                             } else {
                                 onReplay()
                             }
@@ -1048,6 +1084,9 @@ internal fun SubtitleSettingsDialog(
     onCustomColorsChange: (Boolean) -> Unit = {},
     onSplitSentencesChange: (Boolean) -> Unit = {},
     onResetSettings: () -> Unit = {},
+    autoPronounce: Boolean = true,
+    onAutoPronounceChange: (Boolean) -> Unit = {},
+    onVocabulary: () -> Unit = {},
     onDismiss: () -> Unit,
 ) {
     var pickerMode by remember { mutableStateOf<LanguagePickerMode?>(null) }
@@ -1151,6 +1190,10 @@ internal fun SubtitleSettingsDialog(
                         .heightIn(max = bodyMaxHeight)
                         .verticalScroll(rememberScrollState()),
                 ) {
+                    SettingsRepositoryLink()
+                    TextButton(onClick = onVocabulary) { Text("Saved words and practice") }
+                    SettingsSwitchRow("Pronounce tapped words", "Automatically speak a word when you open its definition.",
+                        autoPronounce, onAutoPronounceChange, "auto_pronounce_switch")
                     Text("Captions", style = MaterialTheme.typography.titleSmall)
                     Spacer(Modifier.height(8.dp))
                     Text("Original language")

--- a/app/src/main/java/com/kienhoang/dualsubreplay/ui/DualSubApp.kt
+++ b/app/src/main/java/com/kienhoang/dualsubreplay/ui/DualSubApp.kt
@@ -198,7 +198,9 @@ fun DualSubApp(
             repository = viewModel.vocabulary,
             onOnline = { word ->
                 pronouncer.stop()
-                viewModel.acceptSharedText("https://www.youtube.com/watch?v=${word.videoId}")
+                if (state.activeVideoId != word.videoId) {
+                    viewModel.acceptSharedText("https://www.youtube.com/watch?v=${word.videoId}")
+                }
                 webController.replayClip(word)
             },
             onPause = { webController.pause() },

--- a/app/src/main/java/com/kienhoang/dualsubreplay/ui/DualSubApp.kt
+++ b/app/src/main/java/com/kienhoang/dualsubreplay/ui/DualSubApp.kt
@@ -119,6 +119,7 @@ fun DualSubApp(
     fullscreenLearningOverlay: (@Composable BoxScope.() -> Unit)? = null,
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
+    val savedWords by viewModel.vocabulary.words.collectAsStateWithLifecycle()
     val webController = rememberYouTubeWebController()
     val pronouncer = rememberWordPronouncer()
     var showVocabulary by remember { mutableStateOf(false) }
@@ -183,6 +184,7 @@ fun DualSubApp(
                 }
                 WordLearningDialog(
                     selection = selection,
+                    existingWord = savedWords.firstOrNull { it.id == com.kienhoang.dualsubreplay.data.savedWordFrom(selection, "", false, false).id },
                     autoPronounce = state.autoPronounce,
                     onTranslateWord = { viewModel.translateSelection(selection) },
                     onSave = { meaning, online, offline -> viewModel.saveWord(selection, meaning, online, offline); Unit },

--- a/app/src/main/java/com/kienhoang/dualsubreplay/ui/DualSubApp.kt
+++ b/app/src/main/java/com/kienhoang/dualsubreplay/ui/DualSubApp.kt
@@ -279,7 +279,8 @@ private fun DualSubExperience(
             landscapeVideoFraction + delta / splitContainerWidthPx,
         )
     }
-    val sideBySide = shouldUseLandscapeSplit(
+    val nativeDialogVisible by youtubeNativeDialogVisible.collectAsStateWithLifecycle()
+    val sideBySide = !nativeDialogVisible && shouldUseLandscapeSplit(
         splitEnabled = state.landscapeSplitEnabled,
         subtitlePanelVisible = state.subtitlePanelVisible,
         hasActiveVideo = state.activeVideoId != null,
@@ -367,7 +368,7 @@ private fun DualSubExperience(
                 }
             }
 
-            if (!sideBySide && state.activeVideoId != null && state.subtitlePanelVisible) {
+            if (!nativeDialogVisible && !sideBySide && state.activeVideoId != null && state.subtitlePanelVisible) {
                 SubtitlePanel(
                     state = state,
                     modifier = Modifier
@@ -393,7 +394,7 @@ private fun DualSubExperience(
                     },
                 )
             } else if (
-                !sideBySide &&
+                !nativeDialogVisible && !sideBySide &&
                 state.activeVideoId != null &&
                 effectivePlayerMode == PlayerExperienceMode.TRANSCRIPT_PANEL
             ) {

--- a/app/src/main/java/com/kienhoang/dualsubreplay/ui/DualSubApp.kt
+++ b/app/src/main/java/com/kienhoang/dualsubreplay/ui/DualSubApp.kt
@@ -117,6 +117,7 @@ fun DualSubApp(
     onPlayerModeChange: (PlayerExperienceMode) -> Unit = {},
     externalSettingsRequestId: Long = 0L,
     fullscreenLearningOverlay: (@Composable BoxScope.() -> Unit)? = null,
+    onNavigationVisibilityChange: (Boolean) -> Unit = {},
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
     val savedWords by viewModel.vocabulary.words.collectAsStateWithLifecycle()
@@ -143,6 +144,7 @@ fun DualSubApp(
                 onPlayerModeChange = onPlayerModeChange,
                 externalSettingsRequestId = externalSettingsRequestId,
                 fullscreenLearningOverlay = fullscreenLearningOverlay,
+                onNavigationVisibilityChange = onNavigationVisibilityChange,
                 onPageChanged = viewModel::onYouTubePageChanged,
                 onPlaybackSecond = viewModel::onWebPlaybackSecond,
                 onShowSubtitles = viewModel::showSubtitlePanel,
@@ -220,6 +222,7 @@ private fun DualSubExperience(
     onPlayerModeChange: (PlayerExperienceMode) -> Unit,
     externalSettingsRequestId: Long,
     fullscreenLearningOverlay: (@Composable BoxScope.() -> Unit)?,
+    onNavigationVisibilityChange: (Boolean) -> Unit,
     onPageChanged: (String) -> Unit,
     onPlaybackSecond: (String, Float, LiveCaptionSample?) -> Unit,
     onShowSubtitles: () -> Unit,
@@ -287,21 +290,21 @@ private fun DualSubExperience(
     } else {
         WindowInsets.safeDrawing
     }
-    val liveCaptionCaptureEnabled = shouldCaptureLiveCaptions(
+    val liveCaptionCaptureEnabled = state.subtitlePanelVisible && (state.liveFallback || shouldCaptureLiveCaptions(
         mode = state.karaokeTimingMode,
         generatedCaptions = state.generatedCaptions,
         wordHighlightEnabled = state.wordHighlightEnabled,
-    )
+    ))
 
     LaunchedEffect(externalSettingsRequestId) {
         if (externalSettingsRequestId > 0L) showSettings = true
     }
 
+    AppNavigation(onPractice = onVocabulary, onSettings = { showSettings = true }, onVisibilityChange = onNavigationVisibilityChange) { menuButton ->
     Scaffold(contentWindowInsets = contentInsets, topBar = {
         Surface {
-            Row(Modifier.fillMaxWidth().statusBarsPadding(), horizontalArrangement = Arrangement.End) {
-                TextButton(onClick = onVocabulary, modifier = Modifier.testTag("open_saved_words")) { Text("Saved words") }
-                TextButton(onClick = { showSettings = true }) { Text("Settings") }
+            Row(Modifier.fillMaxWidth().statusBarsPadding(), horizontalArrangement = Arrangement.Start) {
+                menuButton()
             }
         }
     }) { innerPadding ->
@@ -398,11 +401,11 @@ private fun DualSubExperience(
             }
         }
     }
+    }
     if (showSettings) {
         SubtitleSettingsDialog(
             autoPronounce = state.autoPronounce,
             onAutoPronounceChange = onAutoPronounceChange,
-            onVocabulary = { showSettings = false; onVocabulary() },
             sourcePreference = state.sourcePreference,
             targetLanguage = state.targetLanguage,
             availableSourceLanguages = state.availableSourceLanguages,
@@ -576,6 +579,7 @@ private fun SubtitlePanel(
             HorizontalDivider(color = Color(0xFF244044))
 
             when {
+                state.liveFallback -> LiveSubtitlePanel(state, onRetry, onWordClick)
                 state.errorMessage != null -> CompactErrorPanel(state.errorMessage, onRetry)
                 state.segments.isEmpty() -> CompactLoadingPanel(state.statusMessage ?: "Loading captions…")
                 else -> SubtitleTimeline(state, onWordClick = onWordClick, onReplay = onReplay)
@@ -757,6 +761,7 @@ private fun SideSubtitlePanel(
             HorizontalDivider(color = Color(0xFF244044))
 
             when {
+                state.liveFallback -> LiveSubtitlePanel(state, onRetry, onWordClick)
                 state.errorMessage != null -> CompactErrorPanel(state.errorMessage, onRetry)
                 state.segments.isEmpty() -> CompactLoadingPanel(state.statusMessage ?: "Loading captions…")
                 else -> SubtitleTimeline(state, onWordClick = onWordClick, onReplay = onReplay)
@@ -884,12 +889,13 @@ internal fun CompactSubtitleCard(
     targetLanguage: String = "vi",
     isDownloadingTranslationModel: Boolean = false,
     onWordClick: (WordTap) -> Unit = {},
+    replayEnabled: Boolean = true,
 ) {
     OutlinedCard(
         modifier = Modifier
             .fillMaxWidth()
             .semantics { stateDescription = if (active) "Active subtitle" else "Subtitle" }
-            .clickable(onClick = onReplay),
+            .clickable(enabled = replayEnabled, onClick = onReplay),
         border = BorderStroke(
             width = if (active) 2.dp else 1.dp,
             color = if (active) MaterialTheme.colorScheme.primary else Color(0xFF183034),
@@ -904,7 +910,7 @@ internal fun CompactSubtitleCard(
             modifier = Modifier.fillMaxWidth().padding(horizontal = 8.dp, vertical = 7.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            Card(
+            if (replayEnabled) Card(
                 modifier = Modifier.size(34.dp),
                 shape = CircleShape,
                 colors = CardDefaults.cardColors(
@@ -920,7 +926,7 @@ internal fun CompactSubtitleCard(
                     )
                 }
             }
-            Spacer(Modifier.size(9.dp))
+            if (replayEnabled) Spacer(Modifier.size(9.dp))
             Column(Modifier.weight(1f)) {
                 val isSentenceEligibleForPos = !wordLearningActiveOnly || active
                 val shouldHighlightPos = wordLearningEnabled && isSentenceEligibleForPos && (wordLearningTarget == "original" || wordLearningTarget == "both")
@@ -1090,7 +1096,6 @@ internal fun SubtitleSettingsDialog(
     onResetSettings: () -> Unit = {},
     autoPronounce: Boolean = true,
     onAutoPronounceChange: (Boolean) -> Unit = {},
-    onVocabulary: () -> Unit = {},
     onDismiss: () -> Unit,
 ) {
     var pickerMode by remember { mutableStateOf<LanguagePickerMode?>(null) }
@@ -1194,7 +1199,6 @@ internal fun SubtitleSettingsDialog(
                         .heightIn(max = bodyMaxHeight)
                         .verticalScroll(rememberScrollState()),
                 ) {
-                    SettingsRepositoryLink()
                     Text("Captions", style = MaterialTheme.typography.titleSmall)
                     Spacer(Modifier.height(8.dp))
                     Text("Original language")
@@ -1229,7 +1233,6 @@ internal fun SubtitleSettingsDialog(
                     Spacer(Modifier.height(12.dp))
                     Text("Text size: ${(fontScale * 100).toInt()}%")
                     Slider(value = fontScale, onValueChange = onFontScaleChange, valueRange = 0.8f..1.5f)
-                    TextButton(onClick = onVocabulary) { Text("Saved words and practice") }
 
                     Spacer(Modifier.height(14.dp))
                     HorizontalDivider()

--- a/app/src/main/java/com/kienhoang/dualsubreplay/ui/KaraokeTiming.kt
+++ b/app/src/main/java/com/kienhoang/dualsubreplay/ui/KaraokeTiming.kt
@@ -29,6 +29,8 @@ internal data class LiveCaptionSample(
     val revision: Long,
     val mediaTimeMs: Long,
     val present: Boolean,
+    val videoId: String? = null,
+    val languageCode: String? = null,
 )
 
 internal data class KaraokePosition(

--- a/app/src/main/java/com/kienhoang/dualsubreplay/ui/LearningPlayerRoot.kt
+++ b/app/src/main/java/com/kienhoang/dualsubreplay/ui/LearningPlayerRoot.kt
@@ -55,6 +55,7 @@ import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.kienhoang.dualsubreplay.data.AnalyzedToken
+import com.kienhoang.dualsubreplay.data.WordTap
 import com.kienhoang.dualsubreplay.data.LanguageAwareTokenizer
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
@@ -493,7 +494,7 @@ fun LearningPlayerRoot(viewModel: AppViewModel) {
                     originalLanguageCode = state.resolvedSourceLanguage ?: state.sourcePreference,
                     targetLanguageCode = state.targetLanguage,
                     lockToVideo = state.lockOverlayToVideo,
-                    onWordClick = viewModel::selectLearningToken,
+                    onWordClick = viewModel::selectLearningWord,
                     modifier = Modifier
                         .align(Alignment.BottomCenter)
                         .padding(start = 20.dp, end = 20.dp, bottom = fullscreenBottomPadding),
@@ -562,7 +563,7 @@ fun LearningPlayerRoot(viewModel: AppViewModel) {
                     originalLanguageCode = state.resolvedSourceLanguage ?: state.sourcePreference,
                     targetLanguageCode = state.targetLanguage,
                     lockToVideo = state.lockOverlayToVideo,
-                    onWordClick = viewModel::selectLearningToken,
+                    onWordClick = viewModel::selectLearningWord,
                     modifier = overlayModifier,
                     onPositionChange = ::updateOverlayPosition,
                     onHorizontalPositionChange = ::updateOverlayHorizontalPosition,
@@ -575,15 +576,7 @@ fun LearningPlayerRoot(viewModel: AppViewModel) {
             }
         }
 
-        state.selectedLearningToken?.let { token ->
-            WordLearningDialog(
-                token = token,
-                sourceLanguage = state.resolvedSourceLanguage ?: state.sourcePreference,
-                targetLanguage = state.targetLanguage,
-                onTranslateWord = viewModel::translateWord,
-                onDismiss = { viewModel.selectLearningToken(null) },
-            )
-        }
+
     }
 }
 
@@ -619,7 +612,7 @@ internal fun LearningSubtitleOverlay(
     originalLanguageCode: String? = null,
     targetLanguageCode: String? = null,
     lockToVideo: Boolean = false,
-    onWordClick: (AnalyzedToken) -> Unit = {},
+    onWordClick: (WordTap) -> Unit = {},
     onPositionChange: (Float) -> Unit = {},
     onHorizontalPositionChange: (Float) -> Unit = {},
     onPositionChangeFinished: () -> Unit = {},
@@ -741,7 +734,7 @@ internal fun LearningSubtitleOverlay(
                             onClick = { offset ->
                                 val token = findWordAtOffset(original, offset, originalLanguageCode)
                                 if (token != null) {
-                                    onWordClick(token)
+                                    onWordClick(WordTap(token, content.segment, false))
                                 } else {
                                     overlayActionsVisible = !overlayActionsVisible
                                 }
@@ -797,7 +790,7 @@ internal fun LearningSubtitleOverlay(
                                     alignedOriginalTokens = origTokens,
                                 )
                                 if (token != null) {
-                                    onWordClick(token)
+                                    onWordClick(WordTap(token, content.segment, true))
                                 } else {
                                     overlayActionsVisible = !overlayActionsVisible
                                 }

--- a/app/src/main/java/com/kienhoang/dualsubreplay/ui/LearningPlayerRoot.kt
+++ b/app/src/main/java/com/kienhoang/dualsubreplay/ui/LearningPlayerRoot.kt
@@ -197,6 +197,11 @@ internal data class LearningOverlayContent(
 
 internal fun learningOverlayContent(state: DualSubUiState): LearningOverlayContent? {
     if (state.activeVideoId == null) return null
+    if (state.liveFallback) return LearningOverlayContent(
+        originalText = state.liveOriginal,
+        translatedText = state.liveTranslated ?: if (state.liveOriginal != null) "Translating…" else null,
+        statusText = "Live subtitles · ${state.statusMessage.orEmpty()}",
+    )
     val active = state.segments.getOrNull(state.currentIndex)
     if (active != null) {
         return LearningOverlayContent(
@@ -317,6 +322,7 @@ fun LearningPlayerRoot(viewModel: AppViewModel) {
     var restoreTranscriptAfterAutomaticOverlay by remember { mutableStateOf(false) }
     var fullscreenOverlayHiddenByUser by remember { mutableStateOf(false) }
     var settingsRequestId by remember { mutableLongStateOf(0L) }
+    var navigationOpen by remember { mutableStateOf(false) }
 
     DisposableEffect(preferences) {
         val listener = SharedPreferences.OnSharedPreferenceChangeListener { sharedPreferences, key ->
@@ -501,6 +507,7 @@ fun LearningPlayerRoot(viewModel: AppViewModel) {
                     onPositionChange = ::updateOverlayPosition,
                     onHorizontalPositionChange = ::updateOverlayHorizontalPosition,
                     onPositionChangeFinished = ::commitOverlayPosition,
+                    onRetryTranscript = if (state.liveFallback && !state.retryingTranscript) viewModel::retryCaptions else null,
                     onSettings = ::requestSubtitleSettings,
                     onClose = { fullscreenOverlayHiddenByUser = true },
                 )
@@ -516,10 +523,11 @@ fun LearningPlayerRoot(viewModel: AppViewModel) {
             onPlayerModeChange = ::selectMode,
             externalSettingsRequestId = settingsRequestId,
             fullscreenLearningOverlay = fullscreenLearningOverlay,
+            onNavigationVisibilityChange = { navigationOpen = it },
         )
 
         if (
-            state.onboardingCompleted &&
+            !navigationOpen && state.onboardingCompleted &&
             state.guideCompleted &&
             state.activeVideoId != null &&
             effectiveMode == PlayerExperienceMode.SCROLL_FRIENDLY_OVERLAY
@@ -568,6 +576,7 @@ fun LearningPlayerRoot(viewModel: AppViewModel) {
                     onPositionChange = ::updateOverlayPosition,
                     onHorizontalPositionChange = ::updateOverlayHorizontalPosition,
                     onPositionChangeFinished = ::commitOverlayPosition,
+                    onRetryTranscript = if (state.liveFallback && !state.retryingTranscript) viewModel::retryCaptions else null,
                     onSettings = ::requestSubtitleSettings,
                     onClose = {
                         selectMode(PlayerExperienceMode.TRANSCRIPT_PANEL)
@@ -617,6 +626,7 @@ internal fun LearningSubtitleOverlay(
     onHorizontalPositionChange: (Float) -> Unit = {},
     onPositionChangeFinished: () -> Unit = {},
     onSettings: () -> Unit,
+    onRetryTranscript: (() -> Unit)? = null,
     onClose: () -> Unit,
 ) {
     var overlayActionsVisible by remember { mutableStateOf(false) }
@@ -806,6 +816,9 @@ internal fun LearningSubtitleOverlay(
                             overflow = TextOverflow.Ellipsis,
                         )
                     }
+                }
+                onRetryTranscript?.let { retry ->
+                    androidx.compose.material3.TextButton(onClick = retry) { Text("Retry full transcript") }
                 }
                 content.statusText?.let { status ->
                     Text(

--- a/app/src/main/java/com/kienhoang/dualsubreplay/ui/LearningPlayerRoot.kt
+++ b/app/src/main/java/com/kienhoang/dualsubreplay/ui/LearningPlayerRoot.kt
@@ -249,6 +249,7 @@ internal fun portraitLearningOverlayTopPaddingDp(
 fun LearningPlayerRoot(viewModel: AppViewModel) {
     val state by viewModel.state.collectAsStateWithLifecycle()
     val youtubeControlsVisible by youtubePlayerControlsVisible.collectAsStateWithLifecycle()
+    val youtubeDialogVisible by youtubeNativeDialogVisible.collectAsStateWithLifecycle()
     val youtubeFullscreen by youtubeFullscreenActive.collectAsStateWithLifecycle()
     val context = LocalContext.current
     val configuration = LocalConfiguration.current
@@ -473,7 +474,7 @@ fun LearningPlayerRoot(viewModel: AppViewModel) {
 
     val fullscreenLearningOverlay: @Composable BoxScope.() -> Unit = {
         HideFullscreenSystemBars()
-        if (overlayContent != null && effectiveMode == PlayerExperienceMode.SCROLL_FRIENDLY_OVERLAY) {
+        if (!youtubeDialogVisible && overlayContent != null && effectiveMode == PlayerExperienceMode.SCROLL_FRIENDLY_OVERLAY) {
             if (fullscreenOverlayHiddenByUser) {
                 MovableSubtitleFab(
                     onClick = { fullscreenOverlayHiddenByUser = false },
@@ -527,7 +528,7 @@ fun LearningPlayerRoot(viewModel: AppViewModel) {
         )
 
         if (
-            !navigationOpen && state.onboardingCompleted &&
+            !youtubeDialogVisible && !navigationOpen && state.onboardingCompleted &&
             state.guideCompleted &&
             state.activeVideoId != null &&
             effectiveMode == PlayerExperienceMode.SCROLL_FRIENDLY_OVERLAY

--- a/app/src/main/java/com/kienhoang/dualsubreplay/ui/LiveSubtitleRecovery.kt
+++ b/app/src/main/java/com/kienhoang/dualsubreplay/ui/LiveSubtitleRecovery.kt
@@ -1,0 +1,73 @@
+package com.kienhoang.dualsubreplay.ui
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.kienhoang.dualsubreplay.data.SubtitleSegment
+import com.kienhoang.dualsubreplay.data.WordTap
+import com.kienhoang.dualsubreplay.translation.TranslationLanguages
+
+internal const val LIVE_TRANSLATION_DEBOUNCE_MS = 300L
+
+internal suspend fun debouncedLiveTranslation(
+    key: LiveTranslationKey,
+    isCurrent: () -> Boolean,
+    translate: suspend (String, String, String) -> String,
+): String? {
+    kotlinx.coroutines.delay(LIVE_TRANSLATION_DEBOUNCE_MS)
+    if (!isCurrent()) return null
+    val result = translate(key.language, key.target, key.text)
+    return result.takeIf { isCurrent() }
+}
+
+internal data class LiveTranslationKey(val videoId: String, val language: String, val target: String, val text: String)
+
+internal fun liveTranslationKey(sample: LiveCaptionSample?, videoId: String, target: String): LiveTranslationKey? {
+    if (sample == null || !sample.present || sample.videoId != videoId) return null
+    val language = sample.languageCode?.takeIf { it.matches(Regex("[a-zA-Z]{2,3}(-[a-zA-Z0-9]+)*")) }
+        ?.let(TranslationLanguages::normalize) ?: return null
+    val text = sample.text.replace(Regex("\\s+"), " ").trim()
+    if (text.isEmpty() || text.length > 4_000) return null
+    return LiveTranslationKey(videoId, language, target, text)
+}
+
+/** Revision numbers may change without the displayed words changing. */
+internal class LiveTranslationGate {
+    var key: LiveTranslationKey? = null
+        private set
+    var generation = 0L
+        private set
+    fun update(next: LiveTranslationKey?, seek: Boolean = false): Boolean {
+        if (!seek && next == key) return false
+        key = next
+        generation++
+        return true
+    }
+    fun accepts(ticket: Long, expected: LiveTranslationKey) = generation == ticket && key == expected
+    fun reset() { key = null; generation++ }
+}
+
+@Composable
+internal fun LiveSubtitlePanel(state: DualSubUiState, onRetry: () -> Unit, onWordClick: (WordTap) -> Unit) {
+    Column(Modifier.fillMaxSize().verticalScroll(rememberScrollState()).padding(12.dp)) {
+        Text("Live subtitles", style = MaterialTheme.typography.labelMedium)
+        Text(state.statusMessage ?: "Current captions only; paragraph replay is unavailable.", style = MaterialTheme.typography.bodySmall)
+        state.liveOriginal?.let { original ->
+            CompactSubtitleCard(
+                segment = SubtitleSegment(0, 0, 0, original, state.liveTranslated),
+                active = true, fontScale = state.fontScale, onReplay = {}, replayEnabled = false,
+                wordLearningEnabled = state.wordLearningEnabled && state.resolvedSourceLanguage != null,
+                wordLearningTarget = state.wordLearningTarget, tapToLearnEnabled = state.tapToLearnEnabled,
+                resolvedSourceLanguage = state.resolvedSourceLanguage, targetLanguage = state.targetLanguage,
+                onWordClick = { onWordClick(it.copy(segment = null)) },
+            )
+        }
+        TextButton(onClick = onRetry, enabled = !state.retryingTranscript) {
+            Text(if (state.retryingTranscript) "Retrying full transcript…" else "Retry full transcript")
+        }
+    }
+}

--- a/app/src/main/java/com/kienhoang/dualsubreplay/ui/SavedWordsScreen.kt
+++ b/app/src/main/java/com/kienhoang/dualsubreplay/ui/SavedWordsScreen.kt
@@ -37,7 +37,10 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
-internal fun intervalLabel(interval: Long): String = if (interval < DAY_MS) "10 min" else "${interval / DAY_MS} days"
+internal fun intervalLabel(interval: Long): String = if (interval < DAY_MS) "10 min" else {
+    val days = interval / DAY_MS
+    "$days ${if (days == 1L) "day" else "days"}"
+}
 
 @Composable
 internal fun SavedWordsScreen(
@@ -69,7 +72,17 @@ internal fun SavedWordsScreen(
     val storage by produceState(0L, words, workInfos) {
         value = withContext(Dispatchers.IO) { repository.clipDirectory.listFiles()?.filter { it.isFile }?.sumOf { it.length() } ?: 0L }
     }
-    LaunchedEffect(Unit) { repository.refresh(); while (true) { now = System.currentTimeMillis(); delay(30_000) } }
+    LaunchedEffect(Unit) {
+        try { repository.refresh() }
+        catch (cancel: CancellationException) { throw cancel }
+        catch (_: Exception) { error = "Could not load saved words. Check storage and reopen this screen to retry." }
+        while (true) { now = System.currentTimeMillis(); delay(30_000) }
+    }
+    LaunchedEffect(workInfos.map { it.id to it.state }) {
+        try { repository.reconcileDownloads(context) }
+        catch (cancel: CancellationException) { throw cancel }
+        catch (_: Exception) { error = "Could not check offline downloads. Reopen this screen to retry." }
+    }
     DisposableEffect(Unit) { onDispose { onPause(); pronouncer.stop() } }
 
     fun action(block: suspend () -> Unit) {
@@ -112,7 +125,7 @@ internal fun SavedWordsScreen(
                         Text("Your reviews are saved. Come back when more words are due.")
                         TextButton(onClick = { practice = false }) { Text("Back to words") }
                     } else {
-                        Text("${words.size} words · ${due.size} due · ${storage / (1024 * 1024)} MiB of clips")
+                        Text("${words.size} ${if (words.size == 1) "word" else "words"} · ${due.size} due · ${storage / (1024 * 1024)} MiB of clips")
                         Button(enabled = due.isNotEmpty(), modifier = Modifier.testTag("practice_words"), onClick = {
                             queue = due.map { it.id }; practice = true
                         }) { Text("Practice due words") }

--- a/app/src/main/java/com/kienhoang/dualsubreplay/ui/SavedWordsScreen.kt
+++ b/app/src/main/java/com/kienhoang/dualsubreplay/ui/SavedWordsScreen.kt
@@ -1,0 +1,233 @@
+package com.kienhoang.dualsubreplay.ui
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.media3.common.MediaItem
+import androidx.media3.common.PlaybackException
+import androidx.media3.common.Player
+import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.ui.PlayerView
+import androidx.work.WorkManager
+import com.kienhoang.dualsubreplay.data.*
+import java.io.File
+import java.text.DateFormat
+import java.util.Date
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+internal fun intervalLabel(interval: Long): String = if (interval < DAY_MS) "10 min" else "${interval / DAY_MS} days"
+
+@Composable
+internal fun SavedWordsScreen(
+    repository: VocabularyRepository,
+    onOnline: (SavedWord) -> Unit,
+    onPause: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val words by repository.words.collectAsStateWithLifecycle()
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    val pronouncer = rememberWordPronouncer()
+    var search by remember { mutableStateOf("") }
+    var selectedId by remember { mutableStateOf<String?>(null) }
+    var practice by remember { mutableStateOf(false) }
+    var queue by remember { mutableStateOf<List<String>>(emptyList()) }
+    var now by remember { mutableLongStateOf(System.currentTimeMillis()) }
+    var busy by remember { mutableStateOf(false) }
+    var error by remember { mutableStateOf<String?>(null) }
+    var confirmDelete by remember { mutableStateOf<SavedWord?>(null) }
+    var onlinePreview by remember { mutableStateOf(false) }
+    var offlinePreview by remember { mutableStateOf<SavedWord?>(null) }
+    val selected = words.firstOrNull { it.id == if (practice) queue.firstOrNull() else selectedId }
+    var revealed by remember(selected?.id, practice) { mutableStateOf(false) }
+    var editedMeaning by remember(selected?.id, selected?.meaning) { mutableStateOf(selected?.meaning.orEmpty()) }
+    val due = words.filter { it.dueAt <= now }.sortedBy { it.dueAt }
+    val workInfos by WorkManager.getInstance(context).getWorkInfosByTagFlow("word-clip")
+        .collectAsStateWithLifecycle(initialValue = emptyList())
+    val storage by produceState(0L, words, workInfos) {
+        value = withContext(Dispatchers.IO) { repository.clipDirectory.listFiles()?.filter { it.isFile }?.sumOf { it.length() } ?: 0L }
+    }
+    LaunchedEffect(Unit) { repository.refresh(); while (true) { now = System.currentTimeMillis(); delay(30_000) } }
+    DisposableEffect(Unit) { onDispose { onPause(); pronouncer.stop() } }
+
+    fun action(block: suspend () -> Unit) {
+        if (busy) return
+        busy = true
+        scope.launch {
+            try { block(); error = null }
+            catch (cancel: CancellationException) { throw cancel }
+            catch (_: Exception) { error = "Could not update saved words. Check storage and try again." }
+            finally { busy = false }
+        }
+    }
+    fun returnFromVideo() { onPause(); onlinePreview = false }
+
+    if (onlinePreview) {
+        BackHandler { returnFromVideo() }
+        Box(Modifier.fillMaxSize(), contentAlignment = Alignment.BottomCenter) {
+            Surface(tonalElevation = 8.dp, modifier = Modifier.padding(16.dp)) {
+                Column(Modifier.padding(12.dp)) {
+                    Text("Example video · internet required")
+                    Text("If the video is unavailable, return to keep practicing.", style = MaterialTheme.typography.bodySmall)
+                    TextButton(onClick = ::returnFromVideo, modifier = Modifier.testTag("return_to_words")) { Text("Return to saved words") }
+                }
+            }
+        }
+        return
+    }
+
+    Dialog(onDismissRequest = onDismiss, properties = DialogProperties(usePlatformDefaultWidth = false)) {
+        Surface(Modifier.fillMaxWidth(0.96f).fillMaxHeight(0.9f), shape = MaterialTheme.shapes.large) {
+            Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+                    Text("Saved words", style = MaterialTheme.typography.titleLarge)
+                    TextButton(onClick = onDismiss) { Text("Close") }
+                }
+                error?.let { Text(it, color = MaterialTheme.colorScheme.error) }
+                if (selected == null) {
+                    if (practice) {
+                        Text("Session complete", modifier = Modifier.testTag("practice_complete"))
+                        Text("Your reviews are saved. Come back when more words are due.")
+                        TextButton(onClick = { practice = false }) { Text("Back to words") }
+                    } else {
+                        Text("${words.size} words · ${due.size} due · ${storage / (1024 * 1024)} MiB of clips")
+                        Button(enabled = due.isNotEmpty(), modifier = Modifier.testTag("practice_words"), onClick = {
+                            queue = due.map { it.id }; practice = true
+                        }) { Text("Practice due words") }
+                        OutlinedTextField(search, { search = it }, label = { Text("Search words or meanings") }, modifier = Modifier.fillMaxWidth())
+                        if (words.isEmpty()) Text("Tap a subtitle word and choose Save word to start your collection.")
+                        else if (due.isEmpty()) words.minOfOrNull { it.dueAt }?.let {
+                            Text("Next review: ${DateFormat.getDateTimeInstance().format(Date(it))}", style = MaterialTheme.typography.bodySmall)
+                        }
+                        LazyColumn(Modifier.weight(1f)) {
+                            items(words.filter { it.word.contains(search, true) || it.meaning.contains(search, true) }, key = { it.id }) { word ->
+                                ListItem(headlineContent = { Text(word.word) }, supportingContent = { Text(word.meaning) },
+                                    modifier = Modifier.clickable { selectedId = word.id }.testTag("saved_word_${word.id}"))
+                                HorizontalDivider()
+                            }
+                        }
+                    }
+                } else {
+                    Column(Modifier.weight(1f).verticalScroll(rememberScrollState()), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                        Text(selected.word, style = MaterialTheme.typography.headlineMedium)
+                        selected.reading?.let { Text(it) }
+                        TextButton(onClick = { onPause(); pronouncer.speak(selected.word, selected.wordLanguage) }) { Text("Pronounce") }
+                        pronouncer.message?.let { Text(it) }
+                        if (practice && !revealed) {
+                            Button(onClick = { revealed = true }, modifier = Modifier.testTag("reveal_meaning")) { Text("Show meaning") }
+                        } else {
+                            if (practice) Text(selected.meaning, modifier = Modifier.testTag("review_meaning"))
+                            else {
+                                OutlinedTextField(editedMeaning, { editedMeaning = it }, label = { Text("Meaning (${selected.meaningLanguage})") })
+                                TextButton(enabled = !busy && editedMeaning != selected.meaning, onClick = { action {
+                                    repository.update(selected.id) { it.copy(meaning = editedMeaning.trim()) }
+                                } }) { Text("Save meaning") }
+                            }
+                            Text(selected.sentence)
+                            selected.translatedSentence?.let { Text(it) }
+                            if (selected.translated) Text("Video example uses the original sentence.", style = MaterialTheme.typography.bodySmall)
+                            if (selected.online) TextButton(onClick = {
+                                pronouncer.stop(); onlinePreview = true; onOnline(selected)
+                            }, modifier = Modifier.testTag("play_online_clip")) { Text("Play online example") }
+                            if (selected.offline && selected.clipStatus == "ready" && repository.clipFile(selected).isFile) {
+                                TextButton(onClick = { pronouncer.stop(); onPause(); offlinePreview = selected },
+                                    modifier = Modifier.testTag("play_offline_clip")) { Text("Play offline clip") }
+                            }
+                            if (selected.offline) {
+                                val work = workInfos.firstOrNull { "word:${selected.id}" in it.tags && !it.state.isFinished }
+                                Text(if (selected.clipStatus == "ready" && !repository.clipFile(selected).isFile) "Offline file missing. Download it again."
+                                    else "Offline clip: ${selected.clipStatus}")
+                                if (work != null) Text("${work.progress.getInt("percent", 0)}%")
+                                selected.clipError?.let { Text(it) }
+                                if (selected.clipStatus != "ready" && work == null || selected.clipStatus == "ready" && !repository.clipFile(selected).isFile) {
+                                    TextButton(enabled = !busy, onClick = { action { enqueueClip(context, selected.id) } }) { Text("Retry download") }
+                                }
+                                TextButton(enabled = !busy, onClick = { action { removeClip(context, selected) } }) {
+                                    Text(if (work != null) "Cancel download" else "Remove offline clip")
+                                }
+                            }
+                            if (practice) {
+                                ReviewRating.entries.forEach { rating ->
+                                    OutlinedButton(enabled = !busy, modifier = Modifier.fillMaxWidth().testTag("review_${rating.name.lowercase()}"), onClick = {
+                                        action {
+                                            repository.update(selected.id) { reviewWord(it, rating, System.currentTimeMillis()) }
+                                            queue = queue.drop(1); pronouncer.stop()
+                                        }
+                                    }) { Text("${rating.name.lowercase().replaceFirstChar { it.uppercase() }} · ${intervalLabel(reviewInterval(selected.intervalMs, rating))}") }
+                                }
+                            } else if (validClipRange(selected.videoId, selected.startMs, selected.endMs)) {
+                                ClipChoice("Online example", selected.online, { enabled -> action { repository.update(selected.id) { it.copy(online = enabled) } } }, "saved_online_choice")
+                                if (!selected.offline) TextButton(enabled = !busy, onClick = { action { enqueueClip(context, selected.id) } }) { Text("Download offline clip") }
+                            }
+                        }
+                    }
+                    Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+                        TextButton(onClick = { selectedId = null; practice = false; pronouncer.stop() }) { Text("Back to words") }
+                        if (!practice) TextButton(enabled = !busy, onClick = { confirmDelete = selected }) { Text("Delete word") }
+                    }
+                }
+            }
+        }
+    }
+    confirmDelete?.let { word ->
+        AlertDialog(onDismissRequest = { confirmDelete = null }, title = { Text("Delete ${word.word}?") },
+            text = { Text("This removes its review history and offline clip.") },
+            confirmButton = { TextButton(onClick = {
+                confirmDelete = null
+                action { repository.remove(word.id); WorkManager.getInstance(context).cancelUniqueWork("word-clip-${word.id}"); selectedId = null }
+            }) { Text("Delete") } }, dismissButton = { TextButton(onClick = { confirmDelete = null }) { Text("Keep") } })
+    }
+    offlinePreview?.let { word -> LocalClipDialog(repository.clipFile(word)) { offlinePreview = null } }
+}
+
+@androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
+@Composable
+private fun LocalClipDialog(file: File, onDismiss: () -> Unit) {
+    val context = LocalContext.current
+    val owner = LocalLifecycleOwner.current
+    var error by remember(file) { mutableStateOf<String?>(null) }
+    val player = remember(file) { ExoPlayer.Builder(context).build().apply {
+        setMediaItem(MediaItem.fromUri(android.net.Uri.fromFile(file)))
+        addListener(object : Player.Listener {
+            override fun onPlayerError(exception: PlaybackException) { error = "This clip cannot be played. Remove it and download it again." }
+        })
+        prepare(); playWhenReady = true
+    } }
+    DisposableEffect(player, owner) {
+        val observer = LifecycleEventObserver { _, event -> if (event == Lifecycle.Event.ON_STOP) player.pause() }
+        owner.lifecycle.addObserver(observer)
+        onDispose { owner.lifecycle.removeObserver(observer); player.release() }
+    }
+    Dialog(onDismissRequest = onDismiss, properties = DialogProperties(usePlatformDefaultWidth = false)) {
+        Surface(Modifier.fillMaxWidth(0.96f), shape = MaterialTheme.shapes.large) {
+            Column(Modifier.padding(12.dp)) {
+                Text("Offline example", style = MaterialTheme.typography.titleMedium)
+                AndroidView(factory = { PlayerView(it).apply { this.player = player } }, modifier = Modifier.fillMaxWidth().height(220.dp))
+                error?.let { Text(it) }
+                TextButton(onClick = onDismiss) { Text("Return to saved words") }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/kienhoang/dualsubreplay/ui/SavedWordsScreen.kt
+++ b/app/src/main/java/com/kienhoang/dualsubreplay/ui/SavedWordsScreen.kt
@@ -104,7 +104,7 @@ internal fun SavedWordsScreen(
                 Column(Modifier.padding(12.dp)) {
                     Text("Example video · internet required")
                     Text("If the video is unavailable, return to keep practicing.", style = MaterialTheme.typography.bodySmall)
-                    TextButton(onClick = ::returnFromVideo, modifier = Modifier.testTag("return_to_words")) { Text("Return to saved words") }
+                    TextButton(onClick = ::returnFromVideo, modifier = Modifier.testTag("return_to_words")) { Text("Return to Practice") }
                 }
             }
         }
@@ -115,7 +115,7 @@ internal fun SavedWordsScreen(
         Surface(Modifier.fillMaxWidth(0.96f).fillMaxHeight(0.9f), shape = MaterialTheme.shapes.large) {
             Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
                 Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
-                    Text("Saved words", style = MaterialTheme.typography.titleLarge)
+                    Text("Practice", style = MaterialTheme.typography.titleLarge)
                     TextButton(onClick = onDismiss) { Text("Close") }
                 }
                 error?.let { Text(it, color = MaterialTheme.colorScheme.error) }
@@ -123,7 +123,7 @@ internal fun SavedWordsScreen(
                     if (practice) {
                         Text("Session complete", modifier = Modifier.testTag("practice_complete"))
                         Text("Your reviews are saved. Come back when more words are due.")
-                        TextButton(onClick = { practice = false }) { Text("Back to words") }
+                        TextButton(onClick = { practice = false }) { Text("Back to saved words") }
                     } else {
                         Text("${words.size} ${if (words.size == 1) "word" else "words"} · ${due.size} due · ${storage / (1024 * 1024)} MiB of clips")
                         Button(enabled = due.isNotEmpty(), modifier = Modifier.testTag("practice_words"), onClick = {
@@ -197,7 +197,7 @@ internal fun SavedWordsScreen(
                         }
                     }
                     Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
-                        TextButton(onClick = { selectedId = null; practice = false; pronouncer.stop() }) { Text("Back to words") }
+                        TextButton(onClick = { selectedId = null; practice = false; pronouncer.stop() }) { Text("Back to saved words") }
                         if (!practice) TextButton(enabled = !busy, onClick = { confirmDelete = selected }) { Text("Delete word") }
                     }
                 }
@@ -239,7 +239,7 @@ private fun LocalClipDialog(file: File, onDismiss: () -> Unit) {
                 Text("Offline example", style = MaterialTheme.typography.titleMedium)
                 AndroidView(factory = { PlayerView(it).apply { this.player = player } }, modifier = Modifier.fillMaxWidth().height(220.dp))
                 error?.let { Text(it) }
-                TextButton(onClick = onDismiss) { Text("Return to saved words") }
+                TextButton(onClick = onDismiss) { Text("Return to Practice") }
             }
         }
     }

--- a/app/src/main/java/com/kienhoang/dualsubreplay/ui/SettingsRepositoryLink.kt
+++ b/app/src/main/java/com/kienhoang/dualsubreplay/ui/SettingsRepositoryLink.kt
@@ -1,0 +1,40 @@
+package com.kienhoang.dualsubreplay.ui
+
+import android.content.ActivityNotFoundException
+import android.content.Intent
+import android.net.Uri
+import androidx.compose.foundation.text.ClickableText
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.withStyle
+
+internal const val REPOSITORY_URL = "https://github.com/hoangkien1703/dual-sub-replay"
+
+@Composable
+internal fun SettingsRepositoryLink() {
+    val context = LocalContext.current
+    var failed by remember { mutableStateOf(false) }
+    val text = buildAnnotatedString {
+        append("Check the latest version of the app on ")
+        pushStringAnnotation("url", REPOSITORY_URL)
+        withStyle(SpanStyle(color = MaterialTheme.colorScheme.primary, textDecoration = TextDecoration.Underline)) { append("GitHub") }
+        pop()
+        append(".")
+    }
+    ClickableText(text, modifier = Modifier.testTag("settings_github_link"),
+        style = MaterialTheme.typography.bodySmall.copy(color = MaterialTheme.colorScheme.onSurfaceVariant),
+        onClick = { offset ->
+            if (text.getStringAnnotations("url", offset, offset).isNotEmpty()) {
+                try { context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(REPOSITORY_URL))) }
+                catch (_: ActivityNotFoundException) { failed = true }
+            }
+        })
+    if (failed) Text("No browser is available to open GitHub.", style = MaterialTheme.typography.bodySmall)
+}

--- a/app/src/main/java/com/kienhoang/dualsubreplay/ui/SettingsRepositoryLink.kt
+++ b/app/src/main/java/com/kienhoang/dualsubreplay/ui/SettingsRepositoryLink.kt
@@ -3,38 +3,53 @@ package com.kienhoang.dualsubreplay.ui
 import android.content.ActivityNotFoundException
 import android.content.Intent
 import android.net.Uri
-import androidx.compose.foundation.text.ClickableText
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.LinkAnnotation
 import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextLinkStyles
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.style.TextDecoration
-import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.text.withLink
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
 internal const val REPOSITORY_URL = "https://github.com/hoangkien1703/dual-sub-replay"
 
 @Composable
-internal fun SettingsRepositoryLink() {
+internal fun SettingsRepositoryLink(onOpen: (() -> Unit)? = null) {
     val context = LocalContext.current
     var failed by remember { mutableStateOf(false) }
+    var showLicense by remember { mutableStateOf(false) }
     val text = buildAnnotatedString {
         append("Check the latest version of the app on ")
-        pushStringAnnotation("url", REPOSITORY_URL)
-        withStyle(SpanStyle(color = MaterialTheme.colorScheme.primary, textDecoration = TextDecoration.Underline)) { append("GitHub") }
-        pop()
+        withLink(LinkAnnotation.Url(REPOSITORY_URL,
+            TextLinkStyles(style = SpanStyle(color = MaterialTheme.colorScheme.primary, textDecoration = TextDecoration.Underline)),
+            linkInteractionListener = {
+                try { if (onOpen != null) onOpen() else context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(REPOSITORY_URL))) }
+                catch (_: ActivityNotFoundException) { failed = true }
+            })) { append("GitHub") }
         append(".")
     }
-    ClickableText(text, modifier = Modifier.testTag("settings_github_link"),
-        style = MaterialTheme.typography.bodySmall.copy(color = MaterialTheme.colorScheme.onSurfaceVariant),
-        onClick = { offset ->
-            if (text.getStringAnnotations("url", offset, offset).isNotEmpty()) {
-                try { context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(REPOSITORY_URL))) }
-                catch (_: ActivityNotFoundException) { failed = true }
-            }
-        })
+    Text(text, modifier = Modifier.testTag("settings_github_link"), style = MaterialTheme.typography.bodySmall)
     if (failed) Text("No browser is available to open GitHub.", style = MaterialTheme.typography.bodySmall)
+    TextButton(onClick = { showLicense = true }) { Text("Open-source licenses") }
+    if (showLicense) {
+        val license by produceState("Loading license…") {
+            value = withContext(Dispatchers.IO) {
+                context.assets.open("licenses/GPL-3.0.txt").bufferedReader().use { it.readText() }
+            }
+        }
+        AlertDialog(onDismissRequest = { showLicense = false }, title = { Text("Open-source licenses") },
+            text = { Text("DualSub Replay © 2026 Hoang Trung Kien. This combined application is distributed under GPL-3.0 without warranty. You may redistribute and modify it under these terms. Original MIT notices and dependency source/build links are in THIRD_PARTY_NOTICES.md in the GitHub repository.\n\n" + license,
+                modifier = Modifier.heightIn(max = 400.dp).verticalScroll(rememberScrollState())) },
+            confirmButton = { TextButton(onClick = { showLicense = false }) { Text("Close") } })
+    }
 }

--- a/app/src/main/java/com/kienhoang/dualsubreplay/ui/SettingsRepositoryLink.kt
+++ b/app/src/main/java/com/kienhoang/dualsubreplay/ui/SettingsRepositoryLink.kt
@@ -44,7 +44,8 @@ internal fun SettingsRepositoryLink(onOpen: (() -> Unit)? = null) {
     if (showLicense) {
         val license by produceState("Loading license…") {
             value = withContext(Dispatchers.IO) {
-                context.assets.open("licenses/GPL-3.0.txt").bufferedReader().use { it.readText() }
+                context.assets.open("licenses/MIT.txt").bufferedReader().use { it.readText() } + "\n\n" +
+                    context.assets.open("licenses/GPL-3.0.txt").bufferedReader().use { it.readText() }
             }
         }
         AlertDialog(onDismissRequest = { showLicense = false }, title = { Text("Open-source licenses") },

--- a/app/src/main/java/com/kienhoang/dualsubreplay/ui/SettingsRepositoryLink.kt
+++ b/app/src/main/java/com/kienhoang/dualsubreplay/ui/SettingsRepositoryLink.kt
@@ -20,12 +20,14 @@ import androidx.compose.ui.text.withLink
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.launch
 
 internal const val REPOSITORY_URL = "https://github.com/hoangkien1703/dual-sub-replay"
 
 @Composable
-internal fun SettingsRepositoryLink(onOpen: (() -> Unit)? = null) {
+internal fun SettingsRepositoryLink(onOpen: (() -> Unit)? = null, beforeOpen: suspend () -> Unit = {}) {
     val context = LocalContext.current
+    val scope = rememberCoroutineScope()
     var failed by remember { mutableStateOf(false) }
     var showLicense by remember { mutableStateOf(false) }
     val text = buildAnnotatedString {
@@ -33,14 +35,17 @@ internal fun SettingsRepositoryLink(onOpen: (() -> Unit)? = null) {
         withLink(LinkAnnotation.Url(REPOSITORY_URL,
             TextLinkStyles(style = SpanStyle(color = MaterialTheme.colorScheme.primary, textDecoration = TextDecoration.Underline)),
             linkInteractionListener = {
+                scope.launch {
+                beforeOpen()
                 try { if (onOpen != null) onOpen() else context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(REPOSITORY_URL))) }
                 catch (_: ActivityNotFoundException) { failed = true }
+                }
             })) { append("GitHub") }
         append(".")
     }
     Text(text, modifier = Modifier.testTag("settings_github_link"), style = MaterialTheme.typography.bodySmall)
     if (failed) Text("No browser is available to open GitHub.", style = MaterialTheme.typography.bodySmall)
-    TextButton(onClick = { showLicense = true }) { Text("Open-source licenses") }
+    TextButton(onClick = { scope.launch { beforeOpen(); showLicense = true } }) { Text("Open-source licenses") }
     if (showLicense) {
         val license by produceState("Loading license…") {
             value = withContext(Dispatchers.IO) {

--- a/app/src/main/java/com/kienhoang/dualsubreplay/ui/SubtitleColors.kt
+++ b/app/src/main/java/com/kienhoang/dualsubreplay/ui/SubtitleColors.kt
@@ -128,6 +128,7 @@ internal fun effectiveHighlightColor(state: DualSubUiState): Color = if (
 
 /** Every preference key that "Reset all settings to defaults" clears (issue #22). */
 val RESETTABLE_SETTING_KEYS = listOf(
+    "auto_pronounce",
     "font_scale",
     "preferred_caption_language",
     "target_language",

--- a/app/src/main/java/com/kienhoang/dualsubreplay/ui/WordLearningSheet.kt
+++ b/app/src/main/java/com/kienhoang/dualsubreplay/ui/WordLearningSheet.kt
@@ -22,20 +22,21 @@ internal fun WordLearningDialog(
     onSpeak: () -> Unit,
     speechMessage: String?,
     onDismiss: () -> Unit,
+    existingWord: com.kienhoang.dualsubreplay.data.SavedWord? = null,
 ) {
-    var meaning by remember(selection) { mutableStateOf("") }
+    var meaning by remember(selection) { mutableStateOf(existingWord?.meaning.orEmpty()) }
     var loading by remember(selection) { mutableStateOf(true) }
     var error by remember(selection) { mutableStateOf<String?>(null) }
-    var saved by remember(selection) { mutableStateOf(false) }
+    var saved by remember(selection) { mutableStateOf(existingWord != null) }
     var saving by remember(selection) { mutableStateOf(false) }
-    var online by remember(selection) { mutableStateOf(true) }
-    var offline by remember(selection) { mutableStateOf(false) }
+    var online by remember(selection) { mutableStateOf(existingWord?.online ?: true) }
+    var offline by remember(selection) { mutableStateOf(existingWord?.offline ?: false) }
     val scope = rememberCoroutineScope()
     val canClip = validClipRange(selection.videoId, selection.segment?.startMs ?: -1, selection.segment?.endMs ?: -1)
 
     LaunchedEffect(selection) {
         if (autoPronounce) onSpeak()
-        try { meaning = onTranslateWord() }
+        try { if (existingWord == null) meaning = onTranslateWord() }
         catch (cancel: CancellationException) { throw cancel }
         catch (_: Exception) { error = "Translation unavailable. You can enter a meaning and save the word." }
         finally { loading = false }

--- a/app/src/main/java/com/kienhoang/dualsubreplay/ui/WordLearningSheet.kt
+++ b/app/src/main/java/com/kienhoang/dualsubreplay/ui/WordLearningSheet.kt
@@ -1,169 +1,87 @@
 package com.kienhoang.dualsubreplay.ui
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
-import androidx.compose.ui.window.Dialog
-import com.kienhoang.dualsubreplay.data.AnalyzedToken
+import com.kienhoang.dualsubreplay.data.LearningWordSelection
+import com.kienhoang.dualsubreplay.data.validClipRange
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.launch
 
-/**
- * Tap-to-learn inspection popup for Word Learning Mode (Issue #42 V2).
- * Shows the word surface form, POS badge, reading, and on-demand definition.
- */
 @Composable
 internal fun WordLearningDialog(
-    token: AnalyzedToken,
-    sourceLanguage: String,
-    targetLanguage: String,
-    onTranslateWord: suspend (word: String) -> String,
+    selection: LearningWordSelection,
+    autoPronounce: Boolean,
+    onTranslateWord: suspend () -> String,
+    onSave: suspend (meaning: String, online: Boolean, offline: Boolean) -> Unit,
+    onSpeak: () -> Unit,
+    speechMessage: String?,
     onDismiss: () -> Unit,
 ) {
-    var definition by remember(token) { mutableStateOf<String?>(null) }
-    var isLoading by remember(token) { mutableStateOf(true) }
+    var meaning by remember(selection) { mutableStateOf("") }
+    var loading by remember(selection) { mutableStateOf(true) }
+    var error by remember(selection) { mutableStateOf<String?>(null) }
+    var saved by remember(selection) { mutableStateOf(false) }
+    var saving by remember(selection) { mutableStateOf(false) }
+    var online by remember(selection) { mutableStateOf(true) }
+    var offline by remember(selection) { mutableStateOf(false) }
+    val scope = rememberCoroutineScope()
+    val canClip = validClipRange(selection.videoId, selection.segment?.startMs ?: -1, selection.segment?.endMs ?: -1)
 
-    LaunchedEffect(token) {
-        isLoading = true
-        definition = try {
-            onTranslateWord(token.text)
-        } catch (_: Exception) {
-            "Translation unavailable"
-        } finally {
-            isLoading = false
-        }
+    LaunchedEffect(selection) {
+        if (autoPronounce) onSpeak()
+        try { meaning = onTranslateWord() }
+        catch (cancel: CancellationException) { throw cancel }
+        catch (_: Exception) { error = "Translation unavailable. You can enter a meaning and save the word." }
+        finally { loading = false }
     }
-
-    Dialog(onDismissRequest = onDismiss) {
-        Surface(
-            shape = RoundedCornerShape(16.dp),
-            color = Color(0xFF132226),
-            contentColor = Color(0xFFF3FAFA),
-            tonalElevation = 8.dp,
-            modifier = Modifier
-                .fillMaxWidth(0.92f)
-                .testTag("word_learning_dialog"),
-        ) {
-            Column(
-                modifier = Modifier.padding(20.dp),
-            ) {
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.SpaceBetween,
-                ) {
-                    // Word surface form
-                    Text(
-                        text = token.text,
-                        fontSize = 24.sp,
-                        fontWeight = FontWeight.Bold,
-                        color = Color.White,
-                    )
-
-                    // POS Category Badge
-                    Box(
-                        modifier = Modifier
-                            .background(
-                                color = Color(token.partOfSpeech.colorHex).copy(alpha = 0.2f),
-                                shape = RoundedCornerShape(8.dp),
-                            )
-                            .padding(horizontal = 10.dp, vertical = 4.dp),
-                    ) {
-                        Text(
-                            text = token.partOfSpeech.label,
-                            fontSize = 12.sp,
-                            fontWeight = FontWeight.SemiBold,
-                            color = Color(token.partOfSpeech.colorHex),
-                        )
-                    }
+    AlertDialog(
+        modifier = Modifier.testTag("word_learning_dialog"),
+        onDismissRequest = onDismiss,
+        title = { Text(selection.token.text) },
+        text = {
+            Column(Modifier.heightIn(max = 450.dp).verticalScroll(rememberScrollState()), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                Text(selection.token.partOfSpeech.label)
+                selection.token.reading?.takeIf { it.isNotBlank() }?.let { Text(it) }
+                TextButton(onClick = onSpeak, modifier = Modifier.testTag("pronounce_word")) { Text("Pronounce") }
+                speechMessage?.let { Text(it) }
+                if (loading) LinearProgressIndicator(Modifier.fillMaxWidth())
+                OutlinedTextField(meaning, { meaning = it; saved = false }, label = { Text("Meaning (${selection.meaningLanguage})") },
+                    enabled = !loading && !saving, modifier = Modifier.testTag("word_meaning"))
+                error?.let { Text(it, color = MaterialTheme.colorScheme.error) }
+                if (canClip) {
+                    ClipChoice("Online example", online, { online = it; saved = false }, "online_clip_choice")
+                    ClipChoice("Download offline clip", offline, { offline = it; saved = false }, "offline_clip_choice")
+                    Text("Both options are optional. Downloads use your internet connection.", style = MaterialTheme.typography.bodySmall)
+                    if (selection.translated) Text("The clip plays the original sentence, not the translated word.", style = MaterialTheme.typography.bodySmall)
                 }
-
-                if (!token.reading.isNullOrBlank()) {
-                    Spacer(Modifier.height(4.dp))
-                    Text(
-                        text = token.reading,
-                        fontSize = 14.sp,
-                        color = Color(0xFF9EA3A5),
-                    )
-                }
-
-                Spacer(Modifier.height(14.dp))
-
-                // Meaning / Definition in user's target language
-                Text(
-                    text = "Meaning",
-                    fontSize = 12.sp,
-                    fontWeight = FontWeight.Medium,
-                    color = Color(0xFF75E7C1),
-                )
-                Spacer(Modifier.height(4.dp))
-
-                if (isLoading) {
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically,
-                        modifier = Modifier.padding(vertical = 8.dp),
-                    ) {
-                        CircularProgressIndicator(
-                            modifier = Modifier.size(16.dp),
-                            strokeWidth = 2.dp,
-                            color = Color(0xFF75E7C1),
-                        )
-                        Spacer(Modifier.width(10.dp))
-                        Text(
-                            text = "Loading definition...",
-                            fontSize = 14.sp,
-                            color = Color(0xFFC0C7C9),
-                        )
-                    }
-                } else {
-                    Text(
-                        text = definition ?: token.text,
-                        fontSize = 16.sp,
-                        color = Color(0xFFF3FAFA),
-                        modifier = Modifier.padding(vertical = 4.dp),
-                    )
-                }
-
-                Spacer(Modifier.height(16.dp))
-
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.End,
-                ) {
-                    TextButton(onClick = onDismiss) {
-                        Text(
-                            text = "Close",
-                            color = Color(0xFF75E7C1),
-                            fontWeight = FontWeight.SemiBold,
-                        )
-                    }
-                }
+                if (saved) Text("Word saved", modifier = Modifier.testTag("word_saved"))
             }
-        }
+        },
+        confirmButton = {
+            TextButton(enabled = !saving && !loading && !saved, modifier = Modifier.testTag("save_word"), onClick = {
+                saving = true
+                scope.launch {
+                    try { onSave(meaning, online && canClip, offline && canClip); saved = true; error = null }
+                    catch (cancel: CancellationException) { throw cancel }
+                    catch (_: Exception) { error = "Could not save. Check your available storage and try again." }
+                    finally { saving = false }
+                }
+            }) { Text(if (saving) "Saving…" else if (saved) "Saved" else "Save word") }
+        },
+        dismissButton = { TextButton(onClick = onDismiss) { Text("Close") } },
+    )
+}
+
+@Composable
+internal fun ClipChoice(label: String, checked: Boolean, onChange: (Boolean) -> Unit, tag: String) {
+    Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+        Text(label, modifier = Modifier.weight(1f).padding(top = 12.dp))
+        Checkbox(checked, onChange, modifier = Modifier.testTag(tag))
     }
 }

--- a/app/src/main/java/com/kienhoang/dualsubreplay/ui/WordPronouncer.kt
+++ b/app/src/main/java/com/kienhoang/dualsubreplay/ui/WordPronouncer.kt
@@ -1,0 +1,59 @@
+package com.kienhoang.dualsubreplay.ui
+
+import android.content.Context
+import android.speech.tts.TextToSpeech
+import androidx.compose.runtime.*
+import androidx.compose.ui.platform.LocalContext
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import java.util.Locale
+
+internal class WordPronouncer(context: Context) {
+    var message by mutableStateOf<String?>(null)
+        private set
+    private var ready = false
+    private var disposed = false
+    private var pending: Pair<String, String>? = null
+    private var engine: TextToSpeech? = null
+
+    init {
+        engine = TextToSpeech(context.applicationContext) { status ->
+            if (!disposed) {
+                ready = status == TextToSpeech.SUCCESS
+                if (ready) pending?.let { speak(it.first, it.second) }
+                else { pending = null; message = "Speech is unavailable on this device." }
+            }
+        }
+    }
+    fun speak(word: String, language: String) {
+        if (disposed || word.isBlank()) return
+        if (!ready) { pending = word to language; return }
+        pending = null
+        val tts = engine ?: return
+        val result = tts.setLanguage(Locale.forLanguageTag(language))
+        if (result == TextToSpeech.LANG_MISSING_DATA || result == TextToSpeech.LANG_NOT_SUPPORTED) {
+            message = "Install a speech voice for this language in Android settings."
+            return
+        }
+        message = null
+        if (tts.speak(word, TextToSpeech.QUEUE_FLUSH, null, "word") == TextToSpeech.ERROR) {
+            message = "Could not pronounce this word. Try again."
+        }
+    }
+    fun stop() { pending = null; engine?.stop() }
+    fun close() { disposed = true; stop(); engine?.shutdown(); engine = null }
+}
+
+@Composable
+internal fun rememberWordPronouncer(): WordPronouncer {
+    val context = LocalContext.current
+    val owner = LocalLifecycleOwner.current
+    val pronouncer = remember(context) { WordPronouncer(context) }
+    DisposableEffect(pronouncer, owner) {
+        val observer = LifecycleEventObserver { _, event -> if (event == Lifecycle.Event.ON_STOP) pronouncer.stop() }
+        owner.lifecycle.addObserver(observer)
+        onDispose { owner.lifecycle.removeObserver(observer); pronouncer.close() }
+    }
+    return pronouncer
+}

--- a/app/src/main/java/com/kienhoang/dualsubreplay/ui/WordPronouncer.kt
+++ b/app/src/main/java/com/kienhoang/dualsubreplay/ui/WordPronouncer.kt
@@ -13,6 +13,7 @@ internal class WordPronouncer(context: Context) {
     var message by mutableStateOf<String?>(null)
         private set
     private var ready = false
+    private var initializationFailed = false
     private var disposed = false
     private var pending: Pair<String, String>? = null
     private var engine: TextToSpeech? = null
@@ -22,12 +23,17 @@ internal class WordPronouncer(context: Context) {
             if (!disposed) {
                 ready = status == TextToSpeech.SUCCESS
                 if (ready) pending?.let { speak(it.first, it.second) }
-                else { pending = null; message = "Speech is unavailable on this device." }
+                else {
+                    initializationFailed = true
+                    if (pending != null) message = "Speech is unavailable on this device."
+                    pending = null
+                }
             }
         }
     }
     fun speak(word: String, language: String) {
         if (disposed || word.isBlank()) return
+        if (initializationFailed) { message = "Speech is unavailable on this device."; return }
         if (!ready) { pending = word to language; return }
         pending = null
         val tts = engine ?: return

--- a/app/src/main/java/com/kienhoang/dualsubreplay/ui/YouTubeBrowserScreen.kt
+++ b/app/src/main/java/com/kienhoang/dualsubreplay/ui/YouTubeBrowserScreen.kt
@@ -1020,7 +1020,7 @@ internal fun webClipReplayScript(videoId: String, startMs: Long, endMs: Long): S
             video.currentTime = ${startMs / 1000.0};
             const promise = video.play();
             if (promise && promise.catch) promise.catch(function() { clearInterval(window.__dualSubClipTimer); });
-          } else if (video.currentTime >= ${endMs / 1000.0} || video.currentTime < ${startMs / 1000.0} - 1) {
+          } else if (video.ended || video.currentTime >= ${endMs / 1000.0} || video.currentTime < ${startMs / 1000.0} - 1) {
             video.pause(); clearInterval(window.__dualSubClipTimer);
           }
         }, 50);

--- a/app/src/main/java/com/kienhoang/dualsubreplay/ui/YouTubeBrowserScreen.kt
+++ b/app/src/main/java/com/kienhoang/dualsubreplay/ui/YouTubeBrowserScreen.kt
@@ -936,6 +936,29 @@ internal fun parseWebPlaybackSnapshot(rawValue: String?): WebPlaybackSnapshot? {
 internal class YouTubeWebController {
     private var bindingToken: Any? = null
     private var replayAction: ((Float) -> Unit)? = null
+    private var scriptAction: ((String) -> Unit)? = null
+    private var pendingClip: com.kienhoang.dualsubreplay.data.SavedWord? = null
+    private var playingClipVideo: String? = null
+
+    fun bindScripts(action: (String) -> Unit) { scriptAction = action }
+    fun pause() {
+        pendingClip = null
+        playingClipVideo = null
+        scriptAction?.invoke(webPauseScript())
+    }
+    fun replayClip(word: com.kienhoang.dualsubreplay.data.SavedWord) {
+        pause()
+        pendingClip = word
+    }
+    fun observePage(url: String) {
+        val videoId = browseVideoSelection(url)?.videoId
+        if (playingClipVideo != null && playingClipVideo != videoId) pause()
+        val clip = pendingClip ?: return
+        if (videoId != clip.videoId) return
+        pendingClip = null
+        playingClipVideo = videoId
+        scriptAction?.invoke(webClipReplayScript(videoId.orEmpty(), clip.startMs, clip.endMs))
+    }
 
     fun bind(replayFrom: (Float) -> Unit): Any {
         val token = Any()
@@ -948,11 +971,59 @@ internal class YouTubeWebController {
         if (bindingToken !== token) return
         bindingToken = null
         replayAction = null
+        scriptAction = null
+        pendingClip = null
+        playingClipVideo = null
     }
 
     fun replayFrom(second: Float) {
+        pause()
         replayAction?.invoke(second.takeIf { it.isFinite() }?.coerceAtLeast(0f) ?: 0f)
     }
+}
+
+internal fun webPauseScript(): String = """
+    (function() {
+      const host = window.location.hostname.toLowerCase().replace(/\.${'$'}/, '');
+      if (window.location.protocol !== 'https:' || !(host === 'youtube.com' || host.endsWith('.youtube.com'))) return false;
+      clearInterval(window.__dualSubClipTimer);
+      document.querySelectorAll('video').forEach(function(video) { video.pause(); });
+      return true;
+    })();
+""".trimIndent()
+
+internal fun webClipReplayScript(videoId: String, startMs: Long, endMs: Long): String {
+    require(com.kienhoang.dualsubreplay.data.validClipRange(videoId, startMs, endMs))
+    return """
+      (function() {
+        const expected = '$videoId';
+        const valid = function() {
+          const host = window.location.hostname.toLowerCase().replace(/\.${'$'}/, '');
+          const url = new URL(window.location.href);
+          const id = url.searchParams.get('v') || url.pathname.split('/')[2];
+          return window.location.protocol === 'https:' && (host === 'youtube.com' || host.endsWith('.youtube.com')) && id === expected;
+        };
+        if (!valid()) return false;
+        clearInterval(window.__dualSubClipTimer);
+        let started = false;
+        const deadline = Date.now() + 30000;
+        window.__dualSubClipTimer = setInterval(function() {
+          if (!valid()) { clearInterval(window.__dualSubClipTimer); return; }
+          const video = document.querySelector('video');
+          if (!started && Date.now() > deadline) { clearInterval(window.__dualSubClipTimer); return; }
+          if (!video || video.readyState < 1 || document.querySelector('.ad-showing')) return;
+          if (!started) {
+            started = true;
+            video.currentTime = ${startMs / 1000.0};
+            const promise = video.play();
+            if (promise && promise.catch) promise.catch(function() { clearInterval(window.__dualSubClipTimer); });
+          } else if (video.currentTime >= ${endMs / 1000.0} || video.currentTime < ${startMs / 1000.0} - 1) {
+            video.pause(); clearInterval(window.__dualSubClipTimer);
+          }
+        }, 50);
+        return true;
+      })();
+    """.trimIndent()
 }
 
 @Composable
@@ -999,6 +1070,7 @@ internal fun SingleYouTubePage(
 
     fun reportNavigation(view: WebView, url: String?) {
         val currentUrl = url?.takeIf(String::isNotBlank) ?: return
+        controller.observePage(currentUrl)
         canGoBack = view.canGoBack()
         if (classifyMainFrameUrl(currentUrl) != EmbeddedNavigationDecision.YOUTUBE_WEB) return
         lastKnownUrl = currentUrl
@@ -1221,6 +1293,7 @@ internal fun SingleYouTubePage(
             }
             webView.evaluateJavascript(WEB_PLAYBACK_SNAPSHOT_SCRIPT) { rawValue ->
                 val snapshot = parseWebPlaybackSnapshot(rawValue) ?: return@evaluateJavascript
+                controller.observePage(snapshot.url)
                 youtubePlayerControlsVisible.value = snapshot.controlsVisible
                 reportNavigation(webView, snapshot.url)
                 val selection = browseVideoSelection(snapshot.url) ?: return@evaluateJavascript
@@ -1254,6 +1327,7 @@ internal fun SingleYouTubePage(
     }
 
     DisposableEffect(controller, webView) {
+        controller.bindScripts { script -> webView.evaluateJavascript(script, null) }
         val token = controller.bind { second ->
             if (webView.url.orEmpty().let(::isYouTubeWebUrl)) {
                 webView.evaluateJavascript(webReplayScript(second), null)
@@ -1265,7 +1339,7 @@ internal fun SingleYouTubePage(
     DisposableEffect(lifecycleOwner, webView) {
         val observer = LifecycleEventObserver { _, _ ->
             lifecycleStarted = lifecycleOwner.lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)
-            if (lifecycleStarted) webView.onResume() else webView.onPause()
+            if (lifecycleStarted) webView.onResume() else { controller.pause(); webView.onPause() }
         }
         lifecycleOwner.lifecycle.addObserver(observer)
         if (lifecycleStarted) webView.onResume() else webView.onPause()

--- a/app/src/main/java/com/kienhoang/dualsubreplay/ui/YouTubeBrowserScreen.kt
+++ b/app/src/main/java/com/kienhoang/dualsubreplay/ui/YouTubeBrowserScreen.kt
@@ -950,6 +950,9 @@ internal class YouTubeWebController {
         pause()
         pendingClip = word
     }
+    fun pageChanged(url: String) {
+        if (playingClipVideo != null && playingClipVideo != browseVideoSelection(url)?.videoId) pause()
+    }
     fun observePage(url: String) {
         val videoId = browseVideoSelection(url)?.videoId
         if (playingClipVideo != null && playingClipVideo != videoId) pause()
@@ -1070,7 +1073,7 @@ internal fun SingleYouTubePage(
 
     fun reportNavigation(view: WebView, url: String?) {
         val currentUrl = url?.takeIf(String::isNotBlank) ?: return
-        controller.observePage(currentUrl)
+        controller.pageChanged(currentUrl)
         canGoBack = view.canGoBack()
         if (classifyMainFrameUrl(currentUrl) != EmbeddedNavigationDecision.YOUTUBE_WEB) return
         lastKnownUrl = currentUrl

--- a/app/src/main/java/com/kienhoang/dualsubreplay/ui/YouTubeBrowserScreen.kt
+++ b/app/src/main/java/com/kienhoang/dualsubreplay/ui/YouTubeBrowserScreen.kt
@@ -188,9 +188,11 @@ internal data class WebPlaybackSnapshot(
     val currentSecond: Float?,
     val controlsVisible: Boolean = false,
     val liveCaption: LiveCaptionSample? = null,
+    val nativeDialogVisible: Boolean = false,
 )
 
 internal val youtubePlayerControlsVisible = MutableStateFlow(false)
+internal val youtubeNativeDialogVisible = MutableStateFlow(false)
 internal val youtubeFullscreenActive = MutableStateFlow(false)
 
 private data class WebFullscreenSession(
@@ -234,10 +236,17 @@ internal val WEB_PLAYBACK_SNAPSHOT_SCRIPT: String =
         isVisible(chromeBottom) ||
         isVisible(progressBar)
       );
+      // YouTube's mobile dialog wrapper can have zero bounds; its fixed scrim/layout is visible.
+      const nativeDialogVisible = Array.from(document.querySelectorAll('[role="dialog"][aria-modal="true"]'))
+        .some(function(dialog) {
+          return isVisible(dialog) || Array.from(dialog.querySelectorAll('ytw-scrim, .ytSpecBottomSheetLayoutHost'))
+            .some(isVisible);
+        });
       return JSON.stringify({
         url: window.location.href,
         currentSecond: second,
         controlsVisible: controlsVisible,
+        nativeDialogVisible: nativeDialogVisible,
         liveCaption: liveState ? {
           text: liveState.text || '',
           revision: liveState.revision,
@@ -490,421 +499,6 @@ internal fun webCaptionVisibilityScript(hidden: Boolean): String {
     """.trimIndent()
 }
 
-/**
- * In-player playback settings overlay and touch interceptor.
- * Resolves issue #39 where YouTube's mobile web sticky topbar blocks touch input and
- * YouTube's fullscreen script drops the settings bottom sheet.
- * Fully compliant with YouTube Trusted Types (pure DOM element construction).
- */
-internal val WEB_PLAYBACK_SETTINGS_SCRIPT: String =
-    """
-    (function() {
-      const host = window.location.hostname.toLowerCase().replace(/\.$/, '');
-      if (window.location.protocol !== 'https:' ||
-          !(host === 'youtube.com' || host.endsWith('.youtube.com'))) return false;
-
-      const STYLE_ID = 'dualsub-settings-overlay-style';
-      const OVERLAY_ID = 'dualsub-settings-overlay';
-
-      let style = document.getElementById(STYLE_ID);
-      if (!style) {
-        style = document.createElement('style');
-        style.id = STYLE_ID;
-        style.textContent = `
-          #dualsub-settings-overlay {
-            position: fixed;
-            top: 0;
-            left: 0;
-            width: 100vw;
-            height: 100vh;
-            z-index: 2147483647;
-            display: flex;
-            justify-content: flex-end;
-            align-items: flex-start;
-            box-sizing: border-box;
-          }
-          #dualsub-settings-scrim {
-            position: absolute;
-            top: 0;
-            left: 0;
-            width: 100%;
-            height: 100%;
-            background: rgba(0, 0, 0, 0.45);
-          }
-          #dualsub-settings-panel {
-            position: relative;
-            background: rgba(28, 28, 28, 0.96);
-            backdrop-filter: blur(20px);
-            -webkit-backdrop-filter: blur(20px);
-            color: #f1f1f1;
-            border-radius: 12px;
-            margin: 48px 24px 16px 16px;
-            min-width: 260px;
-            max-width: 320px;
-            max-height: calc(100vh - 64px);
-            overflow-y: auto;
-            box-shadow: 0 8px 32px rgba(0, 0, 0, 0.7);
-            font-family: Roboto, -apple-system, sans-serif;
-            font-size: 14px;
-            border: 1px solid rgba(255, 255, 255, 0.12);
-            animation: dualsub-pop 0.15s ease-out;
-            z-index: 1;
-          }
-          @keyframes dualsub-pop {
-            from { opacity: 0; transform: scale(0.96) translateY(-6px); }
-            to { opacity: 1; transform: scale(1) translateY(0); }
-          }
-          .dualsub-settings-header {
-            display: flex;
-            align-items: center;
-            padding: 12px 16px;
-            font-weight: 600;
-            font-size: 15px;
-            border-bottom: 1px solid rgba(255, 255, 255, 0.1);
-          }
-          .dualsub-settings-back {
-            background: none;
-            border: none;
-            color: #fff;
-            font-size: 22px;
-            line-height: 1;
-            margin-right: 12px;
-            cursor: pointer;
-            padding: 0 4px;
-            display: flex;
-            align-items: center;
-          }
-          .dualsub-settings-list {
-            list-style: none;
-            margin: 0;
-            padding: 6px 0;
-          }
-          .dualsub-settings-item {
-            display: flex;
-            align-items: center;
-            justify-content: space-between;
-            padding: 12px 16px;
-            cursor: pointer;
-            user-select: none;
-            -webkit-user-select: none;
-            transition: background 0.1s;
-          }
-          .dualsub-settings-item:active {
-            background: rgba(255, 255, 255, 0.15);
-          }
-          .dualsub-settings-item-label {
-            display: flex;
-            align-items: center;
-            gap: 12px;
-          }
-          .dualsub-settings-item-value {
-            color: #aaa;
-            font-size: 13px;
-            display: flex;
-            align-items: center;
-            gap: 4px;
-          }
-          .dualsub-check {
-            color: #3ea6ff;
-            font-weight: bold;
-            width: 16px;
-            display: inline-block;
-          }
-        `;
-        (document.head || document.documentElement).appendChild(style);
-      }
-
-      if (window.__dualsubSettingsInstalled) return true;
-      window.__dualsubSettingsInstalled = true;
-
-      let activeSubmenu = null;
-      let lastOpenTime = 0;
-
-      function getPlayer() {
-        return document.getElementById('movie_player') || document.querySelector('.html5-video-player');
-      }
-
-      function closeOverlay() {
-        const el = document.getElementById(OVERLAY_ID);
-        if (el) el.remove();
-        activeSubmenu = null;
-      }
-
-      function renderOverlay() {
-        const mp = getPlayer();
-        if (!mp) return;
-        lastOpenTime = Date.now();
-
-        let container = document.getElementById(OVERLAY_ID);
-        if (!container) {
-          container = document.createElement('div');
-          container.id = OVERLAY_ID;
-          const parent = document.getElementById('player-container-id') ||
-                         document.getElementById('player') ||
-                         document.body;
-          parent.appendChild(container);
-        }
-        while (container.firstChild) container.removeChild(container.firstChild);
-
-        const scrim = document.createElement('div');
-        scrim.id = 'dualsub-settings-scrim';
-        scrim.onclick = function(e) {
-          e.stopPropagation();
-          if (Date.now() - lastOpenTime < 350) return;
-          closeOverlay();
-        };
-        container.appendChild(scrim);
-
-        const panel = document.createElement('div');
-        panel.id = 'dualsub-settings-panel';
-
-        if (activeSubmenu === 'quality') {
-          renderQualitySubmenu(panel, mp);
-        } else if (activeSubmenu === 'speed') {
-          renderSpeedSubmenu(panel, mp);
-        } else {
-          renderMainMenu(panel, mp);
-        }
-
-        container.appendChild(panel);
-      }
-
-      function createHeader(title, onBack) {
-        const header = document.createElement('div');
-        header.className = 'dualsub-settings-header';
-        if (onBack) {
-          const back = document.createElement('button');
-          back.className = 'dualsub-settings-back';
-          back.textContent = '‹';
-          back.onclick = function(e) {
-            e.stopPropagation();
-            onBack();
-          };
-          header.appendChild(back);
-        }
-        const titleSpan = document.createElement('span');
-        titleSpan.textContent = title;
-        header.appendChild(titleSpan);
-        return header;
-      }
-
-      function createSvgIcon(pathD) {
-        const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
-        svg.setAttribute('width', '20');
-        svg.setAttribute('height', '20');
-        svg.setAttribute('viewBox', '0 0 24 24');
-        svg.setAttribute('fill', 'currentColor');
-        const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
-        path.setAttribute('d', pathD);
-        svg.appendChild(path);
-        return svg;
-      }
-
-      function renderMainMenu(panel, mp) {
-        panel.appendChild(createHeader('Playback settings'));
-        const list = document.createElement('ul');
-        list.className = 'dualsub-settings-list';
-
-        const currentQuality = (mp.getPlaybackQualityLabel && mp.getPlaybackQualityLabel()) ||
-                              (mp.getPlaybackQuality && mp.getPlaybackQuality()) || 'Auto';
-        const qualityItem = createMenuItem(
-          createSvgIcon('M15 17h6v-2h-6v2zm-4 0h2V7h-2v10zm-8 0h6v-4H3v4zM3 7v4h6V7H3zm12 6h6V7h-6v6z'),
-          'Quality',
-          currentQuality + ' ›',
-          function() {
-            activeSubmenu = 'quality';
-            renderOverlay();
-          }
-        );
-        list.appendChild(qualityItem);
-
-        const currentRate = (mp.getPlaybackRate && mp.getPlaybackRate()) || 1;
-        const rateText = currentRate === 1 ? 'Normal' : currentRate + 'x';
-        const speedItem = createMenuItem(
-          createSvgIcon('M10 8v8l6-4-6-4zm9-5H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16H5V5h14v14z'),
-          'Playback speed',
-          rateText + ' ›',
-          function() {
-            activeSubmenu = 'speed';
-            renderOverlay();
-          }
-        );
-        list.appendChild(speedItem);
-
-        const isSubsOn = (mp.isSubtitlesOn && mp.isSubtitlesOn()) || false;
-        const captionsItem = createMenuItem(
-          createSvgIcon('M19 4H5c-1.11 0-2 .9-2 2v12c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm-8 7H9.5v-.5h-2v3h2V13H11v1c0 .55-.45 1-1 1H7c-.55 0-1-.45-1-1v-4c0-.55.45-1 1-1h3c.55 0 1 .45 1 1v1zm7 0h-1.5v-.5h-2v3h2V13H18v1c0 .55-.45 1-1 1h-3c-.55 0-1-.45-1-1v-4c0-.55.45-1 1-1h3c.55 0 1 .45 1 1v1z'),
-          'Captions',
-          isSubsOn ? 'On' : 'Off',
-          function() {
-            if (mp.toggleSubtitles) mp.toggleSubtitles();
-            closeOverlay();
-          }
-        );
-        list.appendChild(captionsItem);
-
-        panel.appendChild(list);
-      }
-
-      function createMenuItem(icon, labelText, valueText, onClick) {
-        const li = document.createElement('li');
-        li.className = 'dualsub-settings-item';
-        li.onclick = function(e) {
-          e.stopPropagation();
-          onClick();
-        };
-
-        const labelDiv = document.createElement('span');
-        labelDiv.className = 'dualsub-settings-item-label';
-        if (icon) labelDiv.appendChild(icon);
-        const labelSpan = document.createElement('span');
-        labelSpan.textContent = labelText;
-        labelDiv.appendChild(labelSpan);
-        li.appendChild(labelDiv);
-
-        if (valueText) {
-          const valSpan = document.createElement('span');
-          valSpan.className = 'dualsub-settings-item-value';
-          valSpan.textContent = valueText;
-          li.appendChild(valSpan);
-        }
-
-        return li;
-      }
-
-      function renderQualitySubmenu(panel, mp) {
-        panel.appendChild(createHeader('Quality', function() {
-          activeSubmenu = null;
-          renderOverlay();
-        }));
-
-        const list = document.createElement('ul');
-        list.className = 'dualsub-settings-list';
-
-        const rawLevels = (mp.getAvailableQualityLevels && mp.getAvailableQualityLevels()) || [];
-        const rawData = (mp.getAvailableQualityData && mp.getAvailableQualityData()) || [];
-        const preferred = (mp.getPreferredQuality && mp.getPreferredQuality()) || '';
-        const currentQuality = (mp.getPlaybackQuality && mp.getPlaybackQuality()) || '';
-
-        const options = [];
-        if (rawData.length > 0) {
-          for (let i = 0; i < rawData.length; i++) {
-            const q = rawData[i];
-            const level = q.quality || q.qualityLevel;
-            const label = q.qualityLabel || level;
-            options.push({ level: level, label: label });
-          }
-          options.push({ level: 'auto', label: 'Auto' });
-        } else if (rawLevels.length > 0) {
-          for (let i = 0; i < rawLevels.length; i++) {
-            const q = rawLevels[i];
-            const num = q.replace(/[^0-9]/g, '');
-            const label = q === 'auto' ? 'Auto' : (num ? num + 'p' : q);
-            options.push({ level: q, label: label });
-          }
-        } else {
-          options.push({ level: 'auto', label: 'Auto' });
-        }
-
-        for (let i = 0; i < options.length; i++) {
-          const opt = options[i];
-          const isSelected = opt.level === preferred || opt.level === currentQuality ||
-                             ((preferred === '' || preferred === 'auto') && opt.level === 'auto');
-          const li = document.createElement('li');
-          li.className = 'dualsub-settings-item';
-          li.onclick = function(e) {
-            e.stopPropagation();
-            if (mp.setPlaybackQualityRange) mp.setPlaybackQualityRange(opt.level, opt.level);
-            else if (mp.setPlaybackQuality) mp.setPlaybackQuality(opt.level);
-            closeOverlay();
-          };
-
-          const labelDiv = document.createElement('span');
-          labelDiv.className = 'dualsub-settings-item-label';
-
-          const check = document.createElement('span');
-          check.className = 'dualsub-check';
-          check.textContent = isSelected ? '✓' : '';
-          labelDiv.appendChild(check);
-
-          const labelSpan = document.createElement('span');
-          labelSpan.textContent = opt.label;
-          labelDiv.appendChild(labelSpan);
-
-          li.appendChild(labelDiv);
-          list.appendChild(li);
-        }
-
-        panel.appendChild(list);
-      }
-
-      function renderSpeedSubmenu(panel, mp) {
-        panel.appendChild(createHeader('Playback speed', function() {
-          activeSubmenu = null;
-          renderOverlay();
-        }));
-
-        const list = document.createElement('ul');
-        list.className = 'dualsub-settings-list';
-
-        const rates = [0.25, 0.5, 0.75, 1, 1.25, 1.5, 1.75, 2];
-        const currentRate = (mp.getPlaybackRate && mp.getPlaybackRate()) || 1;
-
-        for (let i = 0; i < rates.length; i++) {
-          const r = rates[i];
-          const isSelected = Math.abs(currentRate - r) < 0.01;
-          const label = r === 1 ? 'Normal' : r + 'x';
-          const li = document.createElement('li');
-          li.className = 'dualsub-settings-item';
-          li.onclick = function(e) {
-            e.stopPropagation();
-            if (mp.setPlaybackRate) mp.setPlaybackRate(r);
-            closeOverlay();
-          };
-
-          const labelDiv = document.createElement('span');
-          labelDiv.className = 'dualsub-settings-item-label';
-
-          const check = document.createElement('span');
-          check.className = 'dualsub-check';
-          check.textContent = isSelected ? '✓' : '';
-          labelDiv.appendChild(check);
-
-          const labelSpan = document.createElement('span');
-          labelSpan.textContent = label;
-          labelDiv.appendChild(labelSpan);
-
-          li.appendChild(labelDiv);
-          list.appendChild(li);
-        }
-
-        panel.appendChild(list);
-      }
-
-      function handleSettingsCapture(e) {
-        const target = e.target;
-        if (!target) return;
-        const btn = (target.closest && target.closest('.player-settings-icon, [aria-label="Playback Settings"], ytm-mobile-topbar-renderer [aria-label="More options"]')) ||
-                    (target.classList && target.classList.contains('player-settings-icon') ? target : null);
-        if (btn) {
-          const mp = document.getElementById('movie_player');
-          if (mp) {
-            e.stopPropagation();
-            e.preventDefault();
-            renderOverlay();
-          }
-        }
-      }
-
-      window.addEventListener('click', handleSettingsCapture, true);
-      window.addEventListener('touchend', handleSettingsCapture, true);
-      document.addEventListener('click', handleSettingsCapture, true);
-      document.addEventListener('touchend', handleSettingsCapture, true);
-
-      return true;
-    })();
-    """.trimIndent()
-
 internal fun parseWebPlaybackSnapshot(rawValue: String?): WebPlaybackSnapshot? {
     if (rawValue.isNullOrBlank() || rawValue == "null") return null
     return runCatching {
@@ -941,6 +535,7 @@ internal fun parseWebPlaybackSnapshot(rawValue: String?): WebPlaybackSnapshot? {
                 json.getDouble("currentSecond").toFloat()
             },
             controlsVisible = json.optBoolean("controlsVisible", false),
+            nativeDialogVisible = json.optBoolean("nativeDialogVisible", false),
             liveCaption = liveCaption,
         )
     }.getOrNull()
@@ -1203,6 +798,7 @@ internal fun SingleYouTubePage(
 
                 override fun onPageStarted(view: WebView, url: String?, favicon: Bitmap?) {
                     super.onPageStarted(view, url, favicon)
+                    youtubeNativeDialogVisible.value = false
                     pageError = null
                     if (url != null && handleMainFrameUrl(view, url)) return
                     reportNavigation(view, url)
@@ -1224,7 +820,6 @@ internal fun SingleYouTubePage(
                             webCaptionVisibilityScript(currentSuppressPageCaptions),
                             null,
                         )
-                        view.evaluateJavascript(WEB_PLAYBACK_SETTINGS_SCRIPT, null)
                     }
                 }
 
@@ -1304,6 +899,7 @@ internal fun SingleYouTubePage(
         while (isActive) {
             if (!webView.url.orEmpty().let(::isYouTubeWebUrl)) {
                 youtubePlayerControlsVisible.value = false
+                youtubeNativeDialogVisible.value = false
                 delay(PLAYBACK_POLL_INTERVAL_MS)
                 continue
             }
@@ -1311,12 +907,12 @@ internal fun SingleYouTubePage(
                 val snapshot = parseWebPlaybackSnapshot(rawValue) ?: return@evaluateJavascript
                 controller.observePage(snapshot.url)
                 youtubePlayerControlsVisible.value = snapshot.controlsVisible
+                youtubeNativeDialogVisible.value = snapshot.nativeDialogVisible
                 reportNavigation(webView, snapshot.url)
                 val selection = browseVideoSelection(snapshot.url) ?: return@evaluateJavascript
                 val second = snapshot.currentSecond ?: return@evaluateJavascript
                 currentOnPlaybackSecond(selection.videoId, second, snapshot.liveCaption)
             }
-            webView.evaluateJavascript(WEB_PLAYBACK_SETTINGS_SCRIPT, null)
             delay(PLAYBACK_POLL_INTERVAL_MS)
         }
     }
@@ -1368,6 +964,7 @@ internal fun SingleYouTubePage(
     DisposableEffect(webView) {
         onDispose {
             youtubePlayerControlsVisible.value = false
+            youtubeNativeDialogVisible.value = false
             youtubeFullscreenActive.value = false
             webView.webChromeClient?.onHideCustomView()
             if (webView.url.orEmpty().let(::isYouTubeWebUrl)) {

--- a/app/src/main/java/com/kienhoang/dualsubreplay/ui/YouTubeBrowserScreen.kt
+++ b/app/src/main/java/com/kienhoang/dualsubreplay/ui/YouTubeBrowserScreen.kt
@@ -242,6 +242,8 @@ internal val WEB_PLAYBACK_SNAPSHOT_SCRIPT: String =
           text: liveState.text || '',
           revision: liveState.revision,
           mediaSecond: liveState.captionMediaSecond,
+          videoId: liveState.videoId || null,
+          languageCode: liveState.languageCode || null,
           present: !!liveState.text
         } : null
       });
@@ -388,7 +390,15 @@ internal fun webLiveCaptionConfigurationScript(enabled: Boolean): String {
           state.recordCaption = function() {
             if (!state.enabled || !state.trustedOrigin()) return;
             const text = state.visibleCaptionText();
-            if (text === state.text) return;
+            const player = state.player();
+            let response = null;
+            try { response = player && player.getPlayerResponse ? player.getPlayerResponse() : null; } catch (_) {}
+            const videoId = response && response.videoDetails ? response.videoDetails.videoId : null;
+            const track = state.activeCaptionTrack(player);
+            const languageCode = track && (track.translationLanguage ? track.translationLanguage.languageCode : track.languageCode);
+            if (text === state.text && videoId === state.videoId && languageCode === state.languageCode) return;
+            state.videoId = videoId;
+            state.languageCode = languageCode;
             const video = state.activeVideo();
             const mediaSecond = Number.isFinite(state.latestMediaSecond)
               ? state.latestMediaSecond
@@ -900,6 +910,7 @@ internal fun parseWebPlaybackSnapshot(rawValue: String?): WebPlaybackSnapshot? {
     return runCatching {
         val decoded = JSONTokener(rawValue).nextValue() as? String ?: return@runCatching null
         val json = JSONObject(decoded)
+        if (!isYouTubeWebUrl(json.optString("url"))) return@runCatching null
         val liveCaption = json.optJSONObject("liveCaption")?.let { live ->
             val text = live.optString("text").replace(Regex("\\s+"), " ").trim()
             val revision = live.optLong("revision", -1L)
@@ -915,6 +926,8 @@ internal fun parseWebPlaybackSnapshot(rawValue: String?): WebPlaybackSnapshot? {
                     revision = revision,
                     mediaTimeMs = (mediaSecond * 1_000.0).toLong(),
                     present = live.optBoolean("present", text.isNotBlank()) && text.isNotBlank(),
+                    videoId = live.optString("videoId").takeIf { it.matches(Regex("[A-Za-z0-9_-]{11}")) },
+                    languageCode = live.optString("languageCode").takeIf { it.length in 2..35 && it != "null" },
                 )
             } else {
                 null

--- a/app/src/test/java/com/kienhoang/dualsubreplay/data/SavedWordTest.kt
+++ b/app/src/test/java/com/kienhoang/dualsubreplay/data/SavedWordTest.kt
@@ -1,0 +1,50 @@
+package com.kienhoang.dualsubreplay.data
+
+import org.junit.Assert.*
+import org.junit.Test
+
+class SavedWordTest {
+    private val selection = LearningWordSelection(AnalyzedToken("Learn", 0, 5, PartOfSpeech.VERB), "en", "vi",
+        "dQw4w9WgXcQ", SubtitleSegment(1, 1250, 4250, "Learn a word", "Học một từ"), false)
+    private val card = savedWordFrom(selection, "học", true, false)
+
+    @Test fun identityIncludesLanguageAndExampleButNotMeaningOrClipChoices() {
+        assertEquals(card.id, savedWordFrom(selection.copy(token = selection.token.copy(text = "learn")), "new meaning", false, true).id)
+        assertNotEquals(card.id, savedWordFrom(selection.copy(wordLanguage = "de"), "học", true, false).id)
+        assertNotEquals(card.id, savedWordFrom(selection.copy(segment = selection.segment!!.copy(startMs = 1500)), "học", true, false).id)
+        assertTrue(card.id.matches(Regex("[a-f0-9]{64}")))
+    }
+    @Test fun allFourClipChoicesAreIndependentAndInvalidContextCannotCreateClip() {
+        for (online in listOf(true, false)) for (offline in listOf(true, false)) {
+            val saved = savedWordFrom(selection, "học", online, offline)
+            assertEquals(online, saved.online); assertEquals(offline, saved.offline)
+        }
+        val invalid = savedWordFrom(selection.copy(videoId = "../invalid"), "học", true, true)
+        assertFalse(invalid.online); assertFalse(invalid.offline)
+        assertFalse(validClipRange(selection.videoId, 100, 100))
+        assertFalse(validClipRange(selection.videoId, -1, 100))
+    }
+    @Test fun reviewRatingsScheduleFromInjectedTimeAndAgainRestartsProgression() {
+        val now = 1_000_000L
+        assertEquals(now + 600_000, reviewWord(card, ReviewRating.AGAIN, now).dueAt)
+        assertEquals(now + DAY_MS, reviewWord(card, ReviewRating.HARD, now).dueAt)
+        assertEquals(now + 3 * DAY_MS, reviewWord(card, ReviewRating.GOOD, now).dueAt)
+        assertEquals(now + 7 * DAY_MS, reviewWord(card, ReviewRating.EASY, now).dueAt)
+        val reviewed = reviewWord(card, ReviewRating.GOOD, now)
+        assertEquals(6 * DAY_MS, reviewWord(reviewed, ReviewRating.GOOD, now).intervalMs)
+        val lapsed = reviewWord(reviewed, ReviewRating.AGAIN, now)
+        assertEquals(3 * DAY_MS, reviewWord(lapsed, ReviewRating.GOOD, now).intervalMs)
+    }
+    @Test fun savedDataRoundTripsWithReviewAndDownloadState() {
+        val saved = card.copy(clipStatus = "ready", clipGeneration = 4, offline = true, intervalMs = 99, dueAt = 123)
+        assertEquals(saved, decodeWord(encodeWord(saved)))
+        assertEquals(card.copy(videoId = null, reading = null, translatedSentence = null),
+            decodeWord(encodeWord(card.copy(videoId = null, reading = null, translatedSentence = null))))
+    }
+    @Test fun downloadUsesExactSecondsAndNeverExpandsIntoPlaylist() {
+        val arguments = clipDownloadArguments(ClipRequest(selection.videoId!!, 1250, 4250, "request"), java.io.File("clip.%(ext)s"))
+        assertEquals("*1.250-4.250", arguments.toMap()["--download-sections"])
+        assertTrue(arguments.any { it.first == "--no-playlist" })
+        assertTrue(arguments.any { it.first == "--force-keyframes-at-cuts" })
+    }
+}

--- a/app/src/test/java/com/kienhoang/dualsubreplay/data/SavedWordTest.kt
+++ b/app/src/test/java/com/kienhoang/dualsubreplay/data/SavedWordTest.kt
@@ -8,6 +8,17 @@ class SavedWordTest {
         "dQw4w9WgXcQ", SubtitleSegment(1, 1250, 4250, "Learn a word", "Học một từ"), false)
     private val card = savedWordFrom(selection, "học", true, false)
 
+    @Test fun selectionUsesTappedLineLanguageAndKeepsItsSentenceSnapshot() {
+        val original = learningSelection(WordTap(selection.token, selection.segment, false), "en", "vi", selection.videoId)
+        val translated = learningSelection(WordTap(selection.token.copy(text = "học"), selection.segment, true), "en", "vi", selection.videoId)
+        assertEquals("en", original.wordLanguage)
+        assertEquals("vi", original.meaningLanguage)
+        assertEquals("vi", translated.wordLanguage)
+        assertEquals("en", translated.meaningLanguage)
+        assertEquals(selection.segment, translated.segment)
+        assertEquals(selection.videoId, translated.videoId)
+    }
+
     @Test fun identityIncludesLanguageAndExampleButNotMeaningOrClipChoices() {
         assertEquals(card.id, savedWordFrom(selection.copy(token = selection.token.copy(text = "learn")), "new meaning", false, true).id)
         assertNotEquals(card.id, savedWordFrom(selection.copy(wordLanguage = "de"), "học", true, false).id)

--- a/app/src/test/java/com/kienhoang/dualsubreplay/data/YouTubeCaptionFallbackTest.kt
+++ b/app/src/test/java/com/kienhoang/dualsubreplay/data/YouTubeCaptionFallbackTest.kt
@@ -8,7 +8,7 @@ import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
-/** Regression coverage for the August 2026 device-only caption fallback failure. */
+/** Regression coverage for the August/September 2026 device-only caption fallback failures. */
 class YouTubeCaptionFallbackTest {
     @Test
     fun extractsEmbeddedPlayerResponseWithoutBeingConfusedByBracesInsideStrings() {
@@ -62,6 +62,35 @@ class YouTubeCaptionFallbackTest {
                 "https://www.youtube.com/youtubei/v1/player?key=test-key",
             ),
             playerApiUrls("test-key"),
+        )
+    }
+
+    @Test
+    fun currentFallbackOrderStartsWithClientsThatStillExposeLoggedOutPlayerData() {
+        val clients = youtubePlayerClients("2.20260708.00.00")
+
+        assertEquals("VISIONOS", clients.first().clientName)
+        assertTrue(clients.any { it.clientName == "ANDROID_VR" && it.clientNumber == "28" })
+        assertTrue(
+            clients.any {
+                it.clientName == "WEB_EMBEDDED_PLAYER" &&
+                    it.clientNumber == "56" &&
+                    it.embedUrl == "https://www.reddit.com/"
+            },
+        )
+    }
+
+    @Test
+    fun embeddedClientAddsThirdPartyEmbedContext() {
+        val embedded = youtubePlayerClients("2.20260708.00.00")
+            .first { it.clientName == "WEB_EMBEDDED_PLAYER" }
+
+        val body = playerRequestBody("abc123", embedded)
+
+        assertEquals("abc123", body.getString("videoId"))
+        assertEquals(
+            "https://www.reddit.com/",
+            body.getJSONObject("context").getJSONObject("thirdParty").getString("embedUrl"),
         )
     }
 }

--- a/app/src/test/java/com/kienhoang/dualsubreplay/data/YouTubeCaptionProviderTest.kt
+++ b/app/src/test/java/com/kienhoang/dualsubreplay/data/YouTubeCaptionProviderTest.kt
@@ -41,15 +41,13 @@ class YouTubeCaptionProviderTest {
     }
 
     @Test
-    fun triesUpdatedAndroidThenIosThenTvThenWebClients() {
+    fun retainsLegacyClientContextsAlongsideNewFallbacks() {
         val clients = youtubePlayerClients("2.20260826.01.00")
-
-        assertEquals(listOf("ANDROID", "IOS", "TVHTML5", "WEB"), clients.map { it.clientName })
-        assertEquals(listOf("3", "5", "7", "1"), clients.map { it.clientNumber })
-        assertEquals("21.26.364", clients[0].clientVersion)
-        assertEquals("21.26.4", clients[1].clientVersion)
-        assertEquals("7.20260707.07.00", clients[2].clientVersion)
-        assertEquals("2.20260826.01.00", clients[3].clientVersion)
+        val android = clients.first { it.clientName == "ANDROID" }
+        assertEquals("3", android.clientNumber)
+        assertEquals("21.26.364", android.clientVersion)
+        assertEquals("21.26.4", clients.first { it.clientName == "IOS" }.clientVersion)
+        assertEquals("2.20260826.01.00", clients.last { it.clientName == "WEB" }.clientVersion)
     }
 
     @Test

--- a/app/src/test/java/com/kienhoang/dualsubreplay/ui/LiveSubtitleRecoveryTest.kt
+++ b/app/src/test/java/com/kienhoang/dualsubreplay/ui/LiveSubtitleRecoveryTest.kt
@@ -1,0 +1,85 @@
+package com.kienhoang.dualsubreplay.ui
+
+import com.kienhoang.dualsubreplay.data.captionFailureCategory
+import kotlinx.coroutines.*
+import org.junit.Assert.*
+import org.junit.Test
+
+class LiveSubtitleRecoveryTest {
+    private val sample = LiveCaptionSample("Hello world", 1, 1000, true, "abcdefghijk", "en-US")
+    private val key = liveTranslationKey(sample, "abcdefghijk", "vi")!!
+
+    @Test fun metadataMustMatchVideoAndHaveLanguage() {
+        assertEquals("en", key.language)
+        assertNull(liveTranslationKey(sample, "anotherVid1", "vi"))
+        assertNull(liveTranslationKey(sample.copy(languageCode = null), "abcdefghijk", "vi"))
+        assertNull(liveTranslationKey(sample.copy(present = false), "abcdefghijk", "vi"))
+    }
+
+    @Test fun rollingTextReplacesRatherThanAppendsAndDuplicateRevisionsDoNotRetranslate() {
+        val gate = LiveTranslationGate()
+        assertTrue(gate.update(key))
+        val ticket = gate.generation
+        assertFalse(gate.update(liveTranslationKey(sample.copy(revision = 2), "abcdefghijk", "vi")))
+        assertTrue(gate.accepts(ticket, key))
+        assertTrue(gate.update(key.copy(text = "world today")))
+        assertEquals("world today", gate.key?.text)
+        assertFalse(gate.accepts(ticket, key))
+    }
+
+    @Test fun seekVideoLanguageAndTranscriptRecoveryInvalidatePendingResults() {
+        for (next in listOf(key.copy(videoId = "anotherVid1"), key.copy(language = "ja"), key.copy(target = "de"), null)) {
+            val gate = LiveTranslationGate()
+            gate.update(key)
+            val ticket = gate.generation
+            gate.update(next)
+            assertFalse(gate.accepts(ticket, key))
+        }
+        val gate = LiveTranslationGate()
+        gate.update(key)
+        val ticket = gate.generation
+        gate.update(key, seek = true)
+        assertFalse(gate.accepts(ticket, key))
+        val seekTicket = gate.generation
+        gate.reset()
+        assertFalse(gate.accepts(seekTicket, key))
+    }
+
+    @Test fun debounceSkipsReplacedTextAndDiscardsLateTranslation() = runBlocking {
+        var current = true
+        var calls = 0
+        val pending = async {
+            debouncedLiveTranslation(key, { current }) { _, _, _ -> calls++; "Xin chào" }
+        }
+        delay(50)
+        assertEquals(0, calls)
+        current = false
+        assertNull(pending.await())
+        assertEquals(0, calls)
+        current = true
+        assertNull(debouncedLiveTranslation(key, { current }) { _, _, _ -> current = false; "stale" })
+        current = true
+        assertEquals("Xin chào", debouncedLiveTranslation(key, { current }) { source, target, text ->
+            assertEquals("en", source); assertEquals("vi", target); assertEquals("Hello world", text)
+            "Xin chào"
+        })
+    }
+
+    @Test fun overlayUsesLiveTextWithoutInventedReplaySegment() {
+        val content = learningOverlayContent(DualSubUiState(activeVideoId = "abcdefghijk", liveFallback = true,
+            liveOriginal = "Hello", liveTranslated = "Xin chào", wordHighlightEnabled = false,
+            karaokeTimingMode = KaraokeTimingMode.TRANSCRIPT))!!
+        assertEquals("Hello", content.originalText)
+        assertEquals("Xin chào", content.translatedText)
+        assertNull(content.segment)
+        assertTrue(content.statusText!!.contains("Live subtitles"))
+    }
+
+    @Test fun diagnosticsNeverExposeServerTextOrSignedUrls() {
+        assertEquals("HTTP 429", captionFailureCategory("HTTP 429 https://youtube.com/?secret=token"))
+        assertEquals("playability", captionFailureCategory("Player returned UNPLAYABLE: secret"))
+        assertEquals("empty-response", captionFailureCategory("empty response secret"))
+        assertEquals("timeout", captionFailureCategory("request timed out secret"))
+        assertEquals("discovery", captionFailureCategory("https://youtube.com/?secret=token"))
+    }
+}

--- a/app/src/test/java/com/kienhoang/dualsubreplay/ui/PlaybackArchitectureTest.kt
+++ b/app/src/test/java/com/kienhoang/dualsubreplay/ui/PlaybackArchitectureTest.kt
@@ -201,19 +201,20 @@ class PlaybackArchitectureTest {
     }
 
     @Test
-    fun playbackSettingsScriptEnforcesOriginAndAvoidsTrustedHtmlViolations() {
-        val script = WEB_PLAYBACK_SETTINGS_SCRIPT
-
-        assertTrue(script.contains("window.location.protocol !== 'https:'"))
-        assertTrue(script.contains("!(host === 'youtube.com' || host.endsWith('.youtube.com'))"))
-        assertFalse(script.contains("innerHTML"))
-        assertTrue(script.contains("movie_player"))
-        assertTrue(script.contains("setPlaybackQualityRange"))
-        assertTrue(script.contains("setPlaybackRate"))
-        assertTrue(script.contains("toggleSubtitles"))
-        assertTrue(script.contains("player-settings-icon"))
-        assertTrue(script.contains("More options"))
-        assertFalse(script.contains("ytm-mobile-topbar-renderer.sticky-player"))
+    fun captionScriptsDoNotReplaceYouTubePlaybackSettings() {
+        val scripts = listOf(
+            WEB_PLAYBACK_SNAPSHOT_SCRIPT,
+            webLiveCaptionConfigurationScript(true),
+            webLiveCaptionConfigurationScript(false),
+            webCaptionVisibilityScript(true),
+            webCaptionVisibilityScript(false),
+        )
+        scripts.forEach { script ->
+            assertFalse(script.contains("dualsub-settings-overlay"))
+            assertFalse(script.contains("handleSettingsCapture"))
+            assertFalse(script.contains("setPlaybackRate"))
+            assertFalse(script.contains("preventDefault"))
+        }
     }
 
     @Test

--- a/app/src/test/java/com/kienhoang/dualsubreplay/ui/SubtitleHighlightTest.kt
+++ b/app/src/test/java/com/kienhoang/dualsubreplay/ui/SubtitleHighlightTest.kt
@@ -185,6 +185,7 @@ class SubtitleWordHighlightTest {
             WORD_LEARNING_TARGET_PREFERENCE,
             TAP_TO_LEARN_PREFERENCE,
             WORD_LEARNING_ACTIVE_ONLY_PREFERENCE,
+            "auto_pronounce",
         )
         assertEquals(expected, RESETTABLE_SETTING_KEYS.toSet())
         assertEquals(RESETTABLE_SETTING_KEYS.size, RESETTABLE_SETTING_KEYS.distinct().size)
@@ -249,4 +250,3 @@ class SubtitleWordHighlightTest {
         assertTrue("Active sentence should have POS spans", activeAnnotated.spanStyles.isNotEmpty())
     }
 }
-

--- a/app/src/test/java/com/kienhoang/dualsubreplay/ui/WordClipPlaybackTest.kt
+++ b/app/src/test/java/com/kienhoang/dualsubreplay/ui/WordClipPlaybackTest.kt
@@ -1,0 +1,38 @@
+package com.kienhoang.dualsubreplay.ui
+
+import com.kienhoang.dualsubreplay.data.*
+import org.junit.Assert.*
+import org.junit.Test
+
+class WordClipPlaybackTest {
+    private fun card() = savedWordFrom(LearningWordSelection(AnalyzedToken("word", 0, 4, PartOfSpeech.NOUN), "en", "vi",
+        "dQw4w9WgXcQ", SubtitleSegment(1, 1000, 3000, "a word", null), false), "từ", true, false)
+    @Test fun clipWaitsForMatchingVideoAndDoesNotRepeatOnPolling() {
+        val controller = YouTubeWebController()
+        val scripts = mutableListOf<String>()
+        controller.bindScripts(scripts::add)
+        controller.replayClip(card())
+        scripts.clear()
+        controller.observePage("https://m.youtube.com/watch?v=aaaaaaaaaaa")
+        assertTrue(scripts.isEmpty())
+        controller.observePage("https://m.youtube.com/watch?v=dQw4w9WgXcQ")
+        assertEquals(1, scripts.size)
+        controller.observePage("https://m.youtube.com/watch?v=dQw4w9WgXcQ")
+        assertEquals(1, scripts.size)
+        controller.observePage("https://m.youtube.com/")
+        assertEquals(webPauseScript(), scripts.last())
+    }
+    @Test fun dismissalCancelsPendingClipAndScriptsGuardOriginAndEndBoundary() {
+        val controller = YouTubeWebController()
+        val scripts = mutableListOf<String>()
+        controller.bindScripts(scripts::add)
+        controller.replayClip(card()); controller.pause(); scripts.clear()
+        controller.observePage("https://m.youtube.com/watch?v=dQw4w9WgXcQ")
+        assertTrue(scripts.isEmpty())
+        val script = webClipReplayScript("dQw4w9WgXcQ", 1000, 3000)
+        assertTrue(script.contains("window.location.protocol === 'https:'"))
+        assertTrue(script.contains("host.endsWith('.youtube.com')"))
+        assertTrue(script.contains("video.currentTime >= 3.0"))
+        assertTrue(script.contains(".ad-showing"))
+    }
+}


### PR DESCRIPTION
## What changed

Adds saved vocabulary with spaced repetition, automatic word pronunciation, and optional online examples or downloaded offline clips. Practice and Settings now open from a left navigation drawer with a 72 × 48 dp hamburger target. GitHub updates and open-source licenses sit at the drawer footer.

When full transcript retrieval fails, the app attempts live captions from the existing YouTube WebView and translates them using the caption language. Rolling text is reconciled, translation is debounced, and stale results are discarded. Retry full transcript preserves working live subtitles until recovery succeeds. Live mode allows word saving and pronunciation when the language is known, but disables paragraph replay and examples that require reliable transcript boundaries.

Restores YouTube's original playback settings by removing the injected replacement and event interception. App subtitle panels temporarily hide while YouTube's native dialog is open and return when it closes. Existing landscape transcript preferences and the single-WebView architecture are preserved.

Closes #49
Closes #50
Closes #51

## Verification

Local checks passed for the source committed as `563f127`:

- 175 unit tests
- `lintDebug`
- `assembleDebug` and `assembleDebugAndroidTest`
- 28 API 36 managed-device tests

Offline coverage includes drawer dismissal/navigation and the extended tap target, WebView preservation, original click/touch event delivery, native dialog visibility, caption fallback transitions, rolling captions, debounce, stale results, language changes, seeks, and transcript recovery. Caption-failure coverage is simulated; the intermittent live YouTube transcript failure's cause remains unconfirmed.

Live Pixel_10 emulator checks confirmed YouTube's original settings in portrait and landscape. Its native speed control reached 0.90×, with the video reporting an actual playback rate of 0.9. The native fullscreen gear did not open a menu on this emulator; exiting fullscreen restored settings access. No custom fullscreen replacement is retained.

The latest push triggers fresh CI; the local verification above does not imply that the new remote run has completed.

## Notes for reviewers

Saved words retain their language and subtitle context. Review cards support Again/Hard/Good/Easy ratings. Optional private clip downloads expose progress, cancellation, retry, and removal; cards remain usable without clips. Online playback uses the existing YouTube WebView, while downloaded local files use Media3. No browser cookies are exported to the downloader.

The optional downloader uses pinned youtubedl-android/FFmpeg dependencies. Bundled native binaries increase the universal APK from approximately 74 MiB to 243 MiB. The combined distribution carries GPLv3 obligations; existing MIT notices are preserved, with bundled licenses, third-party notices, README, and privacy documentation updated. Download availability depends on YouTube, and pronunciation depends on the installed TTS engine.

The navigation, live-caption recovery, and native-settings follow-ups introduce no version or dependency changes. This PR has not been merged or released.
