### PR TITLE
Fix silent word pronunciation with speech engine and voice fallback

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -10,7 +10,7 @@ DualSub Replay is designed without an application account, analytics SDK, advert
 - The app stores the last Browse URL, target language, subtitle text size, and landscape split ratio in local Android preferences.
 - Saved words, meanings, subtitle context, video IDs, timestamp ranges, and review schedules are stored in a local SQLite database. They are not sent to an application server. Android's normal app backup may include this database and preferences.
 - Optional offline clip downloads send video requests to YouTube and its media hosts using the bundled yt-dlp downloader. Downloads do not copy cookies from the browsing WebView. Clip files are stored privately and excluded from Android backups. Restored cards may require their clips to be downloaded again.
-- Pronunciation sends the selected word and language to the device's configured Android text-to-speech engine. That engine may use an online voice according to its own settings and privacy policy.
+- Pronunciation sends the selected word and language to the device's preferred Android text-to-speech engine and, if needed, other installed speech engines. It prefers installed offline voices but may try a supported online voice when local speech fails or is unavailable. Online voices process the word according to the speech engine provider's settings and privacy policy.
 - If you use the experimental Google/YouTube sign-in flow, authentication occurs inside YouTube's embedded web experience and WebView cookies persist locally. Google may reject embedded-WebView sign-in.
 
 ## What the project does not do

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Online video playback uses the native player in YouTube's mobile webpage. Saved 
 
 ## Saved words and practice
 
-Tap a word in either subtitle line to hear it, inspect its meaning, and choose **Save word**. Pronunciation uses the tapped word's language and the device's installed speech engine; Android voice availability varies. Automatic pronunciation can be disabled in Settings, and the Pronounce button remains available.
+Tap a word in either subtitle line to hear it, inspect its meaning, and choose **Save word**. Pronunciation uses the tapped word's language, trying your preferred Android speech engine and then other installed engines. It prefers installed offline voices and can fall back to a supported network voice. If no voice works, use **Speech settings** to install or select one, then tap **Pronounce** again. Automatic pronunciation can be disabled in Settings, and the Pronounce button remains available.
 
 Each card stores an editable meaning and its original subtitle context. The Online example option replays the saved sentence in the existing YouTube page and stops at its end. A translated word's example contains the original spoken sentence, which may not literally contain the translated word.
 

--- a/app/src/androidTest/java/com/kienhoang/dualsubreplay/ui/WordLearningDialogTest.kt
+++ b/app/src/androidTest/java/com/kienhoang/dualsubreplay/ui/WordLearningDialogTest.kt
@@ -57,4 +57,20 @@ class WordLearningDialogTest {
         compose.waitForIdle()
         compose.runOnIdle { assertEquals(Pair("từ", false), saved) }
     }
+
+    @Test fun missingVoiceOffersSettingsAndAllowsPronunciationRetry() {
+        var settingsOpened = 0
+        var spoken = 0
+        compose.setContent { DualSubTheme {
+            WordLearningDialog(selection, false, { "từ" }, { _, _ -> }, { spoken++ },
+                "No installed speech engine has a voice for this language.", {},
+                onSpeechSettings = { settingsOpened++ })
+        } }
+        compose.onNodeWithTag("speech_settings").performScrollTo().performClick()
+        compose.onNodeWithTag("pronounce_word").performScrollTo().performClick()
+        compose.runOnIdle {
+            assertEquals(1, settingsOpened)
+            assertEquals(1, spoken)
+        }
+    }
 }

--- a/app/src/androidTest/java/com/kienhoang/dualsubreplay/ui/WordLearningDialogTest.kt
+++ b/app/src/androidTest/java/com/kienhoang/dualsubreplay/ui/WordLearningDialogTest.kt
@@ -58,14 +58,24 @@ class WordLearningDialogTest {
         compose.runOnIdle { assertEquals(Pair("từ", false), saved) }
     }
 
-    @Test fun missingVoiceOffersSettingsAndAllowsPronunciationRetry() {
+    @Test
+    fun missingVoiceOffersSettingsAndAllowsPronunciationRetry() {
         var settingsOpened = 0
         var spoken = 0
-        compose.setContent { DualSubTheme {
-            WordLearningDialog(selection, false, { "từ" }, { _, _ -> }, { spoken++ },
-                "No installed speech engine has a voice for this language.", {},
-                onSpeechSettings = { settingsOpened++ })
-        } }
+        compose.setContent {
+            DualSubTheme {
+                WordLearningDialog(
+                    selection = selection,
+                    autoPronounce = false,
+                    onTranslateWord = { "từ" },
+                    onSave = { _, _ -> },
+                    onSpeak = { spoken++ },
+                    speechMessage = "No installed speech engine has a voice for this language.",
+                    onDismiss = {},
+                    onSpeechSettings = { settingsOpened++ },
+                )
+            }
+        }
         compose.onNodeWithTag("speech_settings").performScrollTo().performClick()
         compose.onNodeWithTag("pronounce_word").performScrollTo().performClick()
         compose.runOnIdle {

--- a/app/src/main/java/com/kienhoang/dualsubreplay/ui/AndroidPronunciationEngine.kt
+++ b/app/src/main/java/com/kienhoang/dualsubreplay/ui/AndroidPronunciationEngine.kt
@@ -1,0 +1,116 @@
+package com.kienhoang.dualsubreplay.ui
+
+import android.content.Context
+import android.content.Intent
+import android.media.AudioAttributes
+import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
+import android.provider.Settings
+import android.speech.tts.TextToSpeech
+import android.speech.tts.UtteranceProgressListener
+import kotlinx.coroutines.CompletableDeferred
+import java.util.Locale
+
+internal fun installedPronunciationEngines(context: Context): List<String?> {
+    val preferred = Settings.Secure.getString(context.contentResolver, Settings.Secure.TTS_DEFAULT_SYNTH)
+    val installed =
+        context.packageManager
+            .queryIntentServices(Intent(TextToSpeech.Engine.INTENT_ACTION_TTS_SERVICE), 0)
+            .map { it.serviceInfo.packageName }
+    return (listOf(preferred) + installed).distinct()
+}
+
+internal class AndroidPronunciationEngine(
+    context: Context,
+    engineName: String?,
+) : PronunciationEngine {
+    private val handler = Handler(Looper.getMainLooper())
+    private val initialized = CompletableDeferred<Boolean>()
+    private var closed = false
+    private var nextUtterance = 0L
+    private var utteranceId: String? = null
+    private var playback: CompletableDeferred<Boolean>? = null
+    private val tts =
+        TextToSpeech(context.applicationContext, { status ->
+            // onInit may run before the constructor returns. Post before touching tts or UI state.
+            handler.post { if (!closed) initialized.complete(status == TextToSpeech.SUCCESS) }
+        }, engineName)
+
+    override suspend fun initialize(): Boolean {
+        if (!initialized.await()) return false
+        tts.setAudioAttributes(
+            AudioAttributes
+                .Builder()
+                .setUsage(AudioAttributes.USAGE_MEDIA)
+                .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
+                .build(),
+        )
+        tts.setOnUtteranceProgressListener(
+            object : UtteranceProgressListener() {
+                override fun onStart(id: String?) = Unit
+
+                override fun onDone(id: String?) = complete(id, true)
+
+                @Deprecated("Required by UtteranceProgressListener")
+                override fun onError(id: String?) = complete(id, false)
+
+                override fun onError(id: String?, errorCode: Int) = complete(id, false)
+
+                override fun onStop(id: String?, interrupted: Boolean) = complete(id, false)
+            },
+        )
+        return true
+    }
+
+    private fun complete(id: String?, success: Boolean) {
+        handler.post {
+            if (!closed && id == utteranceId) playback?.complete(success)
+        }
+    }
+
+    override fun voices(): List<PronunciationVoice> =
+        tts.voices.orEmpty().map {
+            PronunciationVoice(
+                it.name,
+                it.locale,
+                it.isNetworkConnectionRequired,
+                TextToSpeech.Engine.KEY_FEATURE_NOT_INSTALLED !in it.features.orEmpty(),
+            )
+        }
+
+    override fun selectVoice(voice: PronunciationVoice): Boolean {
+        val native = tts.voices.orEmpty().firstOrNull { it.name == voice.name } ?: return false
+        return tts.setVoice(native) == TextToSpeech.SUCCESS
+    }
+
+    override fun selectLanguage(locale: Locale): Boolean = tts.setLanguage(locale) >= TextToSpeech.LANG_AVAILABLE
+
+    override suspend fun speak(word: String): Boolean {
+        val result = CompletableDeferred<Boolean>()
+        playback = result
+        val id = "word-${++nextUtterance}"
+        utteranceId = id
+        val parameters = Bundle().apply { putFloat(TextToSpeech.Engine.KEY_PARAM_VOLUME, 1f) }
+        return try {
+            if (tts.speak(word, TextToSpeech.QUEUE_FLUSH, parameters, id) == TextToSpeech.ERROR) false else result.await()
+        } finally {
+            utteranceId = null
+            playback = null
+            tts.stop()
+        }
+    }
+
+    override fun close() {
+        closed = true
+        utteranceId = null
+        playback?.cancel()
+        initialized.cancel()
+        handler.removeCallbacksAndMessages(null)
+        try {
+            tts.stop()
+        } finally {
+            tts.shutdown()
+        }
+    }
+}

--- a/app/src/main/java/com/kienhoang/dualsubreplay/ui/AndroidPronunciationEngine.kt
+++ b/app/src/main/java/com/kienhoang/dualsubreplay/ui/AndroidPronunciationEngine.kt
@@ -55,15 +55,24 @@ internal class AndroidPronunciationEngine(
                 @Deprecated("Required by UtteranceProgressListener")
                 override fun onError(id: String?) = complete(id, false)
 
-                override fun onError(id: String?, errorCode: Int) = complete(id, false)
+                override fun onError(
+                    id: String?,
+                    errorCode: Int,
+                ) = complete(id, false)
 
-                override fun onStop(id: String?, interrupted: Boolean) = complete(id, false)
+                override fun onStop(
+                    id: String?,
+                    interrupted: Boolean,
+                ) = complete(id, false)
             },
         )
         return true
     }
 
-    private fun complete(id: String?, success: Boolean) {
+    private fun complete(
+        id: String?,
+        success: Boolean,
+    ) {
         handler.post {
             if (!closed && id == utteranceId) playback?.complete(success)
         }

--- a/app/src/main/java/com/kienhoang/dualsubreplay/ui/DualSubApp.kt
+++ b/app/src/main/java/com/kienhoang/dualsubreplay/ui/DualSubApp.kt
@@ -192,6 +192,7 @@ fun DualSubApp(
                     onSave = { meaning, online -> viewModel.saveWord(selection, meaning, online); Unit },
                     onSpeak = { webController.pause(); pronouncer.speak(selection.token.text, selection.wordLanguage) },
                     speechMessage = pronouncer.message,
+                    onSpeechSettings = if (pronouncer.showSpeechSettings) pronouncer::openSpeechSettings else null,
                     onDismiss = { viewModel.selectLearningWord(null) },
                 )
             }

--- a/app/src/main/java/com/kienhoang/dualsubreplay/ui/Pronunciation.kt
+++ b/app/src/main/java/com/kienhoang/dualsubreplay/ui/Pronunciation.kt
@@ -41,17 +41,22 @@ internal fun pronunciationLocale(language: String): Locale? =
 internal fun pronunciationVoices(
     voices: List<PronunciationVoice>,
     locale: Locale,
-): List<PronunciationVoice> =
-    voices
-        .filter { it.installed && it.locale.language == locale.language }
-        .filter { locale.script.isBlank() || it.locale.script.isBlank() || it.locale.script == locale.script }
-        .sortedWith(
-            compareBy<PronunciationVoice> { it.network }
-                .thenBy { it.locale != locale }
-                .thenBy { it.locale.country != locale.country }
-                .thenBy { it.name },
-        ).distinctBy { Triple(it.locale, it.network, it.installed) }
+): List<PronunciationVoice> {
+    val matching =
+        voices
+            .filter { it.installed && it.locale.language == locale.language }
+            .filter { locale.script.isBlank() || it.locale.script.isBlank() || it.locale.script == locale.script }
+            .sortedWith(
+                compareBy<PronunciationVoice> { it.network }
+                    .thenBy { it.locale != locale }
+                    .thenBy { it.locale.country != locale.country }
+                    .thenBy { it.name },
+            )
+    // Keep a network fallback reachable even when an engine lists many offline voices.
+    return (matching.take(1) + matching.filter { it.network }.take(1) + matching.drop(1))
+        .distinctBy { it.name }
         .take(3)
+}
 
 /** Try the user's default engine first, then other installed engines, without changing system settings. */
 internal suspend fun pronounceWord(

--- a/app/src/main/java/com/kienhoang/dualsubreplay/ui/Pronunciation.kt
+++ b/app/src/main/java/com/kienhoang/dualsubreplay/ui/Pronunciation.kt
@@ -1,0 +1,99 @@
+package com.kienhoang.dualsubreplay.ui
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.withTimeoutOrNull
+import java.util.Locale
+
+internal data class PronunciationVoice(
+    val name: String,
+    val locale: Locale,
+    val network: Boolean = false,
+    val installed: Boolean = true,
+)
+
+internal interface PronunciationEngine {
+    suspend fun initialize(): Boolean
+
+    fun voices(): List<PronunciationVoice>
+
+    fun selectVoice(voice: PronunciationVoice): Boolean
+
+    fun selectLanguage(locale: Locale): Boolean
+
+    suspend fun speak(word: String): Boolean
+
+    fun close()
+}
+
+internal enum class PronunciationResult {
+    SPOKEN,
+    NO_VOICE,
+    UNAVAILABLE,
+    PLAYBACK_FAILED,
+    INVALID_LANGUAGE,
+}
+
+internal fun pronunciationLocale(language: String): Locale? =
+    Locale.forLanguageTag(language.trim().replace('_', '-')).takeIf {
+        it.language.isNotBlank() && it.language !in setOf("und", "auto")
+    }
+
+internal fun pronunciationVoices(
+    voices: List<PronunciationVoice>,
+    locale: Locale,
+): List<PronunciationVoice> =
+    voices
+        .filter { it.installed && it.locale.language == locale.language }
+        .filter { locale.script.isBlank() || it.locale.script.isBlank() || it.locale.script == locale.script }
+        .sortedWith(
+            compareBy<PronunciationVoice> { it.network }
+                .thenBy { it.locale != locale }
+                .thenBy { it.locale.country != locale.country }
+                .thenBy { it.name },
+        ).distinctBy { Triple(it.locale, it.network, it.installed) }
+        .take(3)
+
+/** Try the user's default engine first, then other installed engines, without changing system settings. */
+internal suspend fun pronounceWord(
+    word: String,
+    language: String,
+    engineNames: List<String?>,
+    createEngine: (String?) -> PronunciationEngine,
+): PronunciationResult {
+    val locale = pronunciationLocale(language) ?: return PronunciationResult.INVALID_LANGUAGE
+    var initialized = false
+    var playbackFailed = false
+    for (name in engineNames.distinct()) {
+        var engine: PronunciationEngine? = null
+        try {
+            val active = createEngine(name).also { engine = it }
+            if (withTimeoutOrNull(4_000) { active.initialize() } != true) continue
+            initialized = true
+            val voices = pronunciationVoices(active.voices(), locale)
+            if (voices.isEmpty()) {
+                // Some older engines implement setLanguage but do not expose a voice catalog.
+                if (!active.selectLanguage(locale)) continue
+                playbackFailed = true
+                if (withTimeoutOrNull(10_000) { active.speak(word) } == true) return PronunciationResult.SPOKEN
+            } else {
+                for (voice in voices) {
+                    if (!active.selectVoice(voice)) continue
+                    playbackFailed = true
+                    if (withTimeoutOrNull(10_000) { active.speak(word) } == true) return PronunciationResult.SPOKEN
+                }
+            }
+        } catch (cancel: CancellationException) {
+            throw cancel
+        } catch (_: Exception) {
+            // A broken vendor engine must not prevent trying the next installed engine.
+            playbackFailed = true
+        } finally {
+            runCatching { engine?.close() }
+        }
+    }
+    return when {
+        playbackFailed -> PronunciationResult.PLAYBACK_FAILED
+        initialized -> PronunciationResult.NO_VOICE
+        else -> PronunciationResult.UNAVAILABLE
+    }
+}

--- a/app/src/main/java/com/kienhoang/dualsubreplay/ui/SavedWordsScreen.kt
+++ b/app/src/main/java/com/kienhoang/dualsubreplay/ui/SavedWordsScreen.kt
@@ -126,6 +126,9 @@ internal fun SavedWordsScreen(
                         selected.reading?.let { Text(it) }
                         TextButton(onClick = { onPause(); pronouncer.speak(selected.word, selected.wordLanguage) }) { Text("Pronounce") }
                         pronouncer.message?.let { Text(it) }
+                        if (pronouncer.showSpeechSettings) {
+                            TextButton(onClick = pronouncer::openSpeechSettings, modifier = Modifier.testTag("speech_settings")) { Text("Speech settings") }
+                        }
                         if (practice && !revealed) {
                             Button(onClick = { revealed = true }, modifier = Modifier.testTag("reveal_meaning")) { Text("Show meaning") }
                         } else {

--- a/app/src/main/java/com/kienhoang/dualsubreplay/ui/SavedWordsScreen.kt
+++ b/app/src/main/java/com/kienhoang/dualsubreplay/ui/SavedWordsScreen.kt
@@ -127,7 +127,12 @@ internal fun SavedWordsScreen(
                         TextButton(onClick = { onPause(); pronouncer.speak(selected.word, selected.wordLanguage) }) { Text("Pronounce") }
                         pronouncer.message?.let { Text(it) }
                         if (pronouncer.showSpeechSettings) {
-                            TextButton(onClick = pronouncer::openSpeechSettings, modifier = Modifier.testTag("speech_settings")) { Text("Speech settings") }
+                            TextButton(
+                                onClick = pronouncer::openSpeechSettings,
+                                modifier = Modifier.testTag("speech_settings"),
+                            ) {
+                                Text("Speech settings")
+                            }
                         }
                         if (practice && !revealed) {
                             Button(onClick = { revealed = true }, modifier = Modifier.testTag("reveal_meaning")) { Text("Show meaning") }

--- a/app/src/main/java/com/kienhoang/dualsubreplay/ui/WordLearningSheet.kt
+++ b/app/src/main/java/com/kienhoang/dualsubreplay/ui/WordLearningSheet.kt
@@ -23,6 +23,7 @@ internal fun WordLearningDialog(
     speechMessage: String?,
     onDismiss: () -> Unit,
     existingWord: com.kienhoang.dualsubreplay.data.SavedWord? = null,
+    onSpeechSettings: (() -> Unit)? = null,
 ) {
     var meaning by remember(selection) { mutableStateOf(existingWord?.meaning.orEmpty()) }
     var loading by remember(selection) { mutableStateOf(true) }
@@ -50,6 +51,9 @@ internal fun WordLearningDialog(
                 selection.token.reading?.takeIf { it.isNotBlank() }?.let { Text(it) }
                 TextButton(onClick = onSpeak, modifier = Modifier.testTag("pronounce_word")) { Text("Pronounce") }
                 speechMessage?.let { Text(it) }
+                onSpeechSettings?.let { open ->
+                    TextButton(onClick = open, modifier = Modifier.testTag("speech_settings")) { Text("Speech settings") }
+                }
                 if (loading) LinearProgressIndicator(Modifier.fillMaxWidth())
                 OutlinedTextField(meaning, { meaning = it; saved = false }, label = { Text("Meaning (${selection.meaningLanguage})") },
                     enabled = !loading && !saving, modifier = Modifier.testTag("word_meaning"))

--- a/app/src/main/java/com/kienhoang/dualsubreplay/ui/WordPronouncer.kt
+++ b/app/src/main/java/com/kienhoang/dualsubreplay/ui/WordPronouncer.kt
@@ -1,54 +1,82 @@
 package com.kienhoang.dualsubreplay.ui
 
 import android.content.Context
-import android.speech.tts.TextToSpeech
+import android.content.Intent
+import android.provider.Settings
 import androidx.compose.runtime.*
 import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
-import java.util.Locale
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
 
 internal class WordPronouncer(context: Context) {
+    private val application = context.applicationContext
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+    private var speech: Job? = null
+    private var disposed = false
     var message by mutableStateOf<String?>(null)
         private set
-    private var ready = false
-    private var initializationFailed = false
-    private var disposed = false
-    private var pending: Pair<String, String>? = null
-    private var engine: TextToSpeech? = null
+    var showSpeechSettings by mutableStateOf(false)
+        private set
 
-    init {
-        engine = TextToSpeech(context.applicationContext) { status ->
-            if (!disposed) {
-                ready = status == TextToSpeech.SUCCESS
-                if (ready) pending?.let { speak(it.first, it.second) }
-                else {
-                    initializationFailed = true
-                    if (pending != null) message = "Speech is unavailable on this device."
-                    pending = null
-                }
+    fun speak(word: String, language: String) {
+        if (disposed || word.isBlank()) return
+        stop()
+        message = "Preparing pronunciation…"
+        speech = scope.launch {
+            val result = try {
+                withTimeoutOrNull(25_000) {
+                    pronounceWord(word, language, installedPronunciationEngines(application)) {
+                        AndroidPronunciationEngine(application, it)
+                    }
+                } ?: PronunciationResult.PLAYBACK_FAILED
+            } catch (cancel: CancellationException) {
+                throw cancel
+            } catch (_: Exception) {
+                PronunciationResult.UNAVAILABLE
+            }
+            showSpeechSettings = result != PronunciationResult.SPOKEN && result != PronunciationResult.INVALID_LANGUAGE
+            message = when (result) {
+                PronunciationResult.SPOKEN -> null
+                PronunciationResult.NO_VOICE -> "No installed speech engine has a voice for this language. Open Speech settings to add one, then tap Pronounce again."
+                PronunciationResult.UNAVAILABLE -> "Speech is unavailable. Open Speech settings to enable or install a text-to-speech engine, then try again."
+                PronunciationResult.PLAYBACK_FAILED -> "Could not play pronunciation. Check media volume and your connection, or choose a voice in Speech settings."
+                PronunciationResult.INVALID_LANGUAGE -> "Choose a subtitle language before pronouncing this word."
             }
         }
     }
-    fun speak(word: String, language: String) {
-        if (disposed || word.isBlank()) return
-        if (initializationFailed) { message = "Speech is unavailable on this device."; return }
-        if (!ready) { pending = word to language; return }
-        pending = null
-        val tts = engine ?: return
-        val result = tts.setLanguage(Locale.forLanguageTag(language))
-        if (result == TextToSpeech.LANG_MISSING_DATA || result == TextToSpeech.LANG_NOT_SUPPORTED) {
-            message = "Install a speech voice for this language in Android settings."
-            return
+
+    fun openSpeechSettings() {
+        stop()
+        val opened = listOf("com.android.settings.TTS_SETTINGS", Settings.ACTION_ACCESSIBILITY_SETTINGS).any { action ->
+            runCatching { application.startActivity(Intent(action).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)) }.isSuccess
         }
-        message = null
-        if (tts.speak(word, TextToSpeech.QUEUE_FLUSH, null, "word") == TextToSpeech.ERROR) {
-            message = "Could not pronounce this word. Try again."
+        if (!opened) {
+            showSpeechSettings = true
+            message = "Open Android Settings and search for Text-to-speech to install or select a voice."
         }
     }
-    fun stop() { pending = null; engine?.stop() }
-    fun close() { disposed = true; stop(); engine?.shutdown(); engine = null }
+
+    fun stop() {
+        speech?.cancel()
+        speech = null
+        message = null
+        showSpeechSettings = false
+    }
+
+    fun close() {
+        disposed = true
+        stop()
+        scope.cancel()
+    }
 }
 
 @Composable
@@ -59,7 +87,10 @@ internal fun rememberWordPronouncer(): WordPronouncer {
     DisposableEffect(pronouncer, owner) {
         val observer = LifecycleEventObserver { _, event -> if (event == Lifecycle.Event.ON_STOP) pronouncer.stop() }
         owner.lifecycle.addObserver(observer)
-        onDispose { owner.lifecycle.removeObserver(observer); pronouncer.close() }
+        onDispose { owner.lifecycle.removeObserver(observer) }
+    }
+    DisposableEffect(pronouncer) {
+        onDispose { pronouncer.close() }
     }
     return pronouncer
 }

--- a/app/src/main/java/com/kienhoang/dualsubreplay/ui/WordPronouncer.kt
+++ b/app/src/main/java/com/kienhoang/dualsubreplay/ui/WordPronouncer.kt
@@ -32,33 +32,39 @@ internal class WordPronouncer(context: Context) {
         stop()
         message = "Preparing pronunciation…"
         speech = scope.launch {
-            val result = try {
-                withTimeoutOrNull(25_000) {
-                    pronounceWord(word, language, installedPronunciationEngines(application)) {
-                        AndroidPronunciationEngine(application, it)
-                    }
-                } ?: PronunciationResult.PLAYBACK_FAILED
-            } catch (cancel: CancellationException) {
-                throw cancel
-            } catch (_: Exception) {
-                PronunciationResult.UNAVAILABLE
-            }
+            val result =
+                try {
+                    withTimeoutOrNull(25_000) {
+                        pronounceWord(word, language, installedPronunciationEngines(application)) {
+                            AndroidPronunciationEngine(application, it)
+                        }
+                    } ?: PronunciationResult.PLAYBACK_FAILED
+                } catch (cancel: CancellationException) {
+                    throw cancel
+                } catch (_: Exception) {
+                    PronunciationResult.UNAVAILABLE
+                }
             showSpeechSettings = result != PronunciationResult.SPOKEN && result != PronunciationResult.INVALID_LANGUAGE
-            message = when (result) {
-                PronunciationResult.SPOKEN -> null
-                PronunciationResult.NO_VOICE -> "No installed speech engine has a voice for this language. Open Speech settings to add one, then tap Pronounce again."
-                PronunciationResult.UNAVAILABLE -> "Speech is unavailable. Open Speech settings to enable or install a text-to-speech engine, then try again."
-                PronunciationResult.PLAYBACK_FAILED -> "Could not play pronunciation. Check media volume and your connection, or choose a voice in Speech settings."
-                PronunciationResult.INVALID_LANGUAGE -> "Choose a subtitle language before pronouncing this word."
-            }
+            message =
+                when (result) {
+                    PronunciationResult.SPOKEN -> null
+                    PronunciationResult.NO_VOICE ->
+                        "No voice is available for this language. Open Speech settings to add one, then tap Pronounce again."
+                    PronunciationResult.UNAVAILABLE ->
+                        "Speech is unavailable. Open Speech settings to enable or install a speech engine, then try again."
+                    PronunciationResult.PLAYBACK_FAILED ->
+                        "Could not play pronunciation. Check media volume and your connection, or choose a voice in Speech settings."
+                    PronunciationResult.INVALID_LANGUAGE -> "Choose a subtitle language before pronouncing this word."
+                }
         }
     }
 
     fun openSpeechSettings() {
         stop()
-        val opened = listOf("com.android.settings.TTS_SETTINGS", Settings.ACTION_ACCESSIBILITY_SETTINGS).any { action ->
-            runCatching { application.startActivity(Intent(action).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)) }.isSuccess
-        }
+        val opened =
+            listOf("com.android.settings.TTS_SETTINGS", Settings.ACTION_ACCESSIBILITY_SETTINGS).any { action ->
+                runCatching { application.startActivity(Intent(action).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)) }.isSuccess
+            }
         if (!opened) {
             showSpeechSettings = true
             message = "Open Android Settings and search for Text-to-speech to install or select a voice."

--- a/app/src/test/java/com/kienhoang/dualsubreplay/ui/PronunciationTest.kt
+++ b/app/src/test/java/com/kienhoang/dualsubreplay/ui/PronunciationTest.kt
@@ -16,137 +16,169 @@ class PronunciationTest {
     private val network = PronunciationVoice("ja-network", Locale.JAPAN, network = true)
 
     @Test
-    fun missingJapaneseInDefaultEngineFallsBackToAnotherInstalledEngine() = runBlocking {
-        val vendor = FakeEngine()
-        val multilingual = FakeEngine(listOf(japanese))
-        val requested = mutableListOf<String?>()
-        val result = pronounceWord("座れそう", "ja", listOf("vendor", "multilingual", "vendor")) {
-            requested += it
-            if (it == "vendor") vendor else multilingual
+    fun missingJapaneseInDefaultEngineFallsBackToAnotherInstalledEngine() {
+        runBlocking {
+            val vendor = FakeEngine()
+            val multilingual = FakeEngine(listOf(japanese))
+            val requested = mutableListOf<String?>()
+            val result =
+                pronounceWord("座れそう", "ja", listOf("vendor", "multilingual", "vendor")) {
+                    requested += it
+                    if (it == "vendor") vendor else multilingual
+                }
+            assertEquals(PronunciationResult.SPOKEN, result)
+            assertEquals(listOf("vendor", "multilingual"), requested)
+            assertEquals(listOf("座れそう"), multilingual.spoken)
+            assertEquals(listOf(japanese), multilingual.selected)
+            assertTrue(vendor.closed && multilingual.closed)
         }
-        assertEquals(PronunciationResult.SPOKEN, result)
-        assertEquals(listOf("vendor", "multilingual"), requested)
-        assertEquals(listOf("座れそう"), multilingual.spoken)
-        assertEquals(listOf(japanese), multilingual.selected)
-        assertTrue(vendor.closed && multilingual.closed)
     }
 
     @Test
-    fun defaultEngineSuccessDoesNotOpenOtherEngines() = runBlocking {
-        val engine = FakeEngine(listOf(japanese))
-        val requested = mutableListOf<String?>()
-        assertEquals(PronunciationResult.SPOKEN, pronounceWord("こんにちは", "ja", listOf(null, "other")) {
-            requested += it
-            engine
-        })
-        assertEquals(listOf<String?>(null), requested)
-        assertTrue(engine.closed)
+    fun defaultEngineSuccessDoesNotOpenOtherEngines() {
+        runBlocking {
+            val engine = FakeEngine(listOf(japanese))
+            val requested = mutableListOf<String?>()
+            val result =
+                pronounceWord("こんにちは", "ja", listOf(null, "other")) {
+                    requested += it
+                    engine
+                }
+            assertEquals(PronunciationResult.SPOKEN, result)
+            assertEquals(listOf<String?>(null), requested)
+            assertTrue(engine.closed)
+        }
     }
 
     @Test
-    fun availableNetworkVoiceWorksWithoutAnOfflineLanguagePack() = runBlocking {
-        val engine = FakeEngine(listOf(japanese.copy(installed = false), network))
-        assertEquals(PronunciationResult.SPOKEN, pronounce(engine))
-        assertEquals(listOf(network), engine.selected)
-        assertEquals(0, engine.languageRequests)
+    fun availableNetworkVoiceWorksWithoutAnOfflineLanguagePack() {
+        runBlocking {
+            val engine = FakeEngine(listOf(japanese.copy(installed = false), network))
+            assertEquals(PronunciationResult.SPOKEN, pronounce(engine))
+            assertEquals(listOf(network), engine.selected)
+            assertEquals(0, engine.languageRequests)
+        }
     }
 
     @Test
-    fun asynchronousPlaybackFailureTriesNetworkVoice() = runBlocking {
-        val firstPlayback = CompletableDeferred<Boolean>()
-        val started = CompletableDeferred<Unit>()
-        val engine = FakeEngine(listOf(network, japanese))
-        engine.play = {
-            if (engine.selected.last() == japanese) {
-                started.complete(Unit)
-                firstPlayback.await()
-            } else {
-                true
+    fun asynchronousPlaybackFailureTriesNetworkVoice() {
+        runBlocking {
+            val firstPlayback = CompletableDeferred<Boolean>()
+            val started = CompletableDeferred<Unit>()
+            val engine = FakeEngine(listOf(network, japanese))
+            engine.play = {
+                if (engine.selected.last() == japanese) {
+                    started.complete(Unit)
+                    firstPlayback.await()
+                } else {
+                    true
+                }
             }
+            val result = async { pronounce(engine) }
+            started.await()
+            assertFalse(result.isCompleted)
+            firstPlayback.complete(false)
+            assertEquals(PronunciationResult.SPOKEN, result.await())
+            assertEquals(listOf(japanese, network), engine.selected)
         }
-        val result = async { pronounce(engine) }
-        started.await()
-        assertFalse(result.isCompleted)
-        firstPlayback.complete(false)
-        assertEquals(PronunciationResult.SPOKEN, result.await())
-        assertEquals(listOf(japanese, network), engine.selected)
     }
 
     @Test
-    fun brokenInitializationFallsBackAndClosesEngine() = runBlocking {
-        val broken = FakeEngine().apply { ready = false }
-        val working = FakeEngine(listOf(japanese))
-        assertEquals(PronunciationResult.SPOKEN, pronounceWord("座れそう", "ja", listOf("broken", "working")) {
-            if (it == "broken") broken else working
-        })
-        assertTrue(broken.closed && working.closed)
-    }
-
-    @Test
-    fun vendorExceptionDoesNotPreventFallback() = runBlocking {
-        val working = FakeEngine(listOf(japanese))
-        assertEquals(PronunciationResult.SPOKEN, pronounceWord("座れそう", "ja", listOf("broken", "working")) {
-            if (it == "broken") error("Engine failed to bind") else working
-        })
-    }
-
-    @Test
-    fun olderEngineWithoutVoiceCatalogCanUseSetLanguage() = runBlocking {
-        val engine = FakeEngine().apply { languageAvailable = true }
-        assertEquals(PronunciationResult.SPOKEN, pronounce(engine))
-        assertEquals(1, engine.languageRequests)
-    }
-
-    @Test
-    fun missingVoiceAndPlaybackFailureHaveDifferentResults() = runBlocking {
-        assertEquals(PronunciationResult.NO_VOICE, pronounce(FakeEngine()))
-        assertEquals(PronunciationResult.UNAVAILABLE, pronounce(FakeEngine().apply { ready = false }))
-        assertEquals(PronunciationResult.PLAYBACK_FAILED, pronounce(FakeEngine(listOf(japanese)).apply { play = { false } }))
-    }
-
-    @Test
-    fun cancellationWhileInitializingClosesEngineWithoutFallback() = runBlocking {
-        val started = CompletableDeferred<Unit>()
-        val engine = FakeEngine(listOf(japanese)).apply {
-            init = {
-                started.complete(Unit)
-                CompletableDeferred<Boolean>().await()
-            }
+    fun brokenInitializationFallsBackAndClosesEngine() {
+        runBlocking {
+            val broken = FakeEngine().apply { ready = false }
+            val working = FakeEngine(listOf(japanese))
+            val result =
+                pronounceWord("座れそう", "ja", listOf("broken", "working")) {
+                    if (it == "broken") broken else working
+                }
+            assertEquals(PronunciationResult.SPOKEN, result)
+            assertTrue(broken.closed && working.closed)
         }
-        val requested = mutableListOf<String?>()
-        val job = async {
-            pronounceWord("座れそう", "ja", listOf("first", "other")) {
-                requested += it
-                engine
-            }
-        }
-        started.await()
-        job.cancelAndJoin()
-        assertTrue(engine.closed)
-        assertTrue(engine.spoken.isEmpty())
-        assertEquals(listOf("first"), requested)
     }
 
     @Test
-    fun cancellationDuringPlaybackClosesEngineWithoutFallback() = runBlocking {
-        val started = CompletableDeferred<Unit>()
-        val engine = FakeEngine(listOf(japanese)).apply {
-            play = {
-                started.complete(Unit)
-                CompletableDeferred<Boolean>().await()
-            }
+    fun vendorExceptionDoesNotPreventFallback() {
+        runBlocking {
+            val working = FakeEngine(listOf(japanese))
+            val result =
+                pronounceWord("座れそう", "ja", listOf("broken", "working")) {
+                    if (it == "broken") error("Engine failed to bind") else working
+                }
+            assertEquals(PronunciationResult.SPOKEN, result)
         }
-        val job = async { pronounce(engine) }
-        started.await()
-        job.cancelAndJoin()
-        assertTrue(engine.closed)
-        assertEquals(1, engine.spoken.size)
     }
 
     @Test
-    fun retryRechecksEnginesAfterVoiceInstallation() = runBlocking {
-        assertEquals(PronunciationResult.NO_VOICE, pronounce(FakeEngine()))
-        assertEquals(PronunciationResult.SPOKEN, pronounce(FakeEngine(listOf(japanese))))
+    fun olderEngineWithoutVoiceCatalogCanUseSetLanguage() {
+        runBlocking {
+            val engine = FakeEngine().apply { languageAvailable = true }
+            assertEquals(PronunciationResult.SPOKEN, pronounce(engine))
+            assertEquals(1, engine.languageRequests)
+        }
+    }
+
+    @Test
+    fun missingVoiceAndPlaybackFailureHaveDifferentResults() {
+        runBlocking {
+            assertEquals(PronunciationResult.NO_VOICE, pronounce(FakeEngine()))
+            assertEquals(PronunciationResult.UNAVAILABLE, pronounce(FakeEngine().apply { ready = false }))
+            assertEquals(PronunciationResult.PLAYBACK_FAILED, pronounce(FakeEngine(listOf(japanese)).apply { play = { false } }))
+        }
+    }
+
+    @Test
+    fun cancellationWhileInitializingClosesEngineWithoutFallback() {
+        runBlocking {
+            val started = CompletableDeferred<Unit>()
+            val engine =
+                FakeEngine(listOf(japanese)).apply {
+                    init = {
+                        started.complete(Unit)
+                        CompletableDeferred<Boolean>().await()
+                    }
+                }
+            val requested = mutableListOf<String?>()
+            val job =
+                async {
+                    pronounceWord("座れそう", "ja", listOf("first", "other")) {
+                        requested += it
+                        engine
+                    }
+                }
+            started.await()
+            job.cancelAndJoin()
+            assertTrue(engine.closed)
+            assertTrue(engine.spoken.isEmpty())
+            assertEquals(listOf("first"), requested)
+        }
+    }
+
+    @Test
+    fun cancellationDuringPlaybackClosesEngineWithoutFallback() {
+        runBlocking {
+            val started = CompletableDeferred<Unit>()
+            val engine =
+                FakeEngine(listOf(japanese)).apply {
+                    play = {
+                        started.complete(Unit)
+                        CompletableDeferred<Boolean>().await()
+                    }
+                }
+            val job = async { pronounce(engine) }
+            started.await()
+            job.cancelAndJoin()
+            assertTrue(engine.closed)
+            assertEquals(1, engine.spoken.size)
+        }
+    }
+
+    @Test
+    fun retryRechecksEnginesAfterVoiceInstallation() {
+        runBlocking {
+            assertEquals(PronunciationResult.NO_VOICE, pronounce(FakeEngine()))
+            assertEquals(PronunciationResult.SPOKEN, pronounce(FakeEngine(listOf(japanese))))
+        }
     }
 
     @Test
@@ -159,10 +191,14 @@ class PronunciationTest {
     }
 
     @Test
-    fun invalidLanguageDoesNotStartAnEngine() = runBlocking {
-        assertEquals(PronunciationResult.INVALID_LANGUAGE, pronounceWord("word", "auto", listOf(null)) {
-            error("Must not open an engine for an unresolved language")
-        })
+    fun invalidLanguageDoesNotStartAnEngine() {
+        runBlocking {
+            val result =
+                pronounceWord("word", "auto", listOf(null)) {
+                    error("Must not open an engine for an unresolved language")
+                }
+            assertEquals(PronunciationResult.INVALID_LANGUAGE, result)
+        }
     }
 
     @Test
@@ -174,8 +210,13 @@ class PronunciationTest {
         assertEquals(listOf(british, english), pronunciationVoices(listOf(english, british), Locale.UK))
     }
 
-    private suspend fun pronounce(engine: FakeEngine): PronunciationResult =
-        pronounceWord("座れそう", "ja", listOf(null)) { engine }
+    private suspend fun pronounce(engine: FakeEngine): PronunciationResult = pronounceWord("座れそう", "ja", listOf(null)) { engine }
+
+    @Test
+    fun manyOfflineVoicesCannotCrowdOutTheNetworkFallback() {
+        val offline = (1..5).map { japanese.copy(name = "offline-$it") }
+        assertEquals(listOf(offline.first(), network, offline[1]), pronunciationVoices(offline + network, Locale.JAPAN))
+    }
 
     private class FakeEngine(
         private val available: List<PronunciationVoice> = emptyList(),

--- a/app/src/test/java/com/kienhoang/dualsubreplay/ui/PronunciationTest.kt
+++ b/app/src/test/java/com/kienhoang/dualsubreplay/ui/PronunciationTest.kt
@@ -1,0 +1,215 @@
+package com.kienhoang.dualsubreplay.ui
+
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.Locale
+
+class PronunciationTest {
+    private val japanese = PronunciationVoice("ja-offline", Locale.JAPAN)
+    private val network = PronunciationVoice("ja-network", Locale.JAPAN, network = true)
+
+    @Test
+    fun missingJapaneseInDefaultEngineFallsBackToAnotherInstalledEngine() = runBlocking {
+        val vendor = FakeEngine()
+        val multilingual = FakeEngine(listOf(japanese))
+        val requested = mutableListOf<String?>()
+        val result = pronounceWord("座れそう", "ja", listOf("vendor", "multilingual", "vendor")) {
+            requested += it
+            if (it == "vendor") vendor else multilingual
+        }
+        assertEquals(PronunciationResult.SPOKEN, result)
+        assertEquals(listOf("vendor", "multilingual"), requested)
+        assertEquals(listOf("座れそう"), multilingual.spoken)
+        assertEquals(listOf(japanese), multilingual.selected)
+        assertTrue(vendor.closed && multilingual.closed)
+    }
+
+    @Test
+    fun defaultEngineSuccessDoesNotOpenOtherEngines() = runBlocking {
+        val engine = FakeEngine(listOf(japanese))
+        val requested = mutableListOf<String?>()
+        assertEquals(PronunciationResult.SPOKEN, pronounceWord("こんにちは", "ja", listOf(null, "other")) {
+            requested += it
+            engine
+        })
+        assertEquals(listOf<String?>(null), requested)
+        assertTrue(engine.closed)
+    }
+
+    @Test
+    fun availableNetworkVoiceWorksWithoutAnOfflineLanguagePack() = runBlocking {
+        val engine = FakeEngine(listOf(japanese.copy(installed = false), network))
+        assertEquals(PronunciationResult.SPOKEN, pronounce(engine))
+        assertEquals(listOf(network), engine.selected)
+        assertEquals(0, engine.languageRequests)
+    }
+
+    @Test
+    fun asynchronousPlaybackFailureTriesNetworkVoice() = runBlocking {
+        val firstPlayback = CompletableDeferred<Boolean>()
+        val started = CompletableDeferred<Unit>()
+        val engine = FakeEngine(listOf(network, japanese))
+        engine.play = {
+            if (engine.selected.last() == japanese) {
+                started.complete(Unit)
+                firstPlayback.await()
+            } else {
+                true
+            }
+        }
+        val result = async { pronounce(engine) }
+        started.await()
+        assertFalse(result.isCompleted)
+        firstPlayback.complete(false)
+        assertEquals(PronunciationResult.SPOKEN, result.await())
+        assertEquals(listOf(japanese, network), engine.selected)
+    }
+
+    @Test
+    fun brokenInitializationFallsBackAndClosesEngine() = runBlocking {
+        val broken = FakeEngine().apply { ready = false }
+        val working = FakeEngine(listOf(japanese))
+        assertEquals(PronunciationResult.SPOKEN, pronounceWord("座れそう", "ja", listOf("broken", "working")) {
+            if (it == "broken") broken else working
+        })
+        assertTrue(broken.closed && working.closed)
+    }
+
+    @Test
+    fun vendorExceptionDoesNotPreventFallback() = runBlocking {
+        val working = FakeEngine(listOf(japanese))
+        assertEquals(PronunciationResult.SPOKEN, pronounceWord("座れそう", "ja", listOf("broken", "working")) {
+            if (it == "broken") error("Engine failed to bind") else working
+        })
+    }
+
+    @Test
+    fun olderEngineWithoutVoiceCatalogCanUseSetLanguage() = runBlocking {
+        val engine = FakeEngine().apply { languageAvailable = true }
+        assertEquals(PronunciationResult.SPOKEN, pronounce(engine))
+        assertEquals(1, engine.languageRequests)
+    }
+
+    @Test
+    fun missingVoiceAndPlaybackFailureHaveDifferentResults() = runBlocking {
+        assertEquals(PronunciationResult.NO_VOICE, pronounce(FakeEngine()))
+        assertEquals(PronunciationResult.UNAVAILABLE, pronounce(FakeEngine().apply { ready = false }))
+        assertEquals(PronunciationResult.PLAYBACK_FAILED, pronounce(FakeEngine(listOf(japanese)).apply { play = { false } }))
+    }
+
+    @Test
+    fun cancellationWhileInitializingClosesEngineWithoutFallback() = runBlocking {
+        val started = CompletableDeferred<Unit>()
+        val engine = FakeEngine(listOf(japanese)).apply {
+            init = {
+                started.complete(Unit)
+                CompletableDeferred<Boolean>().await()
+            }
+        }
+        val requested = mutableListOf<String?>()
+        val job = async {
+            pronounceWord("座れそう", "ja", listOf("first", "other")) {
+                requested += it
+                engine
+            }
+        }
+        started.await()
+        job.cancelAndJoin()
+        assertTrue(engine.closed)
+        assertTrue(engine.spoken.isEmpty())
+        assertEquals(listOf("first"), requested)
+    }
+
+    @Test
+    fun cancellationDuringPlaybackClosesEngineWithoutFallback() = runBlocking {
+        val started = CompletableDeferred<Unit>()
+        val engine = FakeEngine(listOf(japanese)).apply {
+            play = {
+                started.complete(Unit)
+                CompletableDeferred<Boolean>().await()
+            }
+        }
+        val job = async { pronounce(engine) }
+        started.await()
+        job.cancelAndJoin()
+        assertTrue(engine.closed)
+        assertEquals(1, engine.spoken.size)
+    }
+
+    @Test
+    fun retryRechecksEnginesAfterVoiceInstallation() = runBlocking {
+        assertEquals(PronunciationResult.NO_VOICE, pronounce(FakeEngine()))
+        assertEquals(PronunciationResult.SPOKEN, pronounce(FakeEngine(listOf(japanese))))
+    }
+
+    @Test
+    fun languageTagsKeepRegionAndNormalizeUnderscores() {
+        assertEquals(Locale.JAPAN, pronunciationLocale(" ja_JP "))
+        assertEquals("vi", pronunciationLocale("vi-VN")?.language)
+        assertNull(pronunciationLocale("auto"))
+        assertNull(pronunciationLocale("und"))
+        assertNull(pronunciationLocale(""))
+    }
+
+    @Test
+    fun invalidLanguageDoesNotStartAnEngine() = runBlocking {
+        assertEquals(PronunciationResult.INVALID_LANGUAGE, pronounceWord("word", "auto", listOf(null)) {
+            error("Must not open an engine for an unresolved language")
+        })
+    }
+
+    @Test
+    fun voiceChoicePrefersInstalledOfflineVoicesAndNeverUsesAnotherLanguage() {
+        val english = PronunciationVoice("en", Locale.US)
+        val missing = japanese.copy(name = "missing", installed = false)
+        assertEquals(listOf(japanese, network), pronunciationVoices(listOf(english, missing, network, japanese), Locale.JAPAN))
+        val british = PronunciationVoice("gb", Locale.UK)
+        assertEquals(listOf(british, english), pronunciationVoices(listOf(english, british), Locale.UK))
+    }
+
+    private suspend fun pronounce(engine: FakeEngine): PronunciationResult =
+        pronounceWord("座れそう", "ja", listOf(null)) { engine }
+
+    private class FakeEngine(
+        private val available: List<PronunciationVoice> = emptyList(),
+    ) : PronunciationEngine {
+        var ready = true
+        var languageAvailable = false
+        var languageRequests = 0
+        var closed = false
+        val selected = mutableListOf<PronunciationVoice>()
+        val spoken = mutableListOf<String>()
+        var init: suspend () -> Boolean = { ready }
+        var play: suspend () -> Boolean = { true }
+
+        override suspend fun initialize(): Boolean = init()
+
+        override fun voices(): List<PronunciationVoice> = available
+
+        override fun selectVoice(voice: PronunciationVoice): Boolean {
+            selected += voice
+            return true
+        }
+
+        override fun selectLanguage(locale: Locale): Boolean {
+            languageRequests++
+            return languageAvailable
+        }
+
+        override suspend fun speak(word: String): Boolean {
+            spoken += word
+            return play()
+        }
+
+        override fun close() {
+            closed = true
+        }
+    }
+}


### PR DESCRIPTION
Tapping Pronounce currently stops when the default Android TTS engine reports missing/unsupported language data. The reported Japanese word, 座れそう, therefore remains silent even if another installed engine or a network voice can speak Japanese. Later synthesis/playback errors are also ignored.

This PR:
- Tries the preferred speech engine, then other installed engines without changing the device's default.
- Selects matching installed voices directly, preferring offline speech and falling back to a supported network voice. Retains setLanguage support for older engines without voice catalogs.
- Waits for actual utterance completion, handles asynchronous failures, sets speech audio to the media stream, and bounds initialization/playback waits.
- Cancels and shuts down speech on a new request, dialog dismissal, or app backgrounding; each retry rechecks installed engines and voices.
- Adds a Speech settings action to Word Learning and saved-word pronunciation when setup is required.

Validation:
- 15 regression cases passed using the existing Kotlin compiler and a temporary standalone assertion runner, covering Japanese engine fallback, missing offline data with an available network voice, delayed playback failure, initialization failure, cancellation, retries, and voice/language selection.
- git diff --check passed.
- GitHub Actions [run 275](https://github.com/hoangkien1703/dual-sub-replay/actions/runs/34677477962) passed formatCheck, complexityCheck, testDebugUnitTest, lintDebug, assembleDebug, and assembleDebugAndroidTest for implementation commit 9982541. This includes the 15 JUnit pronunciation regressions. The final commit only updates README/privacy documentation; full CI runs again on that head.
- Added a Compose regression for the settings action and manual retry. Optimized release and API 36 device checks are not yet confirmed. The local environment cannot download the required Android toolchain/dependencies.

Phone acceptance: tap Pronounce on 座れそう in Word Learning and in Saved words, test rapid repeated taps and dismissal, and retry after returning from Speech settings. A device with no suitable installed speech engine/voice still needs one installed; this change cannot synthesize a language for which no provider is available. Network voices require connectivity. Physical-device audio has not been verified here.

Android API references: [TextToSpeech](https://developer.android.com/reference/android/speech/tts/TextToSpeech), [Voice](https://developer.android.com/reference/android/speech/tts/Voice).

No version bump or release changes.